### PR TITLE
Add elemental compositions and target materials for radiation physics

### DIFF
--- a/src/pymat/data/metals.toml
+++ b/src/pymat/data/metals.toml
@@ -4,6 +4,7 @@
 
 [stainless]
 name = "Stainless Steel"
+composition = {Fe = 0.68, Cr = 0.18, Ni = 0.10, Mn = 0.02, Si = 0.01, C = 0.005}
 
 [stainless.mechanical]
 density_value = 8.0
@@ -32,6 +33,7 @@ transmission = 0.0
 [stainless.s304]
 name = "Stainless Steel 304"
 grade = "304"
+composition = {Fe = 0.69, Cr = 0.19, Ni = 0.095, Mn = 0.02, Si = 0.005}
 
 [stainless.s304.mechanical]
 yield_strength_value = 170
@@ -49,6 +51,7 @@ resistivity_unit = "ohm*m"
 [stainless.s316L]
 name = "Stainless Steel 316L"
 grade = "316L"
+composition = {Fe = 0.65, Cr = 0.17, Ni = 0.12, Mo = 0.025, Mn = 0.02, Si = 0.01, C = 0.005}
 
 [stainless.s316L.mechanical]
 density_value = 8.0
@@ -97,6 +100,7 @@ tensile_strength_unit = "MPa"
 [stainless.s17_4PH]
 name = "Stainless Steel 17-4 PH"
 grade = "17-4 PH"
+composition = {Fe = 0.738, Cr = 0.16, Ni = 0.04, Cu = 0.035, Mn = 0.01, Si = 0.01, Nb = 0.003, C = 0.004}
 
 [stainless.s17_4PH.mechanical]
 density_value = 7.8
@@ -113,6 +117,7 @@ tensile_strength_unit = "MPa"
 
 [aluminum]
 name = "Aluminum"
+formula = "Al"
 
 [aluminum.mechanical]
 density_value = 2.7
@@ -141,6 +146,7 @@ transmission = 0.0
 [aluminum.a6061]
 name = "Aluminum 6061-T6"
 grade = "6061"
+composition = {Al = 0.972, Mg = 0.01, Si = 0.006, Cu = 0.004, Cr = 0.002, Fe = 0.003, Zn = 0.003}
 
 [aluminum.a6061.mechanical]
 yield_strength_value = 276
@@ -172,6 +178,7 @@ transmission = 0.0
 [aluminum.a7075]
 name = "Aluminum 7075"
 grade = "7075"
+composition = {Al = 0.90, Zn = 0.056, Mg = 0.025, Cu = 0.016, Cr = 0.002, Fe = 0.001}
 
 [aluminum.a7075.mechanical]
 density_value = 2.81
@@ -216,6 +223,7 @@ density_unit = "g/cm^3"
 
 [copper]
 name = "Copper"
+formula = "Cu"
 
 [copper.mechanical]
 density_value = 8.96
@@ -296,6 +304,7 @@ density_unit = "g/cm^3"
 [tungsten.W90]
 name = "Tungsten Heavy Alloy (90% W)"
 grade = "W90"
+composition = {W = 0.90, Ni = 0.07, Fe = 0.03}
 
 [tungsten.W90.mechanical]
 density_value = 17.0
@@ -337,6 +346,7 @@ transmission = 0.0
 
 [titanium]
 name = "Titanium"
+formula = "Ti"
 
 [titanium.mechanical]
 density_value = 4.51
@@ -367,6 +377,7 @@ transmission = 0.0
 
 [brass]
 name = "Brass (Cu-Zn)"
+composition = {Cu = 0.65, Zn = 0.35}
 
 [brass.mechanical]
 density_value = 8.5
@@ -384,5 +395,434 @@ melting_point_unit = "degC"
 base_color = [0.88, 0.78, 0.5, 1.0]
 metallic = 1.0
 roughness = 0.25
