### PR TITLE
chore: sync dev to main — #9, #10, #11, sync-main-to-dev fix

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -44,10 +44,18 @@ name: 'Setup Environment'
 description: 'Set up CI environment with Python, uv, pre-commit, and optional tools (podman, Node.js, devcontainer CLI, BATS)'
 
 inputs:
+  python-version:
+    description: 'Explicit Python version. Overrides .python-version when set.'
+    required: false
+    default: ''
   sync-dependencies:
     description: 'Run uv sync to install project dependencies'
     required: false
     default: 'false'
+  uv-sync-args:
+    description: 'Extra args to pass to uv sync (e.g. "--all-extras", "--extra periodictable"). Used only when sync-dependencies is true.'
+    required: false
+    default: '--all-extras'
   install-podman:
     description: 'Install podman for container operations'
     required: false
@@ -82,7 +90,16 @@ runs:
   using: composite
   steps:
     # ── Python ───────────────────────────────────────────────────────────
-    - name: "Set up Python"
+    # Explicit python-version wins over .python-version file. Matrix jobs
+    # pass their version in; un-parameterized callers fall back to the file.
+    - name: "Set up Python (from input)"
+      if: inputs.python-version != ''
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: "Set up Python (from .python-version)"
+      if: inputs.python-version == ''
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
       with:
         python-version-file: ".python-version"
@@ -105,7 +122,7 @@ runs:
     - name: Sync Python dependencies
       if: inputs.sync-dependencies == 'true'
       shell: bash
-      run: uv sync --frozen --all-extras
+      run: uv sync --frozen ${{ inputs.uv-sync-args }}
 
     # ── Podman ──────────────────────────────────────────────────────────
     - name: Install podman

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,14 +61,31 @@ jobs:
       - name: Run pre-commit hooks
         run: uv run pre-commit run --all-files --show-diff-on-failure
 
