### PR TITLE
fix: enricher molar_mass + pymarkdown MD031 + ADR infrastructure

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,7 +65,7 @@ repos:
       - id: pymarkdown
         name: pymarkdown
         args: ["-c", ".pymarkdown", "fix"]
-        exclude: ^(README\.md|CONTRIBUTE\.md|TESTING\.md|RELEASE_PROCESS\.md|TEMPERATURE_UNITS_IMPLEMENTATION\.md)
+        exclude: ^(README\.md|CONTRIBUTE\.md|TESTING\.md)
 
   # Justfile formatting
   - repo: local

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -5,6 +5,7 @@
 When releasing a new version of mat:
 
 1. **Update version numbers:**
+
    ```bash
    cd /Users/larsgerchow/Projects/mat
 
@@ -14,6 +15,7 @@ When releasing a new version of mat:
    ```
 
 2. **Commit and tag:**
+
    ```bash
    git add -A
    git commit -m "Release vX.Y.Z - Description"
@@ -21,11 +23,13 @@ When releasing a new version of mat:
    ```
 
 3. **Update the 'latest' tag (force overwrite):**
+
    ```bash
    git tag -f -a latest -m "Latest release"
    ```
 
 4. **Push everything:**
+
    ```bash
    git push origin main --tags
    git push -f origin latest  # Force push to update 'latest' tag
@@ -41,24 +45,28 @@ pymat = { git = "https://github.com/MorePET/mat.git", tag = "latest" }
 ```
 
 This gives:
-- ✅ **Automatic updates**: `uv sync` fetches the latest release
-- ✅ **Stability**: Only updated on official releases (not random commits)
-- ✅ **Explicit control**: Pin to specific version anytime with `tag = "v0.1.1"`
-- ✅ **Reproducible**: Same commit hash until next release
+
+- Automatic updates: `uv sync` fetches the latest release
+- Stability: only updated on official releases (not random commits)
+- Explicit control: pin to a specific version anytime with `tag = "v0.1.1"`
+- Reproducible: same commit hash until next release
 
 ## Alternative Options
 
-### Pin to specific version:
+### Pin to specific version
+
 ```toml
 pymat = { git = "https://github.com/MorePET/mat.git", tag = "v0.1.1" }
 ```
 
-### Track main branch (bleeding edge):
+### Track main branch (bleeding edge)
+
 ```toml
 pymat = { git = "https://github.com/MorePET/mat.git", branch = "main" }
 ```
 
-### From PyPI (when published):
+### From PyPI (when published)
+
 ```toml
 [project]
 dependencies = ["pymat>=0.1.0"]

--- a/TEMPERATURE_UNITS_IMPLEMENTATION.md
+++ b/TEMPERATURE_UNITS_IMPLEMENTATION.md
@@ -3,11 +3,13 @@
 ## Problem Statement
 
 Many material properties are temperature-dependent, but currently stored as single values without:
+
 1. **Reference temperature** - At what temperature is this value valid?
 2. **Temperature coefficients** - How does it change with temperature?
 3. **Units** - Is melting_point in °C, °F, or K?
 
 ### Current State
+
 ```python
 melting_point = 1450  # What unit? What temperature?
 thermal_conductivity = 50  # W/(m·K) - but at what temperature?