+transmission = 0.0
+
+
+# ============================================================================
+# HAVAR (cobalt-based superalloy, standard cyclotron target window)
+# ============================================================================
+
+[havar]
+name = "Havar"
+composition = {Co = 0.425, Cr = 0.20, Ni = 0.13, Fe = 0.179, W = 0.028, Mo = 0.02, Mn = 0.016, C = 0.002}
+
+[havar.mechanical]
+density_value = 8.3
+density_unit = "g/cm^3"
+youngs_modulus_value = 200
+youngs_modulus_unit = "GPa"
+yield_strength_value = 1860
+yield_strength_unit = "MPa"
+tensile_strength_value = 2000
+tensile_strength_unit = "MPa"
+
+[havar.thermal]
+melting_point_value = 1480
+melting_point_unit = "degC"
+
+[havar.pbr]
+base_color = [0.7, 0.7, 0.72, 1.0]
+metallic = 1.0
+roughness = 0.3
+transmission = 0.0
+
+
+# ============================================================================
+# NIOBIUM
+# ============================================================================
+
+[niobium]
+name = "Niobium"
+formula = "Nb"
+
+[niobium.mechanical]
+density_value = 8.57
+density_unit = "g/cm^3"
+youngs_modulus_value = 105
+youngs_modulus_unit = "GPa"
+yield_strength_value = 207
+yield_strength_unit = "MPa"
+tensile_strength_value = 330
+tensile_strength_unit = "MPa"
+
+[niobium.thermal]
+melting_point_value = 2477
+melting_point_unit = "degC"
+thermal_conductivity_value = 53.7
+thermal_conductivity_unit = "W/(m*K)"
+specific_heat_value = 265
+specific_heat_unit = "J/(kg*K)"
+
+[niobium.pbr]
+base_color = [0.65, 0.65, 0.68, 1.0]
+metallic = 1.0
+roughness = 0.3
+transmission = 0.0
+
+
+# ============================================================================
+# SILVER
+# ============================================================================
+
+[silver]
+name = "Silver"
+formula = "Ag"
+
+[silver.mechanical]
+density_value = 10.49
+density_unit = "g/cm^3"
+youngs_modulus_value = 83
+youngs_modulus_unit = "GPa"
+
+[silver.thermal]
+melting_point_value = 962
+melting_point_unit = "degC"
+thermal_conductivity_value = 429
+thermal_conductivity_unit = "W/(m*K)"
+specific_heat_value = 235
+specific_heat_unit = "J/(kg*K)"
+
+[silver.pbr]
+base_color = [0.95, 0.95, 0.95, 1.0]
+metallic = 1.0
+roughness = 0.15
+transmission = 0.0
+
+
+# ============================================================================
+# GOLD
+# ============================================================================
+
+[gold]
+name = "Gold"
+formula = "Au"
+
+[gold.mechanical]
+density_value = 19.32
+density_unit = "g/cm^3"
+youngs_modulus_value = 79
+youngs_modulus_unit = "GPa"
+
+[gold.thermal]
+melting_point_value = 1064
+melting_point_unit = "degC"
+thermal_conductivity_value = 318
+thermal_conductivity_unit = "W/(m*K)"
+specific_heat_value = 129
+specific_heat_unit = "J/(kg*K)"
+
+[gold.pbr]
+base_color = [1.0, 0.84, 0.0, 1.0]
+metallic = 1.0
+roughness = 0.15
+transmission = 0.0
+
+
+# ============================================================================
+# MOLYBDENUM
+# ============================================================================
+
+[molybdenum]
+name = "Molybdenum"
+formula = "Mo"
+
+[molybdenum.mechanical]
+density_value = 10.28
+density_unit = "g/cm^3"
+youngs_modulus_value = 329
+youngs_modulus_unit = "GPa"
+yield_strength_value = 500
+yield_strength_unit = "MPa"
+tensile_strength_value = 655
+tensile_strength_unit = "MPa"
+
+[molybdenum.thermal]
+melting_point_value = 2623
+melting_point_unit = "degC"
+thermal_conductivity_value = 138
+thermal_conductivity_unit = "W/(m*K)"
+specific_heat_value = 251
+specific_heat_unit = "J/(kg*K)"
+
+[molybdenum.pbr]
+base_color = [0.55, 0.55, 0.58, 1.0]
+metallic = 1.0
+roughness = 0.3
+transmission = 0.0
+
+
+# ============================================================================
+# GALLIUM
+# ============================================================================
+
+[gallium]
+name = "Gallium"
+formula = "Ga"
+
+[gallium.mechanical]
+density_value = 5.91
+density_unit = "g/cm^3"
+
+[gallium.thermal]
+melting_point_value = 29.76
+melting_point_unit = "degC"
+thermal_conductivity_value = 40.6
+thermal_conductivity_unit = "W/(m*K)"
+specific_heat_value = 371
+specific_heat_unit = "J/(kg*K)"
+
+[gallium.pbr]
+base_color = [0.76, 0.79, 0.85, 1.0]
+metallic = 1.0
+roughness = 0.2
+transmission = 0.0
+
+
+# ============================================================================
+# BISMUTH
+# ============================================================================
+
+[bismuth]
+name = "Bismuth"
+formula = "Bi"
+
+[bismuth.mechanical]
+density_value = 9.78
+density_unit = "g/cm^3"
+youngs_modulus_value = 32
+youngs_modulus_unit = "GPa"
+
+[bismuth.thermal]
+melting_point_value = 271
+melting_point_unit = "degC"
+thermal_conductivity_value = 7.97
+thermal_conductivity_unit = "W/(m*K)"
+specific_heat_value = 122
+specific_heat_unit = "J/(kg*K)"
+
+[bismuth.pbr]
+base_color = [0.75, 0.70, 0.72, 1.0]
+metallic = 1.0
+roughness = 0.4
+transmission = 0.0
+
+
+# ============================================================================
+# RHODIUM
+# ============================================================================
+
+[rhodium]
+name = "Rhodium"
+formula = "Rh"
+
+[rhodium.mechanical]
+density_value = 12.41
+density_unit = "g/cm^3"
+youngs_modulus_value = 380
+youngs_modulus_unit = "GPa"
+
+[rhodium.thermal]
+melting_point_value = 1964
+melting_point_unit = "degC"
+thermal_conductivity_value = 150
+thermal_conductivity_unit = "W/(m*K)"
+specific_heat_value = 243
+specific_heat_unit = "J/(kg*K)"
+
+[rhodium.pbr]
+base_color = [0.85, 0.85, 0.87, 1.0]
+metallic = 1.0
+roughness = 0.2
+transmission = 0.0
+
+
+# ============================================================================
+# YTTRIUM
+# ============================================================================
+
+[yttrium]
+name = "Yttrium"
+formula = "Y"
+
+[yttrium.mechanical]
+density_value = 4.47
+density_unit = "g/cm^3"
+youngs_modulus_value = 64
+youngs_modulus_unit = "GPa"
+
+[yttrium.thermal]
+melting_point_value = 1526
+melting_point_unit = "degC"
+thermal_conductivity_value = 17.2
+thermal_conductivity_unit = "W/(m*K)"
+specific_heat_value = 298
+specific_heat_unit = "J/(kg*K)"
+
+[yttrium.pbr]
+base_color = [0.78, 0.78, 0.78, 1.0]
+metallic = 1.0
+roughness = 0.3
+transmission = 0.0
+
+
+# ============================================================================
+# RADIUM
+# ============================================================================
+
+[radium]
+name = "Radium"
+formula = "Ra"
+
+[radium.mechanical]
+density_value = 5.5
+density_unit = "g/cm^3"
+
+[radium.thermal]
+melting_point_value = 700
+melting_point_unit = "degC"
+
+[radium.pbr]
+base_color = [0.9, 0.9, 0.85, 1.0]
+metallic = 1.0
+roughness = 0.4
+transmission = 0.0
+
+
+# ============================================================================
+# TITANIUM ALLOYS
+# ============================================================================
+
+[titanium.grade5]
+name = "Ti-6Al-4V (Grade 5)"
+grade = "grade5"
+composition = {Ti = 0.90, Al = 0.06, V = 0.04}
+
+[titanium.grade5.mechanical]
+density_value = 4.43
+density_unit = "g/cm^3"
+yield_strength_value = 880
+yield_strength_unit = "MPa"
+tensile_strength_value = 950
+tensile_strength_unit = "MPa"
+elongation = 14
+
+
+# ============================================================================
+# NICKEL
+# ============================================================================
+
+[nickel]
+name = "Nickel"
+formula = "Ni"
+
+[nickel.mechanical]
+density_value = 8.90
+density_unit = "g/cm^3"
+youngs_modulus_value = 200
+youngs_modulus_unit = "GPa"
+yield_strength_value = 148
+yield_strength_unit = "MPa"
+tensile_strength_value = 462
+tensile_strength_unit = "MPa"
+
+[nickel.thermal]
+melting_point_value = 1455
+melting_point_unit = "degC"
+thermal_conductivity_value = 90.9
+thermal_conductivity_unit = "W/(m*K)"
+specific_heat_value = 444
+specific_heat_unit = "J/(kg*K)"
+
+[nickel.pbr]
+base_color = [0.75, 0.75, 0.73, 1.0]
+metallic = 1.0
+roughness = 0.3
+transmission = 0.0
+
+
+# ============================================================================
+# IRON
+# ============================================================================
+
+[iron]
+name = "Iron"
+formula = "Fe"
+
+[iron.mechanical]
+density_value = 7.87
+density_unit = "g/cm^3"
+youngs_modulus_value = 211
+youngs_modulus_unit = "GPa"
+
+[iron.thermal]
+melting_point_value = 1538
+melting_point_unit = "degC"
+thermal_conductivity_value = 80.4
+thermal_conductivity_unit = "W/(m*K)"
+specific_heat_value = 449
+specific_heat_unit = "J/(kg*K)"
+
+[iron.pbr]
+base_color = [0.56, 0.57, 0.58, 1.0]
+metallic = 1.0
+roughness = 0.4
+transmission = 0.0
+
+
+# ============================================================================
+# ZINC
+# ============================================================================
+
+[zinc]
+name = "Zinc"
+formula = "Zn"
+
+[zinc.mechanical]
+density_value = 7.14
+density_unit = "g/cm^3"
+youngs_modulus_value = 108
+youngs_modulus_unit = "GPa"
+
+[zinc.thermal]
+melting_point_value = 419.5
+melting_point_unit = "degC"
+thermal_conductivity_value = 116
+thermal_conductivity_unit = "W/(m*K)"
+specific_heat_value = 388
+specific_heat_unit = "J/(kg*K)"
+
+[zinc.pbr]
+base_color = [0.72, 0.73, 0.76, 1.0]
+metallic = 1.0
+roughness = 0.35
+transmission = 0.0
+
+
+# ============================================================================
+# TIN
+# ============================================================================
+
+[tin]
+name = "Tin"
+formula = "Sn"
+
+[tin.mechanical]
+density_value = 7.31
+density_unit = "g/cm^3"
+youngs_modulus_value = 50
+youngs_modulus_unit = "GPa"
+
+[tin.thermal]
+melting_point_value = 232
+melting_point_unit = "degC"
+thermal_conductivity_value = 66.8
+thermal_conductivity_unit = "W/(m*K)"
+specific_heat_value = 228
+specific_heat_unit = "J/(kg*K)"
+
+[tin.pbr]
+base_color = [0.85, 0.85, 0.83, 1.0]
+metallic = 1.0
+roughness = 0.3
 transmission = 0.0
 

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -193,6 +193,69 @@ class TestFormulaAndComposition:
         assert "Lu1.8Y0.2SiO5" in info or "Formula" not in info  # May or may not include
 
 
