### PR TITLE
chore: refresh vig-os scaffold pin drift (partial backport)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,11 +48,11 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@0d579ffd059c29b07949a3cce3983f0780820c98  # v4
+        uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13  # v4
         with:
           languages: ${{ matrix.language }}
 
       - name: Run CodeQL analysis
-        uses: github/codeql-action/analyze@0d579ffd059c29b07949a3cce3983f0780820c98  # v4
+        uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13  # v4
         with:
           category: '/language:${{ matrix.language }}'

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -44,7 +44,7 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF to GitHub Security
-        uses: github/codeql-action/upload-sarif@0d579ffd059c29b07949a3cce3983f0780820c98  # v4
+        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13  # v4
         with:
           sarif_file: results.sarif
           category: 'scorecard'

--- a/.github/workflows/sync-issues.yml
+++ b/.github/workflows/sync-issues.yml
@@ -52,7 +52,7 @@ jobs:
     steps:
       - name: Generate a token
         id: generate-token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf  # v2
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859  # v3
         with:
           app-id: ${{ secrets.COMMIT_APP_ID }}
           private-key: ${{ secrets.COMMIT_APP_PRIVATE_KEY }}
@@ -107,12 +107,13 @@ jobs:
       - name: Commit and push changes via API
         id: commit
         if: steps.sync.outputs.modified-files != ''
-        uses: vig-os/commit-action@c0024cbad0e501764127cccab732c6cd465b4646  # v0.1.5
+        uses: vig-os/commit-action@1bc004353d08d9332a0cb54920b148256220c8e0  # v0.2.0
         env:
           # Use App token so push can bypass branch protection when App is in bypass list
-          GH_TOKEN: ${{ steps.generate-token.outputs.token || github.token }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           TARGET_BRANCH: refs/heads/${{ github.event.inputs.target-branch || 'dev' }}
+          MAX_ATTEMPTS: "3"
           COMMIT_MESSAGE: "${{ github.event.inputs.commit-msg || 'chore: sync issues and PRs' }}"
           FILE_PATHS: ${{ steps.sync.outputs.modified-files }}
 


### PR DESCRIPTION
## Summary

Partial backport of pin bumps from \`vig-os/devcontainer\` upstream. Only the items that don't require infrastructure we don't have locally (containers, \`resolve-image\` action, \`retry\` CLI).

Tackles item (3) from the session task list — "broader vig-os devcontainer template resync".

## What changed

| File | Change | Age behind upstream |
|---|---|---|
| \`codeql.yml\` | \`github/codeql-action\` SHA \`0d579ffd\` → \`c10b8064\` (both v4) | 22 days |
| \`scorecard.yml\` | same \`codeql-action/upload-sarif\` SHA bump | 22 days |
| \`sync-issues.yml\` | \`create-github-app-token\` v2→v3, \`commit-action\` v0.1.5→v0.2.0, \`MAX_ATTEMPTS: "3"\` env, drop dead \`github.token\` fallback | multiple weeks |

## What was intentionally NOT backported

**Container-based execution** — upstream now runs \`ci.yml\`, \`sync-issues.yml\`, and \`sync-main-to-dev.yml\` inside \`ghcr.io/vig-os/devcontainer\` via a new \`resolve-image\` action. Running those in containers requires shipping that action locally, parsing \`.vig-os\` for the image tag, and accepting the container startup cost on every CI run. Host-runner execution is fine for our needs and keeps the CI setup standard.

**\`retry --retries 3\` wrappers** — the \`retry\` CLI is baked into the devcontainer image. Not on bare ubuntu-22.04 runners. Flaky-API retries would need to be re-implemented in shell for our workflows. Low-value tradeoff given we haven't hit flakes.

**\`ci.yml\` full resync** — upstream's current \`ci.yml\` is a container shell. A straight replace would **delete** our:
- Python test matrix (py3.12+all, py3.13+all — the #11 fix)
- Bandit/Safety security scan job
- Dependency Review job
- Rust (mat-rs) PR gate
- The Tests roll-up pattern that keeps the required-check context stable

Our local \`ci.yml\` is strictly more capable for this repo. Intentional divergence, documented here.

## Audit provenance

Drift audit done via agent scan of \`vig-os/devcontainer/assets/workspace/\` vs local:

- **Both drifted** (don't straight-sync): \`ci.yml\`, \`sync-issues.yml\`, \`sync-main-to-dev.yml\`
- **Upstream-only** (safe to sync): \`codeql.yml\`, \`scorecard.yml\`
- **Local-only** (keep): \`ci-container.yml\`, \`setup-env/action.yml\`, release workflows
- **Identical**: \`.pre-commit-config.yaml\`, \`.pymarkdown\`, \`.yamllint\`, \`justfile\`, \`justfile.local\`

## Test plan

- [ ] CI green on all required checks
- [ ] \`sync-issues.yml\` still runs cleanly (validated separately on the next scheduled or manual trigger)
- [ ] No regression in CodeQL / Scorecard runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)