### PR TITLE
chore: adopt vigOS convention + mat-rs PR gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,11 +161,43 @@ jobs:
         with:
           fail-on-severity: high
 
+  rust:
+    name: Rust (mat-rs)
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    if: |
+      github.event_name != 'workflow_dispatch' ||
+      inputs.test-suite == 'all' ||
+      inputs.test-suite == 'test'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: mat-rs
+
+      - name: Check formatting
+        run: cargo fmt --manifest-path mat-rs/Cargo.toml --all -- --check
+
+      - name: Run clippy
+        run: cargo clippy --manifest-path mat-rs/Cargo.toml --all-targets -- -D warnings
+
+      - name: Run tests
+        run: cargo test --manifest-path mat-rs/Cargo.toml
+
   summary:
     name: CI Summary
     runs-on: ubuntu-22.04
     timeout-minutes: 5
-    needs: [lint, test, security, dependency-review]
+    needs: [lint, test, security, dependency-review, rust]
     if: always()
 
     steps:
@@ -178,6 +210,7 @@ jobs:
           echo "Test:              ${{ needs.test.result }}"
           echo "Security:          ${{ needs.security.result }}"
           echo "Dependency Review: ${{ needs.dependency-review.result }}"
+          echo "Rust (mat-rs):     ${{ needs.rust.result }}"
           echo ""
 
           FAILED=false
@@ -199,6 +232,11 @@ jobs:
 
           if [ "${{ needs.dependency-review.result }}" = "failure" ]; then
             echo "ERROR: Dependency review failed"
+            FAILED=true
+          fi
+
+          if [ "${{ needs.rust.result }}" = "failure" ]; then
+            echo "ERROR: Rust checks failed"
             FAILED=true
           fi
 

--- a/.vig-os
+++ b/.vig-os
@@ -1,2 +1,2 @@
 # vig-os devcontainer configuration
-DEVCONTAINER_VERSION=0.3.0
+DEVCONTAINER_VERSION=0.3.3


### PR DESCRIPTION
## Summary

First PR under the new dev/main rulesets. Bundles four housekeeping items and the new Rust PR gate.

**Commits:**
- `chore: housekeeping` — sync `mat-rs/Cargo.lock` to v0.2.0 release, bump `.vig-os` devcontainer 0.3.0 → 0.3.3, gitignore `.cursor/`
- `ci(rust): add PR gate for mat-rs crate` — cargo fmt/clippy/test on pull_request

## Context

- Branch rulesets were just applied to `main` and `dev` (see #522 on vig-os/devcontainer for the gap in the scaffold docs).
- The `mat-rs` crate previously had no PR-time CI gate — `release-rs-materials.yml` only runs on tag push, so a broken Rust change could land undetected. This PR closes that gap.
- The `Rust (mat-rs)` check will be added to the required-status-checks list in both rulesets after this PR confirms the context name.

## Test plan

- [ ] Lint & Format passes
- [ ] Tests pass
- [ ] Security Scan passes
- [ ] Dependency Review passes
- [ ] CodeQL Analysis (python) passes
- [ ] Rust (mat-rs) — `cargo fmt --check`, `cargo clippy -D warnings`, `cargo test` all pass
- [ ] CI Summary green

🤖 Generated with [Claude Code](https://claude.com/claude-code)