+class TestCompositionData:
+    """Test elemental composition data for alloys and target materials."""
+
+    def test_alloy_compositions_sum_to_one(self):
+        """All composition dicts should sum to ~1.0."""
+        from pymat import load_all
+
+        materials = load_all()
+        for name, mat in materials.items():
+            if mat.composition:
+                total = sum(mat.composition.values())
+                assert abs(total - 1.0) < 0.02, (
+                    f"{name}: composition sums to {total}, expected ~1.0"
+                )
+
+    def test_havar_composition(self):
+        """Havar should have correct elemental breakdown."""
+        materials = load_category("metals")
+        havar = materials["havar"]
+        assert havar.composition is not None
+        assert "Co" in havar.composition
+        assert "Cr" in havar.composition
+        assert abs(havar.composition["Co"] - 0.425) < 0.001
+        assert havar.density == 8.3
+
+    def test_ss316L_composition(self):
+        """SS 316L should have Mo in composition (distinguishes from 304)."""
+        materials = load_category("metals")
+        s316L = materials["stainless"]._children["s316L"]
+        assert s316L.composition is not None
+        assert "Mo" in s316L.composition
+        assert "Fe" in s316L.composition
+
+    def test_ti64_composition(self):
+        """Ti-6Al-4V should have Ti, Al, V."""
+        materials = load_category("metals")
+        grade5 = materials["titanium"]._children["grade5"]
+        assert grade5.composition is not None
+        assert abs(grade5.composition["Ti"] - 0.90) < 0.001
+        assert abs(grade5.composition["Al"] - 0.06) < 0.001
+        assert abs(grade5.composition["V"] - 0.04) < 0.001
+
+    def test_pure_metals_have_formula(self):
+        """Pure metals should have a formula (single element)."""
+        materials = load_category("metals")
+        for name in ["copper", "aluminum", "titanium", "niobium", "silver",
+                      "gold", "molybdenum", "gallium", "bismuth", "rhodium",
+                      "yttrium", "nickel", "iron", "zinc", "tin", "radium"]:
+            mat = materials.get(name)
+            assert mat is not None, f"Missing material: {name}"
+            assert mat.formula is not None, f"{name} should have a formula"
+
+    def test_target_materials_have_density(self):
+        """All target materials should have density set."""
+        materials = load_category("metals")
+        for name in ["havar", "niobium", "silver", "gold", "molybdenum",
+                      "gallium", "bismuth", "rhodium", "yttrium", "radium"]:
+            mat = materials.get(name)
+            assert mat is not None, f"Missing target material: {name}"
+            assert mat.density is not None, f"{name} should have density"
+            assert mat.density > 0, f"{name} density should be positive"
+
+
 class TestManufacturingProperties:
     """Test manufacturing properties are loaded."""
     


