### PR TITLE
fix(sync): use git merge-tree for false-positive-free conflict detection

### DIFF
--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -158,13 +158,31 @@ jobs:
         id: merge-check
         run: |
           set -euo pipefail
-          git fetch origin main
-          if git merge --no-commit --no-ff origin/main 2>/dev/null; then
+          git fetch origin main dev
+          # git merge-tree --write-tree does an in-memory trial merge
+          # without touching the working tree or index. Exits 0 on clean
+          # merge, 1 on conflicts, anything else is an error. This is the
+          # right tool for "can these be merged" checks — the previous
+          # implementation used `git merge --no-commit --no-ff 2>/dev/null`
+          # which misfired when the trial merge was a degenerate
+          # fast-forward-with-no-ff (e.g. dev tip is an ancestor of main's
+          # merge commit after a dev→main PR) and reported false-positive
+          # conflicts with the error output silenced.
+          if merge_out="$(git merge-tree --write-tree origin/dev origin/main 2>&1)"; then
             echo "conflict=false" >> "$GITHUB_OUTPUT"
+            echo "Merge-tree check: no conflicts between origin/dev and origin/main."
           else
-            echo "conflict=true" >> "$GITHUB_OUTPUT"
+            merge_rc=$?
+            if [ "${merge_rc}" -eq 1 ]; then
+              echo "conflict=true" >> "$GITHUB_OUTPUT"
+              echo "::warning::Merge conflicts detected between origin/dev and origin/main."
+              echo "${merge_out}"
+            else
+              echo "::error::git merge-tree failed with exit code ${merge_rc}"
+              echo "${merge_out}"
+              exit "${merge_rc}"
+            fi
           fi
-          git merge --abort 2>/dev/null || true
 
       - name: Create sync branch from main
         if: steps.existing-pr.outputs.count == '0' && steps.recheck.outputs.up_to_date != 'true'


### PR DESCRIPTION
## Summary

Replaces the broken \`Detect merge conflicts\` step in \`sync-main-to-dev.yml\` with \`git merge-tree --write-tree\`, matching the current upstream `vig-os/devcontainer` implementation.

**Not actually a new upstream bug**: the current `vig-os/devcontainer` template already uses \`git merge-tree\`. Our scaffolded copy is stale and still runs the old \`git merge --no-commit --no-ff\` pattern. No upstream issue to file — this is a stale-template sync.

## What was wrong

On PR #13 (the auto-created sync-back after the initial dev→main bootstrap), sync-main-to-dev opened a PR labeled \`merge-conflict\` and titled \`(conflicts)\`, but the PR had \`mergeable: MERGEABLE\`, 0 files changed, and all CI checks green. Locally, \`git merge --no-commit --no-ff origin/main\` on dev worked fine.

Root cause: \`git merge --no-ff\` has degenerate behavior when one side is already an ancestor of the other. After a dev→main merge PR, main's tip is a merge commit whose second parent is dev's old tip, so dev is an ancestor of main. In that topology \`git merge --no-ff\` can exit non-zero without producing a real conflict, which the workflow then mislabels. The \`2>/dev/null\` redirect compounds the problem by hiding all diagnostic output.

## Fix

\`\`\`yaml
if merge_out="\$(git merge-tree --write-tree origin/dev origin/main 2>&1)"; then
  echo "conflict=false" >> "\$GITHUB_OUTPUT"
else
  merge_rc=\$?
  if [ "\${merge_rc}" -eq 1 ]; then
    echo "conflict=true" >> "\$GITHUB_OUTPUT"
    ...
  else
    echo "::error::git merge-tree failed with exit code \${merge_rc}"
    exit "\${merge_rc}"
  fi
fi
\`\`\`

\`git merge-tree --write-tree\` does an in-memory trial merge without touching the working tree or index. Exit 0 = clean (outputs merged tree SHA), exit 1 = conflicts, anything else = real error. stderr is now captured instead of dropped, so future misbehavior is visible.

## Test plan

- [ ] CI passes
- [ ] On next dev→main merge, \`sync-main-to-dev\` opens the PR with a clean title (not \`(conflicts)\`) and no \`merge-conflict\` label

## Out of scope

The upstream workflow also adds container-based execution, a \`resolve-image\` action, retry wrappers, and a \`git push\` flow for branch creation. Those require infrastructure (\`resolve-image\` action, the vigOS devcontainer image) that we don't have locally. This PR is the surgical fix; a broader template resync is a separate task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)