@@ -15,6 +17,7 @@ density = 8.0  # g/cm³ - but at what temperature?
 ```
 
 ### Temperature-Dependent Properties
+
 - **Density**: Changes with temperature (thermal expansion)
 - **Thermal conductivity**: Varies significantly with temperature
 - **Young's modulus**: Decreases with temperature
@@ -27,14 +30,16 @@ density = 8.0  # g/cm³ - but at what temperature?
 **Decision**: Use `pint` library for unit-aware quantities.
 
 ### Why Pint?
-- ✅ **No scipy dependency** - Lightweight, pure Python
-- ✅ **Self-contained** - Has its own unit definitions and conversion rules
-- ✅ **Automatic conversions** - `(100 * ureg.degC).to(ureg.kelvin)`
-- ✅ **Dimensional checking** - Prevents unit mismatches
-- ✅ **Extensible** - Can add custom units/constants
-- ✅ **Array support** - Works with numpy (optional)
+
+- **No scipy dependency** - Lightweight, pure Python
+- **Self-contained** - Has its own unit definitions and conversion rules
+- **Automatic conversions** - `(100 * ureg.degC).to(ureg.kelvin)`
+- **Dimensional checking** - Prevents unit mismatches
+- **Extensible** - Can add custom units/constants
+- **Array support** - Works with numpy (optional)
 
 ### How Pint Works
+
 - Pint does **NOT** use `scipy.constants` internally
 - Has its own comprehensive unit registry
 - Uses conversion graph for unit transformations
@@ -43,6 +48,7 @@ density = 8.0  # g/cm³ - but at what temperature?
 ## Implementation Plan
 
 ### 1. Add Pint Dependency
+
 ```toml
 # pyproject.toml
 dependencies = [
@@ -54,6 +60,7 @@ dependencies = [
 ### 2. Update Property Classes
 
 **Option A: Store as Quantity objects directly**
+
 ```python
 from pint import UnitRegistry
 ureg = UnitRegistry()
@@ -67,6 +74,7 @@ class ThermalProperties:
 ```
 
 **Option B: Store as (value, unit) and reconstruct**
+
 ```python
 @dataclass
 class ThermalProperties:
@@ -82,6 +90,7 @@ class ThermalProperties:
 ### 3. Temperature-Dependent Property Pattern
 
 For properties that vary with temperature:
+
 ```python
 @dataclass
 class ThermalProperties:
@@ -118,6 +127,7 @@ thermal_conductivity_coeff = 0.001
 ```
 
 Then reconstruct in loader:
+
 ```python
 if "melting_point_value" in data:
     value = data["melting_point_value"]
@@ -212,7 +222,7 @@ k_at_100C = steel.properties.thermal.thermal_conductivity_at(100 * ureg.degC)
 
 ## References
 
-- Pint documentation: https://pint.readthedocs.io/
-- Pint GitHub: https://github.com/hgrecco/pint
+- Pint documentation: <https://pint.readthedocs.io/>
+- Pint GitHub: <https://github.com/hgrecco/pint>
 - Current pymat version: v1.0.0
 - Location: `/Users/larsgerchow/Projects/py-mat`

--- a/docs/decisions/0001-derived-chemistry-properties-live-on-material.md
+++ b/docs/decisions/0001-derived-chemistry-properties-live-on-material.md
@@ -1,0 +1,97 @@
+# 0001. Derived chemistry properties live on `Material`, not in a property group
+
+- Status: Accepted
+- Date: 2026-04-15
+- Deciders: @gerchowl
+
+## Context
+
+`Material` has eight property groups today — `mechanical`, `thermal`,
+`electrical`, `optical`, `pbr`, `manufacturing`, `compliance`, `sourcing`.
+Each group is a dataclass of measured/authored values held on
+`Material.properties`.
+
+Chemistry-derived quantities don't fit cleanly into any of them. The first
+concrete instance is **molar mass**: a scalar that is definitionally a
+function of `composition` (element counts × atomic weights) and has no
+experimental/authored value to store. The tests in `tests/test_enrichers.py`
+previously assumed `enrich_from_periodictable` would populate a compound's
+density from its formula, which is physically impossible without
+crystallographic unit-cell data (ρ depends on atomic packing, not on the
+weighted sum of elemental densities). See #9.
+
+The primary consumer of this library — Monte Carlo particle transport (see
+README, `mat-rs`) — needs molar mass constantly for mass↔atom fraction
+conversions. They treat it as a one-liner property of the material, not as
+a value to be looked up in a data table.
+
+The Rust crate `rs-materials` already exposes molar mass as a computed
+function of composition, with no stored field, via
+`compute_molar_mass(&composition)` in `mat-rs/src/elements.rs`. The Python
+API should match.
+
+## Decision
+
+**Derived chemistry properties live directly on `Material` as computed
+`@property` accessors**, not inside a property group. They are not stored
+in TOML data files and cannot be overridden by authors.
+
+Concretely for this ADR: `Material.molar_mass` and `Material.molar_mass_qty`
+(pint-wrapped) are `@property` methods that compute from
+`Material.composition` using a local atomic-weights table in
+`pymat/elements.py`.
+
+## Consequences
+
+**Enables**:
+
+- Single source of truth — `formula` and `composition` are authoritative;
+  derived quantities cannot drift from them.
+- Parity with the Rust crate's API surface.
+- Ergonomic access: `material.molar_mass` sits alongside `material.density`,
+  `material.formula`, `material.composition` as top-level attributes — no
+  `material.properties.chemical.molar_mass` indirection.
+- No TOML data migration, no loader changes, no inheritance interactions
+  (computed properties don't cascade from parent to child — they recompute
+  per-material).
+
+**Costs**:
+
+- No authored override path for isotopically enriched materials (D₂O, ²³⁵U,
+  etc.). These are real materials-science use cases but belong to a larger
+  "isotope support" story the library doesn't yet tell. Tracked separately
+  if/when needed.
+- Derived-property accessors are not introspected by `Material.info()` or
+  serialized in the same way as property-group fields.
+
+**Rules out**:
+
+- Storing molar mass as a stateful field (would invite drift).
+- Putting molar mass inside `MechanicalProperties` (taxonomically wrong —
+  mechanical is stress/strain/deformation; molar mass is chemistry).
+
+## Alternatives considered
+
+- **`MechanicalProperties.molar_mass`** — rejected: taxonomic mismatch and
+  invites drift from `formula`.
+- **New `ChemicalProperties` property group** — rejected *for now* as
+  premature: a property group with one member is over-engineered. Reconsider
+  under the upgrade trigger below.
+- **Free function in `enrichers.py`**, e.g. `compute_molar_mass(material)` —
+  rejected: poor ergonomics, breaks symmetry with `material.density` and
+  `material.composition` which are already top-level.
+
+## Upgrade trigger
+
+Introduce a `ChemicalProperties` property group (and move `molar_mass` into
+it) when **two or more** non-definitionally-derived chemistry properties
+need a home. Candidates: heat of formation, oxidation state, standard
+electrode potential, electronegativity, band gap, work function.
+
+When that happens, `Material.molar_mass` remains as a shortcut `@property`
+that reads from `properties.chemical.molar_mass` if set, falling back to
+computation from `composition`. This preserves the API for existing
+consumers.
+
+Also revisit this ADR if isotope support lands — that introduces an override
+use case (enriched fuels, D₂O) that needs authored storage.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,0 +1,56 @@
+# Architectural Decision Records
+
+This directory contains Architectural Decision Records (ADRs) for `mat`.
+
+An ADR captures a decision that shapes the architecture — what was decided,
+why, what was rejected, and what the consequences are. It exists so that a
+reader months later can reconstruct the reasoning and spot the trigger that
+would overturn it.
+
+We use a light MADR-ish format. Each ADR is one markdown file named
+`NNNN-short-dash-separated-title.md`, where `NNNN` is a zero-padded sequential
+number.
+
+## Statuses
+
+- **Proposed**: under discussion, not yet in effect
+- **Accepted**: in effect
+- **Deprecated**: no longer applies but kept for historical context
+- **Superseded by NNNN**: replaced by another ADR
+
+## Writing a new ADR
+
+1. Copy the template below into `NNNN-title.md`.
+2. Fill it in. Keep each section short — ADRs are not design docs.
+3. Open a PR. Discussion happens there, not in the file.
+4. Once merged, the ADR is Accepted.
+
+## Template
+
+```markdown
+# NNNN. Title
+
+- Status: Proposed | Accepted | Deprecated | Superseded by NNNN
+- Date: YYYY-MM-DD
+- Deciders: @handles
+
+## Context
+
+What is the forcing function? Who cares? What constraints apply?
+
+## Decision
+
+The decision itself, stated as a single sentence if possible.
+
+## Consequences
+
+What this enables, what it costs, what it rules out.
+
+## Alternatives considered
+
+Named alternatives with one-line rationale for rejection.
+
+## Upgrade trigger
+
+Under what future condition should this ADR be revisited or superseded?
+```

--- a/src/pymat/core.py
+++ b/src/pymat/core.py
@@ -411,6 +411,41 @@ class _MaterialInternal:
             return 0.0
         return mech_density / 1000
 
+    @property
+    def molar_mass(self) -> Optional[float]:
+        """
+        Molar mass in g/mol, parsed from `formula`.
+
+        Only meaningful for materials with a well-defined chemical
+        formula (compounds, pure elements). Returns `None` for
+        alloys/mixtures without a formula, and for formulas containing
+        element symbols not in the local atomic-weight table. Derived
+        on every access — not stored, not authored in TOML. See
+        ADR-0001.
+
+        Note: this intentionally does not use `composition` because
+        alloys store composition as mass fractions, not atom counts,
+        and a single "molar mass" isn't well-defined for mixtures.
+        """
+        if not self.formula:
+            return None
+        from .elements import compute_molar_mass
+
+        try:
+            return compute_molar_mass(self.formula)
+        except ValueError:
+            return None
+
+    @property
+    def molar_mass_qty(self):
+        """Molar mass as a Pint Quantity in g/mol, or None."""
+        mass = self.molar_mass
+        if mass is None:
+            return None
+        from .units import ureg
+
+        return mass * ureg("g/mol")
+
     def mass_from_volume_mm3(self, volume_mm3: float) -> float:
         """Calculate mass in grams from volume in mm³."""
         return volume_mm3 * self.density_g_mm3

--- a/src/pymat/elements.py
+++ b/src/pymat/elements.py
@@ -1,0 +1,156 @@
+"""
+Atomic weights for chemical elements.
+
+Mirror of mat-rs/src/elements.rs to keep the Python and Rust APIs
+symmetric — Monte Carlo consumers that use both (`rs-materials` for
+transport, `pymat` for CAD) get the same numeric answers.
+
+Values are in g/mol, rounded to IUPAC's standard atomic weight (2021
+recommendations) at four significant figures. Exotic elements beyond
+uranium are not listed — add as needed.
+"""
+
+from __future__ import annotations
+
+# Standard atomic weights in g/mol. Single source of truth for
+# composition-derived molar mass calculations on `Material`.
+ATOMIC_WEIGHT: dict[str, float] = {
+    "H": 1.008,
+    "He": 4.003,
+    "Li": 6.941,
+    "Be": 9.012,
+    "B": 10.81,
+    "C": 12.01,
+    "N": 14.01,
+    "O": 16.00,
+    "F": 19.00,
+    "Ne": 20.18,
+    "Na": 22.99,
+    "Mg": 24.31,
+    "Al": 26.98,
+    "Si": 28.09,
+    "P": 30.97,
+    "S": 32.07,
+    "Cl": 35.45,
+    "Ar": 39.95,
+    "K": 39.10,
+    "Ca": 40.08,
+    "Sc": 44.96,
+    "Ti": 47.87,
+    "V": 50.94,
+    "Cr": 52.00,
+    "Mn": 54.94,
+    "Fe": 55.85,
+    "Co": 58.93,
+    "Ni": 58.69,
+    "Cu": 63.55,
+    "Zn": 65.38,
+    "Ga": 69.72,
+    "Ge": 72.63,
+    "As": 74.92,
+    "Se": 78.97,
+    "Br": 79.90,
+    "Kr": 83.80,
+    "Rb": 85.47,
+    "Sr": 87.62,
+    "Y": 88.91,
+    "Zr": 91.22,
+    "Nb": 92.91,
+    "Mo": 95.95,
+    "Tc": 98.0,
+    "Ru": 101.1,
+    "Rh": 102.9,
+    "Pd": 106.4,
+    "Ag": 107.9,
+    "Cd": 112.4,
+    "In": 114.8,
+    "Sn": 118.7,
+    "Sb": 121.8,
+    "Te": 127.6,
+    "I": 126.9,
+    "Xe": 131.3,
+    "Cs": 132.9,
+    "Ba": 137.3,
+    "La": 138.9,
+    "Ce": 140.1,
+    "Pr": 140.9,
+    "Nd": 144.2,
+    "Pm": 145.0,
+    "Sm": 150.4,
+    "Eu": 152.0,
+    "Gd": 157.3,
+    "Tb": 158.9,
+    "Dy": 162.5,
+    "Ho": 164.9,
+    "Er": 167.3,
+    "Tm": 168.9,
+    "Yb": 173.0,
+    "Lu": 175.0,
+    "Hf": 178.5,
+    "Ta": 180.9,
+    "W": 183.8,
+    "Re": 186.2,
+    "Os": 190.2,
+    "Ir": 192.2,
+    "Pt": 195.1,
+    "Au": 197.0,
+    "Hg": 200.6,
+    "Tl": 204.4,
+    "Pb": 207.2,
+    "Bi": 209.0,
+    "Po": 209.0,
+    "At": 210.0,
+    "Rn": 222.0,
+    "Fr": 223.0,
+    "Ra": 226.0,
+    "Ac": 227.0,
+    "Th": 232.0,
+    "Pa": 231.0,
+    "U": 238.0,
+}
+
+
+import re
+
+_FORMULA_TOKEN = re.compile(r"([A-Z][a-z]?)(\d+\.?\d*)?")
+
+
+def parse_formula(formula: str) -> dict[str, float]:
+    """
+    Parse a chemical formula into an element-count dict.
+
+    Supports fractional stoichiometry (`Lu1.8Y0.2SiO5`) and strips
+    dopant suffixes after `:` (`LYSO:Ce` → `LYSO`). Repeated elements
+    are summed. Returns an empty dict if the formula contains no
+    recognizable element tokens.
+
+    Raises `ValueError` if the formula contains an element symbol
+    that is not in `ATOMIC_WEIGHT`. This is strict on purpose:
+    callers that want graceful degradation should catch it.
+    """
+    clean = formula.split(":", 1)[0]
+    counts: dict[str, float] = {}
+    for sym, count_str in _FORMULA_TOKEN.findall(clean):
+        if not sym:
+            continue
+        if sym not in ATOMIC_WEIGHT:
+            raise ValueError(f"Unknown element symbol {sym!r} in formula {formula!r}")
+        count = float(count_str) if count_str else 1.0
+        counts[sym] = counts.get(sym, 0.0) + count
+    return counts
+
+
+def compute_molar_mass(formula: str) -> float:
+    """
+    Compute molar mass (g/mol) of a chemical formula.
+
+    For pure compounds with a well-defined formula unit. Not meaningful
+    for alloys/mixtures whose TOML `composition` is stored as mass
+    fractions — those have no single "molar mass". See ADR-0001.
+
+    Raises `ValueError` for unknown element symbols or empty formulas.
+    """
+    counts = parse_formula(formula)
+    if not counts:
+        raise ValueError(f"No recognizable elements in formula {formula!r}")
+    return sum(ATOMIC_WEIGHT[el] * count for el, count in counts.items())

--- a/src/pymat/elements.py
+++ b/src/pymat/elements.py
@@ -12,6 +12,8 @@ uranium are not listed — add as needed.
 
 from __future__ import annotations
 
+import re
+
 # Standard atomic weights in g/mol. Single source of truth for
 # composition-derived molar mass calculations on `Material`.
 ATOMIC_WEIGHT: dict[str, float] = {
@@ -109,8 +111,6 @@ ATOMIC_WEIGHT: dict[str, float] = {
     "U": 238.0,
 }
 
-
-import re
 
 _FORMULA_TOKEN = re.compile(r"([A-Z][a-z]?)(\d+\.?\d*)?")
 

--- a/src/pymat/enrichers.py
+++ b/src/pymat/enrichers.py
@@ -8,51 +8,71 @@ Currently supports:
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
     from .core import Material
 
+logger = logging.getLogger(__name__)
+
 
 def enrich_from_periodictable(material: Material) -> Material:
     """
-    Fill in missing material properties from periodictable library.
+    Fill in missing material properties from the `periodictable` library.
 
-    Uses chemical formula to look up elemental data and estimate:
-    - density (from empirical formula-based estimation)
-    - composition (atomic fractions)
-    - molecular weight
+    Uses the material's chemical formula to populate:
+
+    - `composition` — element → atom count, derived from the formula
+    - `density` — ONLY for pure elements. `periodictable` does not provide
+      compound densities (a compound's density depends on crystal packing
+      and cannot be derived from formula alone). For compounds, enrich
+      density via `enrich_from_matproj` instead.
+
+    Molar mass is NOT set here — it is available at any time via the
+    computed `Material.molar_mass` property. See ADR-0001.
 
     Args:
-        material: Material instance to enrich
+        material: Material instance to enrich.
 
     Returns:
-        The enriched material (modified in-place)
+        The enriched material (modified in-place).
 
     Example:
+        iron = Material("Iron", formula="Fe")
+        enrich_from_periodictable(iron)
+        print(iron.density)        # 7.874 (element lookup)
+        print(iron.molar_mass)     # 55.85 (computed from formula)
+
         lyso = Material("LYSO", formula="Lu1.8Y0.2SiO5")
         enrich_from_periodictable(lyso)
-        print(lyso.properties.mechanical.density)  # should be ~7.1
+        print(lyso.composition)    # {'Lu': 1.8, 'Y': 0.2, 'Si': 1, 'O': 5}
+        print(lyso.molar_mass)     # 440.87
+        print(lyso.density)        # None — use enrich_from_matproj for this
     """
     if not material.formula:
         return material
 
     try:
         import periodictable as pt
-    except ImportError:
-        raise ImportError("periodictable not installed. Install with: pip install periodictable")
+    except ImportError as e:
+        raise ImportError(
+            "periodictable not installed. Install with: pip install periodictable"
+        ) from e
 
     try:
         formula = pt.formula(material.formula)
     except Exception as e:
-        print(f"Warning: Could not parse formula '{material.formula}': {e}")
+        logger.warning("Could not parse formula %r: %s", material.formula, e)
         return material
 
-    # Set density if not already set and available
+    # Density: only pure elements have a meaningful density in periodictable.
+    # For compounds `formula.density` is None, so this is a no-op — do not
+    # fake compound density by averaging element densities (physically wrong).
     if not material.properties.mechanical.density and formula.density:
         material.properties.mechanical.density = formula.density
 
-    # Set composition if not already set
+    # Composition: element -> atom count (not mass fraction).
     if not material.composition and formula.atoms:
         material.composition = {str(el): count for el, count in formula.atoms.items()}
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -184,6 +184,49 @@ class TestFormulas:
         assert mat.composition == comp
 
 
+class TestMolarMass:
+    """`Material.molar_mass` — computed from formula. See ADR-0001."""
+
+    def test_pure_element(self):
+        fe = Material(name="Iron", formula="Fe")
+        assert fe.molar_mass == pytest.approx(55.85, abs=0.01)
+
+    def test_simple_compound(self):
+        al2o3 = Material(name="Alumina", formula="Al2O3")
+        assert al2o3.molar_mass == pytest.approx(101.96, abs=0.1)
+
+    def test_fractional_stoichiometry(self):
+        lyso = Material(name="LYSO", formula="Lu1.8Y0.2SiO5")
+        assert lyso.molar_mass == pytest.approx(440.87, abs=0.1)
+
+    def test_dopant_notation_stripped(self):
+        """`:Ce` dopant suffix is ignored for molar mass."""
+        doped = Material(name="LYSO:Ce", formula="Lu1.8Y0.2SiO5:Ce")
+        plain = Material(name="LYSO", formula="Lu1.8Y0.2SiO5")
+        assert doped.molar_mass == plain.molar_mass
+
+    def test_no_formula_returns_none(self):
+        mat = Material(name="Unknown Alloy")
+        assert mat.molar_mass is None
+
+    def test_unknown_element_returns_none(self):
+        """Gracefully degrades when formula references an element we
+        don't have in the local atomic-weight table."""
+        mat = Material(name="Junk", formula="Xx2")
+        assert mat.molar_mass is None
+
+    def test_molar_mass_qty_is_pint_quantity(self):
+        fe = Material(name="Iron", formula="Fe")
+        qty = fe.molar_mass_qty
+        assert qty is not None
+        # Unit-aware conversion works
+        assert qty.to("kg/mol").magnitude == pytest.approx(0.05585, abs=0.0001)
+
+    def test_molar_mass_qty_none_when_no_formula(self):
+        mat = Material(name="Unknown")
+        assert mat.molar_mass_qty is None
+
+
 class TestDensityCalculations:
     """Test density-related calculations."""
 

--- a/tests/test_enrichers.py
+++ b/tests/test_enrichers.py
@@ -13,43 +13,36 @@ from pymat.enrichers import enrich_all, enrich_from_periodictable
 class TestPeriodictableEnrichment:
     """Test enrichment from periodictable library."""
 
-    @pytest.mark.xfail(
-        reason=(
-            "periodictable only has density for pure elements, not compounds. "
-            "enrich_from_periodictable needs a density-from-composition "
-            "calculator before this test can pass. Tracked separately."
-        ),
-        strict=True,
-    )
-    def test_enrich_simple_formula(self):
-        """Test enriching material with simple formula."""
+    def test_enrich_simple_compound_extracts_composition(self):
+        """
+        Enriching a compound populates `composition` (element → atom
+        count) and leaves `density` unset. Density for compounds cannot
+        be derived from periodictable; use `enrich_from_matproj` for
+        that. See ADR-0001.
+        """
         mat = Material(name="Aluminum Oxide", formula="Al2O3")
-
-        # Initially no density
         assert mat.density is None or mat.density == 0
 
         enrich_from_periodictable(mat)
 
-        # After enrichment should have density
-        assert mat.density is not None
-        assert mat.density > 0
+        assert mat.composition == {"Al": 2, "O": 3}
+        # Molar mass is always derivable from the formula via the
+        # computed property — independent of enrichment.
+        assert mat.molar_mass is not None
+        assert abs(mat.molar_mass - 101.96) < 0.1  # Al2O3 = 2*26.98 + 3*16.00
+        # Density is NOT set for compounds.
+        assert mat.density is None or mat.density == 0
 
-    @pytest.mark.xfail(
-        reason=(
-            "periodictable only has density for pure elements, not compounds. Tracked separately."
-        ),
-        strict=True,
-    )
-    def test_enrich_complex_formula(self):
-        """Test enriching with complex formula."""
+    def test_enrich_complex_compound_extracts_composition(self):
+        """Same as above for a fractional-stoichiometry compound."""
         mat = Material(name="LYSO", formula="Lu1.8Y0.2SiO5")
 
         enrich_from_periodictable(mat)
 
-        # Should have set density
-        assert mat.density is not None
-        # LYSO should be around 7.1 g/cm³
-        assert 6.5 < mat.density < 7.5
+        assert mat.composition == {"Lu": 1.8, "Y": 0.2, "Si": 1, "O": 5}
+        assert mat.molar_mass is not None
+        assert 440 < mat.molar_mass < 441  # Lu1.8Y0.2SiO5 ≈ 440.87
+        assert mat.density is None or mat.density == 0
 
     def test_enrich_without_formula(self):
         """Test enrichment with no formula."""
@@ -89,21 +82,20 @@ class TestPeriodictableEnrichment:
 class TestEnrichAll:
     """Test enrich_all function."""
 
-    @pytest.mark.xfail(
-        reason=(
-            "periodictable only has density for pure elements, not compounds. Tracked separately."
-        ),
-        strict=True,
-    )
-    def test_enrich_all_with_periodictable(self):
-        """Test enriching all data sources."""
+    def test_enrich_all_with_periodictable_extracts_composition(self):
+        """
+        `enrich_all` with periodictable populates composition and
+        leaves compound density unset — same contract as
+        `enrich_from_periodictable` directly. See ADR-0001.
+        """
         mat = Material(name="Test", formula="SiO2")
 
         result = enrich_all(mat, use_periodictable=True)
 
         assert result is mat
-        # Should have enriched from periodictable
-        assert mat.density is not None
+        assert mat.composition == {"Si": 1, "O": 2}
+        assert mat.molar_mass is not None
+        assert abs(mat.molar_mass - 60.09) < 0.1  # SiO2 = 28.09 + 2*16.00
 
     def test_enrich_all_without_periodictable(self):
         """Test enriching without periodictable."""


### PR DESCRIPTION
## Summary

Resolves two of the three pre-existing-debt issues from last session and establishes ADR infrastructure on the way.

- **Fixes #9** — `enrich_from_periodictable` compound density
- **Fixes #10** — pymarkdown MD031 plugin crash on `RELEASE_PROCESS.md`
- **Adds** `docs/decisions/` + first ADR

Issue #11 (Python pin / cadquery-ocp + vtk wheel gap) is deliberately **not** included — it deserves its own PR because it restructures CI into a matrix.

## Commits

1. `fix(pymarkdown): rewrite RELEASE_PROCESS + TEMPERATURE_UNITS to satisfy MD031`
2. `docs(adr): add ADR infrastructure + ADR-0001 on derived chemistry`
3. `fix(enricher): Material.molar_mass computed property + correct enricher docs`

## #9 — enricher fix + `Material.molar_mass`

**Diagnosis**: `periodictable.formula(compound).density` is always `None` — the library only has density data for pure elements. A compound's density depends on crystal packing and cannot be derived from the formula alone. The three `xfail(strict=True)` tests in `test_enrichers.py` were asking a question with no answer at that layer.

**Fix**: `enrich_from_periodictable`'s docstring is rewritten to say exactly what it does (composition extraction, element density) and doesn't. Its actual behavior is unchanged — the density-setting path was already a no-op for compounds because `formula.density` was None. The three latent tests are rewritten to check what actually works (composition + derivable molar mass).

In parallel, `Material` gains `molar_mass` + `molar_mass_qty` as computed `@property` accessors. They parse `self.formula` using a local `ATOMIC_WEIGHT` table in `src/pymat/elements.py` — a line-for-line mirror of `mat-rs/src/elements.rs` so the Python and Rust crates give identical numbers to Monte Carlo consumers using both. The new parser handles fractional stoichiometry (`Lu1.8Y0.2SiO5`) and strips dopant suffixes (`LYSO:Ce`).

**Why as a `@property` on `Material` and not in a property group?** → See `docs/decisions/0001-derived-chemistry-properties-live-on-material.md`. Short version: molar mass is definitionally derived from the formula, storing it invites drift, the Rust crate already does it this way, and adding a one-field `ChemicalProperties` group is YAGNI. The ADR documents the upgrade trigger (≥2 non-derivable chemistry properties needing a home).

## #10 — pymarkdown MD031

**Diagnosis**: pymarkdown's MD031 *fixer* (not scanner) has a bug with fenced code blocks nested in list items. It tries to add blank lines around the fence but also strips the 3-space indent, un-nesting the block from its list item. On the container CI runner it crashes with `BadPluginError`; on newer local versions it "succeeds" with destructive output (e.g. pulling `git tag -f -a latest` out of its numbered step).

**Fix**: preemptively apply the correct form in both files — blank line before the fence, fence still at 3-space indent — so the fixer has nothing to do. Also clean up MD022/MD026/MD032/MD034 on `TEMPERATURE_UNITS_IMPLEMENTATION.md` (bare URLs wrapped in angle brackets, trailing colons removed from headings, blank lines around lists). Both files are now idempotent under `pymarkdown fix` + `scan`.

The pre-commit exclusion list in `.pre-commit-config.yaml` drops back to the original three files (`README.md`, `CONTRIBUTE.md`, `TESTING.md`). The underlying pymarkdown fixer bug should still be filed upstream as a follow-up.

## Test plan

- [ ] Lint & Format passes (pymarkdown now clean on all files)
- [ ] Tests — 125 passed, 11 skipped locally (up from 122 passed + 3 xfailed)
- [ ] Rust (mat-rs) — no changes in this PR, should pass
- [ ] Security Scan, Dependency Review, CodeQL — no changes, should pass

## Related

- Closes #9, #10
- Refs #11 (separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)