### PR DESCRIPTION
## Summary

- Add `composition` dicts (element → mass fraction) to existing alloys that were missing them: stainless steel grades (304, 316L, 17-4PH), aluminum alloys (6061, 7075), tungsten W90, brass, Ti-6Al-4V
- Add `formula` fields to pure metals that were missing them (Al, Cu, Ti)
- Add 14 new materials commonly used as cyclotron targets, backings, and windows in isotope production: havar, niobium, silver, gold, molybdenum, gallium, bismuth, rhodium, yttrium, radium, nickel, iron, zinc, tin

## Motivation

The `composition` field exists on `Material` and the loader reads it from TOML, but no material in the database actually populated it. This data is needed by downstream consumers (e.g. hyrr) that resolve materials into elemental breakdowns for radiation transport calculations.

The new target materials are standard in medical isotope production (cyclotron targets, beam windows, backing foils) and were missing from the catalog entirely.

## What changed

- **`src/pymat/data/metals.toml`** — compositions on 9 existing alloys, formulas on 3 pure metals, 14 new material entries with full properties (mechanical, thermal, PBR)
- **`tests/test_loader.py`** — 6 new tests validating compositions sum to ~1.0, spot-checking key alloys, and verifying all new materials have density + formula

## Test plan

- [x] All existing tests pass (102 passed, 5 pre-existing factory failures unrelated to this PR)
- [x] New `TestCompositionData` tests pass (6/6)
- [x] TOML validates with `tomllib`
- [x] `load_all()` loads 127 materials without errors
- [x] All composition dicts sum to ~1.0