-  test:
-    name: Tests
+  test-matrix:
+    # Matrix of (python-version, extras set). Each cell is a visible
+    # status check. The roll-up `test` job below aggregates them into
+    # the single `Tests` context consumers of the ruleset depend on.
+    name: "Tests (${{ matrix.label }})"
     runs-on: ubuntu-22.04
     timeout-minutes: 15
     if: |
       github.event_name != 'workflow_dispatch' ||
       inputs.test-suite == 'all' ||
       inputs.test-suite == 'test'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Full integration including build123d (pulls cadquery-ocp + vtk,
+          # which have cp311/cp312 wheels only). See #11.
+          - label: "py3.12, all"
+            python-version: "3.12"
+            uv-sync-args: "--all-extras"
+          # Core + lightweight extras on the latest Python the ecosystem
+          # lets us use.
+          - label: "py3.13, core"
+            python-version: "3.13"
+            uv-sync-args: "--extra periodictable --extra matproj"
 
     steps:
       - name: Checkout repository
@@ -77,7 +94,9 @@ jobs:
       - name: Set up environment
         uses: ./.github/actions/setup-env
         with:
+          python-version: ${{ matrix.python-version }}
           sync-dependencies: 'true'
+          uv-sync-args: ${{ matrix.uv-sync-args }}
 
       - name: Run tests with coverage
         run: uv run pytest --cov --cov-report=term-missing --cov-report=xml
@@ -86,10 +105,28 @@ jobs:
         if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
-          name: coverage-report
+          name: coverage-report-${{ matrix.python-version }}
           path: coverage.xml
           retention-days: 30
           if-no-files-found: ignore
+
+  test:
+    # Roll-up status check. Keeps `Tests` stable as a required-status
+    # context in branch rulesets while individual matrix cells report
+    # under `Tests (py3.12, all)` / `Tests (py3.13, core)`.
+    name: Tests
+    runs-on: ubuntu-22.04
+    timeout-minutes: 2
+    needs: [test-matrix]
+    if: always()
+    steps:
+      - name: Check matrix result
+        run: |
+          if [ "${{ needs.test-matrix.result }}" != "success" ]; then
+            echo "::error::One or more test-matrix cells failed"
+            exit 1
+          fi
+          echo "All test-matrix cells passed"
 
   security:
     name: Security Scan

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,16 +76,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Full integration including build123d (pulls cadquery-ocp + vtk,
-          # which have cp311/cp312 wheels only). See #11.
+          # Full integration. On 3.12, `--all-extras` installs
+          # periodictable, matproj, build123d, and dev (pytest). On
+          # 3.13+, the env marker on build123d drops it silently,
+          # which is exactly what we want for forward-compat testing.
           - label: "py3.12, all"
             python-version: "3.12"
             uv-sync-args: "--all-extras"
-          # Core + lightweight extras on the latest Python the ecosystem
-          # lets us use.
-          - label: "py3.13, core"
+          - label: "py3.13, all"
             python-version: "3.13"
-            uv-sync-args: "--extra periodictable --extra matproj"
+            uv-sync-args: "--all-extras"
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -158,13 +158,31 @@ jobs:
         id: merge-check
         run: |
           set -euo pipefail
-          git fetch origin main
-          if git merge --no-commit --no-ff origin/main 2>/dev/null; then
+          git fetch origin main dev
+          # git merge-tree --write-tree does an in-memory trial merge
+          # without touching the working tree or index. Exits 0 on clean
+          # merge, 1 on conflicts, anything else is an error. This is the
+          # right tool for "can these be merged" checks — the previous
+          # implementation used `git merge --no-commit --no-ff 2>/dev/null`
+          # which misfired when the trial merge was a degenerate
+          # fast-forward-with-no-ff (e.g. dev tip is an ancestor of main's
+          # merge commit after a dev→main PR) and reported false-positive
+          # conflicts with the error output silenced.
+          if merge_out="$(git merge-tree --write-tree origin/dev origin/main 2>&1)"; then
             echo "conflict=false" >> "$GITHUB_OUTPUT"
+            echo "Merge-tree check: no conflicts between origin/dev and origin/main."
           else
-            echo "conflict=true" >> "$GITHUB_OUTPUT"
+            merge_rc=$?
+            if [ "${merge_rc}" -eq 1 ]; then
+              echo "conflict=true" >> "$GITHUB_OUTPUT"
+              echo "::warning::Merge conflicts detected between origin/dev and origin/main."
+              echo "${merge_out}"
+            else
+              echo "::error::git merge-tree failed with exit code ${merge_rc}"
+              echo "${merge_out}"
+              exit "${merge_rc}"
+            fi
           fi
-          git merge --abort 2>/dev/null || true
 
       - name: Create sync branch from main
         if: steps.existing-pr.outputs.count == '0' && steps.recheck.outputs.up_to_date != 'true'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,7 +65,7 @@ repos:
       - id: pymarkdown
         name: pymarkdown
         args: ["-c", ".pymarkdown", "fix"]
-        exclude: ^(README\.md|CONTRIBUTE\.md|TESTING\.md|RELEASE_PROCESS\.md|TEMPERATURE_UNITS_IMPLEMENTATION\.md)
+        exclude: ^(README\.md|CONTRIBUTE\.md|TESTING\.md)
 
   # Justfile formatting
   - repo: local

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -5,6 +5,7 @@
 When releasing a new version of mat:
 
 1. **Update version numbers:**
+
    ```bash
    cd /Users/larsgerchow/Projects/mat
 
@@ -14,6 +15,7 @@ When releasing a new version of mat:
    ```
 
 2. **Commit and tag:**
+
    ```bash
    git add -A
    git commit -m "Release vX.Y.Z - Description"
@@ -21,11 +23,13 @@ When releasing a new version of mat:
    ```
 
 3. **Update the 'latest' tag (force overwrite):**
+
    ```bash
    git tag -f -a latest -m "Latest release"
    ```
 
 4. **Push everything:**
+
    ```bash
    git push origin main --tags
    git push -f origin latest  # Force push to update 'latest' tag
@@ -41,24 +45,28 @@ pymat = { git = "https://github.com/MorePET/mat.git", tag = "latest" }
 ```
 
 This gives:
-- ✅ **Automatic updates**: `uv sync` fetches the latest release
-- ✅ **Stability**: Only updated on official releases (not random commits)
-- ✅ **Explicit control**: Pin to specific version anytime with `tag = "v0.1.1"`
-- ✅ **Reproducible**: Same commit hash until next release
+
+- Automatic updates: `uv sync` fetches the latest release
+- Stability: only updated on official releases (not random commits)
+- Explicit control: pin to a specific version anytime with `tag = "v0.1.1"`
+- Reproducible: same commit hash until next release
 
 ## Alternative Options
 
-### Pin to specific version:
+### Pin to specific version
+
 ```toml
 pymat = { git = "https://github.com/MorePET/mat.git", tag = "v0.1.1" }
 ```
 
-### Track main branch (bleeding edge):
+### Track main branch (bleeding edge)
+
 ```toml
 pymat = { git = "https://github.com/MorePET/mat.git", branch = "main" }
 ```
 
-### From PyPI (when published):
+### From PyPI (when published)
+
 ```toml
 [project]
 dependencies = ["pymat>=0.1.0"]

--- a/TEMPERATURE_UNITS_IMPLEMENTATION.md
+++ b/TEMPERATURE_UNITS_IMPLEMENTATION.md
@@ -3,11 +3,13 @@
 ## Problem Statement
 
 Many material properties are temperature-dependent, but currently stored as single values without:
+
 1. **Reference temperature** - At what temperature is this value valid?
 2. **Temperature coefficients** - How does it change with temperature?
 3. **Units** - Is melting_point in °C, °F, or K?
 
 ### Current State
+
 ```python
 melting_point = 1450  # What unit? What temperature?
 thermal_conductivity = 50  # W/(m·K) - but at what temperature?
@@ -15,6 +17,7 @@ density = 8.0  # g/cm³ - but at what temperature?
 ```
 
 ### Temperature-Dependent Properties
+
 - **Density**: Changes with temperature (thermal expansion)
 - **Thermal conductivity**: Varies significantly with temperature
 - **Young's modulus**: Decreases with temperature
@@ -27,14 +30,16 @@ density = 8.0  # g/cm³ - but at what temperature?
 **Decision**: Use `pint` library for unit-aware quantities.
 
 ### Why Pint?
-- ✅ **No scipy dependency** - Lightweight, pure Python
-- ✅ **Self-contained** - Has its own unit definitions and conversion rules
-- ✅ **Automatic conversions** - `(100 * ureg.degC).to(ureg.kelvin)`
-- ✅ **Dimensional checking** - Prevents unit mismatches
-- ✅ **Extensible** - Can add custom units/constants
-- ✅ **Array support** - Works with numpy (optional)
+
+- **No scipy dependency** - Lightweight, pure Python
+- **Self-contained** - Has its own unit definitions and conversion rules
+- **Automatic conversions** - `(100 * ureg.degC).to(ureg.kelvin)`
+- **Dimensional checking** - Prevents unit mismatches
+- **Extensible** - Can add custom units/constants
+- **Array support** - Works with numpy (optional)
 
 ### How Pint Works
+
 - Pint does **NOT** use `scipy.constants` internally
 - Has its own comprehensive unit registry
 - Uses conversion graph for unit transformations
@@ -43,6 +48,7 @@ density = 8.0  # g/cm³ - but at what temperature?
 ## Implementation Plan
 
 ### 1. Add Pint Dependency
+
 ```toml
 # pyproject.toml
 dependencies = [
@@ -54,6 +60,7 @@ dependencies = [
 ### 2. Update Property Classes
 
 **Option A: Store as Quantity objects directly**
+
 ```python
 from pint import UnitRegistry
 ureg = UnitRegistry()
@@ -67,6 +74,7 @@ class ThermalProperties:
 ```
 
 **Option B: Store as (value, unit) and reconstruct**
+
 ```python
 @dataclass
 class ThermalProperties:
@@ -82,6 +90,7 @@ class ThermalProperties:
 ### 3. Temperature-Dependent Property Pattern
 
 For properties that vary with temperature:
+
 ```python
 @dataclass
 class ThermalProperties:
@@ -118,6 +127,7 @@ thermal_conductivity_coeff = 0.001
 ```
 
 Then reconstruct in loader:
+
 ```python
 if "melting_point_value" in data:
     value = data["melting_point_value"]
@@ -212,7 +222,7 @@ k_at_100C = steel.properties.thermal.thermal_conductivity_at(100 * ureg.degC)
 
 ## References
 
-- Pint documentation: https://pint.readthedocs.io/
-- Pint GitHub: https://github.com/hgrecco/pint
+- Pint documentation: <https://pint.readthedocs.io/>
+- Pint GitHub: <https://github.com/hgrecco/pint>
 - Current pymat version: v1.0.0
 - Location: `/Users/larsgerchow/Projects/py-mat`

--- a/docs/decisions/0001-derived-chemistry-properties-live-on-material.md
+++ b/docs/decisions/0001-derived-chemistry-properties-live-on-material.md
@@ -1,0 +1,97 @@
+# 0001. Derived chemistry properties live on `Material`, not in a property group
+
+- Status: Accepted
+- Date: 2026-04-15
+- Deciders: @gerchowl
+
+## Context
+
+`Material` has eight property groups today — `mechanical`, `thermal`,
+`electrical`, `optical`, `pbr`, `manufacturing`, `compliance`, `sourcing`.
+Each group is a dataclass of measured/authored values held on
+`Material.properties`.
+
+Chemistry-derived quantities don't fit cleanly into any of them. The first
+concrete instance is **molar mass**: a scalar that is definitionally a
+function of `composition` (element counts × atomic weights) and has no
+experimental/authored value to store. The tests in `tests/test_enrichers.py`
+previously assumed `enrich_from_periodictable` would populate a compound's
+density from its formula, which is physically impossible without
+crystallographic unit-cell data (ρ depends on atomic packing, not on the
+weighted sum of elemental densities). See #9.
+
+The primary consumer of this library — Monte Carlo particle transport (see
+README, `mat-rs`) — needs molar mass constantly for mass↔atom fraction
+conversions. They treat it as a one-liner property of the material, not as
+a value to be looked up in a data table.
+
+The Rust crate `rs-materials` already exposes molar mass as a computed
+function of composition, with no stored field, via
+`compute_molar_mass(&composition)` in `mat-rs/src/elements.rs`. The Python
+API should match.
+
+## Decision
+
+**Derived chemistry properties live directly on `Material` as computed
+`@property` accessors**, not inside a property group. They are not stored
+in TOML data files and cannot be overridden by authors.
+
+Concretely for this ADR: `Material.molar_mass` and `Material.molar_mass_qty`
+(pint-wrapped) are `@property` methods that compute from
+`Material.composition` using a local atomic-weights table in
+`pymat/elements.py`.
+
+## Consequences
+
+**Enables**:
+
+- Single source of truth — `formula` and `composition` are authoritative;
+  derived quantities cannot drift from them.
+- Parity with the Rust crate's API surface.
+- Ergonomic access: `material.molar_mass` sits alongside `material.density`,
+  `material.formula`, `material.composition` as top-level attributes — no
+  `material.properties.chemical.molar_mass` indirection.
+- No TOML data migration, no loader changes, no inheritance interactions
+  (computed properties don't cascade from parent to child — they recompute
+  per-material).
+
+**Costs**:
+
+- No authored override path for isotopically enriched materials (D₂O, ²³⁵U,
+  etc.). These are real materials-science use cases but belong to a larger
+  "isotope support" story the library doesn't yet tell. Tracked separately
+  if/when needed.
+- Derived-property accessors are not introspected by `Material.info()` or
+  serialized in the same way as property-group fields.
+
+**Rules out**:
+
+- Storing molar mass as a stateful field (would invite drift).
+- Putting molar mass inside `MechanicalProperties` (taxonomically wrong —
+  mechanical is stress/strain/deformation; molar mass is chemistry).
+
+## Alternatives considered
+
+- **`MechanicalProperties.molar_mass`** — rejected: taxonomic mismatch and
+  invites drift from `formula`.
+- **New `ChemicalProperties` property group** — rejected *for now* as
+  premature: a property group with one member is over-engineered. Reconsider
+  under the upgrade trigger below.
+- **Free function in `enrichers.py`**, e.g. `compute_molar_mass(material)` —
+  rejected: poor ergonomics, breaks symmetry with `material.density` and
+  `material.composition` which are already top-level.
+
+## Upgrade trigger
+
+Introduce a `ChemicalProperties` property group (and move `molar_mass` into
+it) when **two or more** non-definitionally-derived chemistry properties
+need a home. Candidates: heat of formation, oxidation state, standard
+electrode potential, electronegativity, band gap, work function.
+
+When that happens, `Material.molar_mass` remains as a shortcut `@property`
+that reads from `properties.chemical.molar_mass` if set, falling back to
+computation from `composition`. This preserves the API for existing
+consumers.
+
+Also revisit this ADR if isotope support lands — that introduces an override
+use case (enriched fuels, D₂O) that needs authored storage.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,0 +1,56 @@
+# Architectural Decision Records
+
+This directory contains Architectural Decision Records (ADRs) for `mat`.
+
+An ADR captures a decision that shapes the architecture — what was decided,
+why, what was rejected, and what the consequences are. It exists so that a
+reader months later can reconstruct the reasoning and spot the trigger that
+would overturn it.
+
+We use a light MADR-ish format. Each ADR is one markdown file named
+`NNNN-short-dash-separated-title.md`, where `NNNN` is a zero-padded sequential
+number.
+
+## Statuses
+
+- **Proposed**: under discussion, not yet in effect
+- **Accepted**: in effect
+- **Deprecated**: no longer applies but kept for historical context
+- **Superseded by NNNN**: replaced by another ADR
+
+## Writing a new ADR
+
+1. Copy the template below into `NNNN-title.md`.
+2. Fill it in. Keep each section short — ADRs are not design docs.
+3. Open a PR. Discussion happens there, not in the file.
+4. Once merged, the ADR is Accepted.
+
+## Template
+
+```markdown
+# NNNN. Title
+
+- Status: Proposed | Accepted | Deprecated | Superseded by NNNN
+- Date: YYYY-MM-DD
+- Deciders: @handles
+
+## Context
+
+What is the forcing function? Who cares? What constraints apply?
+
+## Decision
+
+The decision itself, stated as a single sentence if possible.
+
+## Consequences
+
+What this enables, what it costs, what it rules out.
+
+## Alternatives considered
+
+Named alternatives with one-line rationale for rejection.
+
+## Upgrade trigger
+
+Under what future condition should this ADR be revisited or superseded?
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: Physics",
 ]
@@ -30,16 +31,20 @@ dependencies = ["pint>=0.20"]
 [project.optional-dependencies]
 periodictable = ["periodictable>=1.6.0"]
 matproj = ["pymatgen>=2024.0.0"]
-build123d = ["build123d>=0.7.0"]
+# build123d pulls cadquery-ocp and vtk, which only publish wheels for
+# cp311/cp312 as of 2026-04. The environment marker means `pip install
+# py-materials[build123d]` on Python 3.13+ is a no-op rather than a hard
+# wheel-resolution error — installers silently drop the dep. See #11.
+build123d = ["build123d>=0.7.0; python_version<'3.13'"]
 dev = [
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",
-    "build123d>=0.7.0",
+    "build123d>=0.7.0; python_version<'3.13'",
 ]
 all = [
     "periodictable>=1.6.0",
     "pymatgen>=2024.0.0",
-    "build123d>=0.7.0",
+    "build123d>=0.7.0; python_version<'3.13'",
 ]
 
 [project.urls]

--- a/src/pymat/core.py
+++ b/src/pymat/core.py
@@ -411,6 +411,41 @@ class _MaterialInternal:
             return 0.0
         return mech_density / 1000
 
+    @property
+    def molar_mass(self) -> Optional[float]:
+        """
+        Molar mass in g/mol, parsed from `formula`.
+
+        Only meaningful for materials with a well-defined chemical
+        formula (compounds, pure elements). Returns `None` for
+        alloys/mixtures without a formula, and for formulas containing
+        element symbols not in the local atomic-weight table. Derived
+        on every access — not stored, not authored in TOML. See
+        ADR-0001.
+
+        Note: this intentionally does not use `composition` because
+        alloys store composition as mass fractions, not atom counts,
+        and a single "molar mass" isn't well-defined for mixtures.
+        """
+        if not self.formula:
+            return None
+        from .elements import compute_molar_mass
+
+        try:
+            return compute_molar_mass(self.formula)
+        except ValueError:
+            return None
+
+    @property
+    def molar_mass_qty(self):
+        """Molar mass as a Pint Quantity in g/mol, or None."""
+        mass = self.molar_mass
+        if mass is None:
+            return None
+        from .units import ureg
+
+        return mass * ureg("g/mol")
+
     def mass_from_volume_mm3(self, volume_mm3: float) -> float:
         """Calculate mass in grams from volume in mm³."""
         return volume_mm3 * self.density_g_mm3

--- a/src/pymat/elements.py
+++ b/src/pymat/elements.py
@@ -1,0 +1,156 @@
+"""
+Atomic weights for chemical elements.
+
+Mirror of mat-rs/src/elements.rs to keep the Python and Rust APIs
+symmetric — Monte Carlo consumers that use both (`rs-materials` for
+transport, `pymat` for CAD) get the same numeric answers.
+
+Values are in g/mol, rounded to IUPAC's standard atomic weight (2021
+recommendations) at four significant figures. Exotic elements beyond
+uranium are not listed — add as needed.
+"""
+
+from __future__ import annotations
+
+# Standard atomic weights in g/mol. Single source of truth for
+# composition-derived molar mass calculations on `Material`.
+ATOMIC_WEIGHT: dict[str, float] = {
+    "H": 1.008,
+    "He": 4.003,
+    "Li": 6.941,
+    "Be": 9.012,
+    "B": 10.81,
+    "C": 12.01,
+    "N": 14.01,
+    "O": 16.00,
+    "F": 19.00,
+    "Ne": 20.18,
+    "Na": 22.99,
+    "Mg": 24.31,
+    "Al": 26.98,
+    "Si": 28.09,
+    "P": 30.97,
+    "S": 32.07,
+    "Cl": 35.45,
+    "Ar": 39.95,
+    "K": 39.10,
+    "Ca": 40.08,
+    "Sc": 44.96,
+    "Ti": 47.87,
+    "V": 50.94,
+    "Cr": 52.00,
+    "Mn": 54.94,
+    "Fe": 55.85,
+    "Co": 58.93,
+    "Ni": 58.69,
+    "Cu": 63.55,
+    "Zn": 65.38,
+    "Ga": 69.72,
+    "Ge": 72.63,
+    "As": 74.92,
+    "Se": 78.97,
+    "Br": 79.90,
+    "Kr": 83.80,
+    "Rb": 85.47,
+    "Sr": 87.62,
+    "Y": 88.91,
+    "Zr": 91.22,
+    "Nb": 92.91,
+    "Mo": 95.95,
+    "Tc": 98.0,
+    "Ru": 101.1,
+    "Rh": 102.9,
+    "Pd": 106.4,
+    "Ag": 107.9,
+    "Cd": 112.4,
+    "In": 114.8,
+    "Sn": 118.7,
+    "Sb": 121.8,
+    "Te": 127.6,
+    "I": 126.9,
+    "Xe": 131.3,
+    "Cs": 132.9,
+    "Ba": 137.3,
+    "La": 138.9,
+    "Ce": 140.1,
+    "Pr": 140.9,
+    "Nd": 144.2,
+    "Pm": 145.0,
+    "Sm": 150.4,
+    "Eu": 152.0,
+    "Gd": 157.3,
+    "Tb": 158.9,
+    "Dy": 162.5,
+    "Ho": 164.9,
+    "Er": 167.3,
+    "Tm": 168.9,
+    "Yb": 173.0,
+    "Lu": 175.0,
+    "Hf": 178.5,
+    "Ta": 180.9,
+    "W": 183.8,
+    "Re": 186.2,
+    "Os": 190.2,
+    "Ir": 192.2,
+    "Pt": 195.1,
+    "Au": 197.0,
+    "Hg": 200.6,
+    "Tl": 204.4,
+    "Pb": 207.2,
+    "Bi": 209.0,
+    "Po": 209.0,
+    "At": 210.0,
+    "Rn": 222.0,
+    "Fr": 223.0,
+    "Ra": 226.0,
+    "Ac": 227.0,
+    "Th": 232.0,
+    "Pa": 231.0,
+    "U": 238.0,
+}
+
+
+import re
+
+_FORMULA_TOKEN = re.compile(r"([A-Z][a-z]?)(\d+\.?\d*)?")
+
+
+def parse_formula(formula: str) -> dict[str, float]:
+    """
+    Parse a chemical formula into an element-count dict.
+
+    Supports fractional stoichiometry (`Lu1.8Y0.2SiO5`) and strips
+    dopant suffixes after `:` (`LYSO:Ce` → `LYSO`). Repeated elements
+    are summed. Returns an empty dict if the formula contains no
+    recognizable element tokens.
+
+    Raises `ValueError` if the formula contains an element symbol
+    that is not in `ATOMIC_WEIGHT`. This is strict on purpose:
+    callers that want graceful degradation should catch it.
+    """
+    clean = formula.split(":", 1)[0]
+    counts: dict[str, float] = {}
+    for sym, count_str in _FORMULA_TOKEN.findall(clean):
+        if not sym:
+            continue
+        if sym not in ATOMIC_WEIGHT:
+            raise ValueError(f"Unknown element symbol {sym!r} in formula {formula!r}")
+        count = float(count_str) if count_str else 1.0
+        counts[sym] = counts.get(sym, 0.0) + count
+    return counts
+
+
+def compute_molar_mass(formula: str) -> float:
+    """
+    Compute molar mass (g/mol) of a chemical formula.
+
+    For pure compounds with a well-defined formula unit. Not meaningful
+    for alloys/mixtures whose TOML `composition` is stored as mass
+    fractions — those have no single "molar mass". See ADR-0001.
+
+    Raises `ValueError` for unknown element symbols or empty formulas.
+    """
+    counts = parse_formula(formula)
+    if not counts:
+        raise ValueError(f"No recognizable elements in formula {formula!r}")
+    return sum(ATOMIC_WEIGHT[el] * count for el, count in counts.items())

--- a/src/pymat/elements.py
+++ b/src/pymat/elements.py
@@ -12,6 +12,8 @@ uranium are not listed — add as needed.
 
 from __future__ import annotations
 
+import re
+
 # Standard atomic weights in g/mol. Single source of truth for
 # composition-derived molar mass calculations on `Material`.
 ATOMIC_WEIGHT: dict[str, float] = {
@@ -109,8 +111,6 @@ ATOMIC_WEIGHT: dict[str, float] = {
     "U": 238.0,
 }
 
-
-import re
 
 _FORMULA_TOKEN = re.compile(r"([A-Z][a-z]?)(\d+\.?\d*)?")
 

--- a/src/pymat/enrichers.py
+++ b/src/pymat/enrichers.py
@@ -8,51 +8,71 @@ Currently supports:
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
     from .core import Material
 
+logger = logging.getLogger(__name__)
+
 
 def enrich_from_periodictable(material: Material) -> Material:
     """
-    Fill in missing material properties from periodictable library.
+    Fill in missing material properties from the `periodictable` library.
 
-    Uses chemical formula to look up elemental data and estimate:
-    - density (from empirical formula-based estimation)
-    - composition (atomic fractions)
-    - molecular weight
+    Uses the material's chemical formula to populate:
+
+    - `composition` — element → atom count, derived from the formula
+    - `density` — ONLY for pure elements. `periodictable` does not provide
+      compound densities (a compound's density depends on crystal packing
+      and cannot be derived from formula alone). For compounds, enrich
+      density via `enrich_from_matproj` instead.
+
+    Molar mass is NOT set here — it is available at any time via the
+    computed `Material.molar_mass` property. See ADR-0001.
 
     Args:
-        material: Material instance to enrich
+        material: Material instance to enrich.
 
     Returns:
-        The enriched material (modified in-place)
+        The enriched material (modified in-place).
 
     Example:
+        iron = Material("Iron", formula="Fe")
+        enrich_from_periodictable(iron)
+        print(iron.density)        # 7.874 (element lookup)
+        print(iron.molar_mass)     # 55.85 (computed from formula)
+
         lyso = Material("LYSO", formula="Lu1.8Y0.2SiO5")
         enrich_from_periodictable(lyso)
-        print(lyso.properties.mechanical.density)  # should be ~7.1
+        print(lyso.composition)    # {'Lu': 1.8, 'Y': 0.2, 'Si': 1, 'O': 5}
+        print(lyso.molar_mass)     # 440.87
+        print(lyso.density)        # None — use enrich_from_matproj for this
     """
     if not material.formula:
         return material
 
     try:
         import periodictable as pt
-    except ImportError:
-        raise ImportError("periodictable not installed. Install with: pip install periodictable")
+    except ImportError as e:
+        raise ImportError(
+            "periodictable not installed. Install with: pip install periodictable"
+        ) from e
 
     try:
         formula = pt.formula(material.formula)
     except Exception as e:
-        print(f"Warning: Could not parse formula '{material.formula}': {e}")
+        logger.warning("Could not parse formula %r: %s", material.formula, e)
         return material
 
-    # Set density if not already set and available
+    # Density: only pure elements have a meaningful density in periodictable.
+    # For compounds `formula.density` is None, so this is a no-op — do not
+    # fake compound density by averaging element densities (physically wrong).
     if not material.properties.mechanical.density and formula.density:
         material.properties.mechanical.density = formula.density
 
-    # Set composition if not already set
+    # Composition: element -> atom count (not mass fraction).
     if not material.composition and formula.atoms:
         material.composition = {str(el): count for el, count in formula.atoms.items()}
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -184,6 +184,49 @@ class TestFormulas:
         assert mat.composition == comp
 
 
+class TestMolarMass:
+    """`Material.molar_mass` — computed from formula. See ADR-0001."""
+
+    def test_pure_element(self):
+        fe = Material(name="Iron", formula="Fe")
+        assert fe.molar_mass == pytest.approx(55.85, abs=0.01)
+
+    def test_simple_compound(self):
+        al2o3 = Material(name="Alumina", formula="Al2O3")
+        assert al2o3.molar_mass == pytest.approx(101.96, abs=0.1)
+
+    def test_fractional_stoichiometry(self):
+        lyso = Material(name="LYSO", formula="Lu1.8Y0.2SiO5")
+        assert lyso.molar_mass == pytest.approx(440.87, abs=0.1)
+
+    def test_dopant_notation_stripped(self):
+        """`:Ce` dopant suffix is ignored for molar mass."""
+        doped = Material(name="LYSO:Ce", formula="Lu1.8Y0.2SiO5:Ce")
+        plain = Material(name="LYSO", formula="Lu1.8Y0.2SiO5")
+        assert doped.molar_mass == plain.molar_mass
+
+    def test_no_formula_returns_none(self):
+        mat = Material(name="Unknown Alloy")
+        assert mat.molar_mass is None
+
+    def test_unknown_element_returns_none(self):
+        """Gracefully degrades when formula references an element we
+        don't have in the local atomic-weight table."""
+        mat = Material(name="Junk", formula="Xx2")
+        assert mat.molar_mass is None
+
+    def test_molar_mass_qty_is_pint_quantity(self):
+        fe = Material(name="Iron", formula="Fe")
+        qty = fe.molar_mass_qty
+        assert qty is not None
+        # Unit-aware conversion works
+        assert qty.to("kg/mol").magnitude == pytest.approx(0.05585, abs=0.0001)
+
+    def test_molar_mass_qty_none_when_no_formula(self):
+        mat = Material(name="Unknown")
+        assert mat.molar_mass_qty is None
+
+
 class TestDensityCalculations:
     """Test density-related calculations."""
 

--- a/tests/test_enrichers.py
+++ b/tests/test_enrichers.py
@@ -13,43 +13,36 @@ from pymat.enrichers import enrich_all, enrich_from_periodictable
 class TestPeriodictableEnrichment:
     """Test enrichment from periodictable library."""
 
-    @pytest.mark.xfail(
-        reason=(
-            "periodictable only has density for pure elements, not compounds. "
-            "enrich_from_periodictable needs a density-from-composition "
-            "calculator before this test can pass. Tracked separately."
-        ),
-        strict=True,
-    )
-    def test_enrich_simple_formula(self):
-        """Test enriching material with simple formula."""
+    def test_enrich_simple_compound_extracts_composition(self):
+        """
+        Enriching a compound populates `composition` (element → atom
+        count) and leaves `density` unset. Density for compounds cannot
+        be derived from periodictable; use `enrich_from_matproj` for
+        that. See ADR-0001.
+        """
         mat = Material(name="Aluminum Oxide", formula="Al2O3")
-
-        # Initially no density
         assert mat.density is None or mat.density == 0
 
         enrich_from_periodictable(mat)
 
-        # After enrichment should have density
-        assert mat.density is not None
-        assert mat.density > 0
+        assert mat.composition == {"Al": 2, "O": 3}
+        # Molar mass is always derivable from the formula via the
+        # computed property — independent of enrichment.
+        assert mat.molar_mass is not None
+        assert abs(mat.molar_mass - 101.96) < 0.1  # Al2O3 = 2*26.98 + 3*16.00
+        # Density is NOT set for compounds.
+        assert mat.density is None or mat.density == 0
 
-    @pytest.mark.xfail(
-        reason=(
-            "periodictable only has density for pure elements, not compounds. Tracked separately."
-        ),
-        strict=True,
-    )
-    def test_enrich_complex_formula(self):
-        """Test enriching with complex formula."""
+    def test_enrich_complex_compound_extracts_composition(self):
+        """Same as above for a fractional-stoichiometry compound."""
         mat = Material(name="LYSO", formula="Lu1.8Y0.2SiO5")
 
         enrich_from_periodictable(mat)
 
-        # Should have set density
-        assert mat.density is not None
-        # LYSO should be around 7.1 g/cm³
-        assert 6.5 < mat.density < 7.5
+        assert mat.composition == {"Lu": 1.8, "Y": 0.2, "Si": 1, "O": 5}
+        assert mat.molar_mass is not None
+        assert 440 < mat.molar_mass < 441  # Lu1.8Y0.2SiO5 ≈ 440.87
+        assert mat.density is None or mat.density == 0
 
     def test_enrich_without_formula(self):
         """Test enrichment with no formula."""
@@ -89,21 +82,20 @@ class TestPeriodictableEnrichment:
 class TestEnrichAll:
     """Test enrich_all function."""
 
-    @pytest.mark.xfail(
-        reason=(
-            "periodictable only has density for pure elements, not compounds. Tracked separately."
-        ),
-        strict=True,
-    )
-    def test_enrich_all_with_periodictable(self):
-        """Test enriching all data sources."""
+    def test_enrich_all_with_periodictable_extracts_composition(self):
+        """
+        `enrich_all` with periodictable populates composition and
+        leaves compound density unset — same contract as
+        `enrich_from_periodictable` directly. See ADR-0001.
+        """
         mat = Material(name="Test", formula="SiO2")
 
         result = enrich_all(mat, use_periodictable=True)
 
         assert result is mat
-        # Should have enriched from periodictable
-        assert mat.density is not None
+        assert mat.composition == {"Si": 1, "O": 2}
+        assert mat.molar_mass is not None
+        assert abs(mat.molar_mass - 60.09) < 0.1  # SiO2 = 28.09 + 2*16.00
 
     def test_enrich_all_without_periodictable(self):
         """Test enriching without periodictable."""

--- a/uv.lock
+++ b/uv.lock
@@ -42,21 +42,21 @@ name = "build123d"
 version = "0.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anytree" },
-    { name = "cadquery-ocp" },
-    { name = "ezdxf" },
+    { name = "anytree", marker = "python_full_version < '3.14'" },
+    { name = "cadquery-ocp", marker = "python_full_version < '3.14'" },
+    { name = "ezdxf", marker = "python_full_version < '3.14'" },
     { name = "ipython", version = "9.10.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "ipython", version = "9.11.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "lib3mf" },
-    { name = "numpy" },
-    { name = "ocp-gordon" },
-    { name = "ocpsvg" },
-    { name = "scipy" },
-    { name = "svgpathtools" },
-    { name = "sympy" },
-    { name = "trianglesolver" },
-    { name = "typing-extensions" },
-    { name = "webcolors" },
+    { name = "ipython", version = "9.11.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "lib3mf", marker = "python_full_version < '3.14'" },
+    { name = "numpy", marker = "python_full_version < '3.14'" },
+    { name = "ocp-gordon", marker = "python_full_version < '3.14'" },
+    { name = "ocpsvg", marker = "python_full_version < '3.14'" },
+    { name = "scipy", marker = "python_full_version < '3.14'" },
+    { name = "svgpathtools", marker = "python_full_version < '3.14'" },
+    { name = "sympy", marker = "python_full_version < '3.14'" },
+    { name = "trianglesolver", marker = "python_full_version < '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
+    { name = "webcolors", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7e/00/b56ebe1d2a31611dbfcc315d22ebb5403eddc60027d5f82acd493ebb5ac1/build123d-0.10.0.tar.gz", hash = "sha256:73ded38ddca8ebb95e7dd078ac3d7aacc8ca42fce8f1d176f1040e35fba4f608", size = 20011921, upload-time = "2025-11-05T22:04:37.054Z" }
 wheels = [
@@ -68,7 +68,7 @@ name = "cadquery-ocp"
 version = "7.8.1.1.post1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "vtk" },
+    { name = "vtk", marker = "python_full_version < '3.14'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/00/6636c7527787aea18e4ebf37f11e022da77711068c3acdc4788ac5ac484e/cadquery_ocp-7.8.1.1.post1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b80b28a2b24bfe52ddcc7962429455a0f8457e33747a0e4e3d184134e286ea7b", size = 68131502, upload-time = "2025-01-29T14:33:41.462Z" },
@@ -402,10 +402,10 @@ name = "ezdxf"
 version = "1.4.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "fonttools" },
-    { name = "numpy" },
-    { name = "pyparsing" },
-    { name = "typing-extensions" },
+    { name = "fonttools", marker = "python_full_version < '3.14'" },
+    { name = "numpy", marker = "python_full_version < '3.14'" },
+    { name = "pyparsing", marker = "python_full_version < '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6d/ff/e2fea17633a4c04abdf260d53e0d67463b01e11d957b8faaf3b195666e10/ezdxf-1.4.3.tar.gz", hash = "sha256:403adf7ce305877f6c9f3c007fe2e5c5df504dfb797032122abedd7170176764", size = 1816226, upload-time = "2025-10-19T03:48:12.137Z" }
 wheels = [
@@ -558,22 +558,20 @@ name = "ipython"
 version = "9.11.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.14' and sys_platform != 'win32'",
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version >= '3.12'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.12'" },
-    { name = "jedi", marker = "python_full_version >= '3.12'" },
-    { name = "matplotlib-inline", marker = "python_full_version >= '3.12'" },
-    { name = "pexpect", marker = "python_full_version >= '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version >= '3.12'" },
-    { name = "pygments", marker = "python_full_version >= '3.12'" },
-    { name = "stack-data", marker = "python_full_version >= '3.12'" },
-    { name = "traitlets", marker = "python_full_version >= '3.12'" },
+    { name = "colorama", marker = "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "jedi", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "matplotlib-inline", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "pexpect", marker = "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "pygments", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "stack-data", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "traitlets", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/86/28/a4698eda5a8928a45d6b693578b135b753e14fa1c2b36ee9441e69a45576/ipython-9.11.0.tar.gz", hash = "sha256:2a94bc4406b22ecc7e4cb95b98450f3ea493a76bec8896cda11b78d7752a6667", size = 4427354, upload-time = "2026-03-05T08:57:30.549Z" }
 wheels = [
@@ -585,7 +583,7 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments" },
+    { name = "pygments", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
@@ -597,7 +595,7 @@ name = "jedi"
 version = "0.19.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "parso" },
+    { name = "parso", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/72/3a/79a912fbd4d8dd6fbb02bf69afd3bb72cf0c729bb3063c6f4498603db17a/jedi-0.19.2.tar.gz", hash = "sha256:4770dc3de41bde3966b02eb84fbcf557fb33cce26ad23da12c742fb50ecb11f0", size = 1231287, upload-time = "2024-11-11T01:41:42.873Z" }
 wheels = [
@@ -798,7 +796,7 @@ name = "matplotlib-inline"
 version = "0.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "traitlets" },
+    { name = "traitlets", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c7/74/97e72a36efd4ae2bccb3463284300f8953f199b5ffbc04cbbb0ec78f74b1/matplotlib_inline-0.2.1.tar.gz", hash = "sha256:e1ee949c340d771fc39e241ea75683deb94762c8fa5f2927ec57c83c4dffa9fe", size = 8110, upload-time = "2025-10-23T09:00:22.126Z" }
 wheels = [
@@ -929,9 +927,9 @@ name = "ocp-gordon"
 version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cadquery-ocp-proxy" },
-    { name = "numpy" },
-    { name = "scipy" },
+    { name = "cadquery-ocp-proxy", marker = "python_full_version < '3.14'" },
+    { name = "numpy", marker = "python_full_version < '3.14'" },
+    { name = "scipy", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/72/ed/3d8955df5d412bd6e711e7c0673d6420efe6ce3a106f0dbc50fc5cc82b3e/ocp_gordon-0.2.0.tar.gz", hash = "sha256:3ce1f1fb589e891534d0c1fd7553a518733336308837c4b5e5164d77df1cf5c9", size = 118840, upload-time = "2026-01-09T00:33:56.107Z" }
 wheels = [
@@ -943,8 +941,8 @@ name = "ocpsvg"
 version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cadquery-ocp" },
-    { name = "svgelements" },
+    { name = "cadquery-ocp", marker = "python_full_version < '3.14'" },
+    { name = "svgelements", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/af/e2/3ba2ad53395f91c72070cb3b8b033c5d9f9ba2ae6f61e869ef2a5f7f8ade/ocpsvg-0.5.0.tar.gz", hash = "sha256:5cd8dbec8bf590d373a82aaebeab241838185aab04ee2859f33b9d7956bbfba6", size = 54195, upload-time = "2025-02-21T15:54:12.333Z" }
 wheels = [
@@ -1123,7 +1121,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "sys_platform != 'win32'" },
+    { name = "ptyprocess", marker = "python_full_version < '3.14' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -1268,7 +1266,7 @@ name = "prompt-toolkit"
 version = "3.0.52"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "wcwidth" },
+    { name = "wcwidth", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
 wheels = [
@@ -1303,15 +1301,15 @@ dependencies = [
 
 [package.optional-dependencies]
 all = [
-    { name = "build123d" },
+    { name = "build123d", marker = "python_full_version < '3.13'" },
     { name = "periodictable" },
     { name = "pymatgen" },
 ]
 build123d = [
-    { name = "build123d" },
+    { name = "build123d", marker = "python_full_version < '3.13'" },
 ]
 dev = [
-    { name = "build123d" },
+    { name = "build123d", marker = "python_full_version < '3.13'" },
     { name = "pytest" },
     { name = "pytest-cov" },
 ]
@@ -1329,9 +1327,9 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "build123d", marker = "extra == 'all'", specifier = ">=0.7.0" },
-    { name = "build123d", marker = "extra == 'build123d'", specifier = ">=0.7.0" },
-    { name = "build123d", marker = "extra == 'dev'", specifier = ">=0.7.0" },
+    { name = "build123d", marker = "python_full_version < '3.13' and extra == 'all'", specifier = ">=0.7.0" },
+    { name = "build123d", marker = "python_full_version < '3.13' and extra == 'build123d'", specifier = ">=0.7.0" },
+    { name = "build123d", marker = "python_full_version < '3.13' and extra == 'dev'", specifier = ">=0.7.0" },
     { name = "periodictable", marker = "extra == 'all'", specifier = ">=1.6.0" },
     { name = "periodictable", marker = "extra == 'periodictable'", specifier = ">=1.6.0" },
     { name = "pint", specifier = ">=0.20" },
@@ -1634,9 +1632,9 @@ name = "stack-data"
 version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "asttokens" },
-    { name = "executing" },
-    { name = "pure-eval" },
+    { name = "asttokens", marker = "python_full_version < '3.14'" },
+    { name = "executing", marker = "python_full_version < '3.14'" },
+    { name = "pure-eval", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9", size = 44707, upload-time = "2023-09-30T13:58:05.479Z" }
 wheels = [
@@ -1657,9 +1655,9 @@ name = "svgpathtools"
 version = "1.7.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
-    { name = "scipy" },
-    { name = "svgwrite" },
+    { name = "numpy", marker = "python_full_version < '3.14'" },
+    { name = "scipy", marker = "python_full_version < '3.14'" },
+    { name = "svgwrite", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3e/a0/06163182bdb00300a23e51b433a6ca5c881761e7dfbef432b4da44e3a84a/svgpathtools-1.7.2.tar.gz", hash = "sha256:5974daba24825e22f284ea10aa980d7d6f77a1ca55d914d80283e3ea8a7ac450", size = 2136092, upload-time = "2025-11-30T19:15:03.446Z" }
 wheels = [
@@ -1821,7 +1819,7 @@ name = "vtk"
 version = "9.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "matplotlib" },
+    { name = "matplotlib", marker = "python_full_version < '3.14'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/58/08/94e2d38ae35ebb85cad96cb11738208307341cac8b16e162ed95ccb26860/vtk-9.3.1-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:55e2df9e6993b959b482b79a6d68b8d46397b479d69738d41b1501396fcad50c", size = 76687738, upload-time = "2024-06-29T03:14:54.449Z" },


### PR DESCRIPTION
## Summary

Second dev → main sync under the new rulesets. Catches \`main\` up with three merged PRs on \`dev\`.

**Rolls up:**
- **PR #14** — Fixes #9 (enricher compound density), #10 (pymarkdown MD031 crash), adds ADR infrastructure + ADR-0001
- **PR #15** — Fixes #11 (Python pin via matrix CI: 3.12+all-extras and 3.13+all-extras, env markers on build123d/dev/all extras)
- **PR #16** — Replaces broken \`git merge --no-ff\` trial merge in \`sync-main-to-dev.yml\` with \`git merge-tree --write-tree\` (false-positive (conflicts) on PR #13 root cause)

## Test plan

- [ ] Lint & Format, Tests (both matrix cells), Security Scan, Dependency Review, CodeQL Analysis (python), Rust (mat-rs) — all required checks green
- [ ] \`sync-main-to-dev\` fires on the merge push and opens a clean sync-back PR (no spurious \`(conflicts)\` title this time — that's the first live validation of the merge-tree fix from #16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)