### PR TITLE
release: 3.2.1 — Vis adapter-method sugar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,10 @@ sites keep working identically.
   serialized without an owning `Material`. `name=` kwarg populates the glTF /
   MTLX name field when `obj` is a plain Vis.
 * **Test pins** (15 new):
-  - `TestAdapterPolymorphism` — `to_*(m) == to_*(m.vis)`.
-  - `TestVisAdapterMethods` — `m.vis.to_*() == to_*(m)`.
-  - `TestAdapterOnDetachedVis` — full adapter path on `Vis()` with no Material.
-  - Duck-typing invariant (`Vis` has no `.vis` attribute), keyword-only `name=`
+  * `TestAdapterPolymorphism` — `to_*(m) == to_*(m.vis)`.
+  * `TestVisAdapterMethods` — `m.vis.to_*() == to_*(m)`.
+  * `TestAdapterOnDetachedVis` — full adapter path on `Vis()` with no Material.
+  * Duck-typing invariant (`Vis` has no `.vis` attribute), keyword-only `name=`
     signature, and method-surface presence each dedicated-tested.
 * **build123d glTF behaviour pinned** — `TestGltfMaterialPassthrough` documents
   the real state today: `apply_to()` preserves only `baseColorFactor`; direct

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,48 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.1] - 2026-04-19
+
+Discoverability sugar for the output adapters — motivated by the
+[build123d#1270](https://github.com/gumyr/build123d/pull/1270) Materials-class
+integration. Zero breaking change; existing `pymat.vis.to_gltf(material)` call
+sites keep working identically.
+
+### Added
+
+* **`Vis.to_threejs()` / `Vis.to_gltf(*, name=None)` / `Vis.export_mtlx(out, *, name=None)`** —
+  method-form sugar on `Vis`. `m.vis.<TAB>` now surfaces the three handoff
+  formats. Thin delegates to the module-level adapters; same output byte-for-byte.
+  ([#78](https://github.com/MorePET/mat/issues/78))
+* **Adapters accept `Material` or `Vis`** — `to_gltf(obj)`, `to_threejs(obj)`,
+  `export_mtlx(obj, out)` duck-type on `.vis`, so a detached `Vis()` can be
+  serialized without an owning `Material`. `name=` kwarg populates the glTF /
+  MTLX name field when `obj` is a plain Vis.
+* **Test pins** (15 new):
+  - `TestAdapterPolymorphism` — `to_*(m) == to_*(m.vis)`.
+  - `TestVisAdapterMethods` — `m.vis.to_*() == to_*(m)`.
+  - `TestAdapterOnDetachedVis` — full adapter path on `Vis()` with no Material.
+  - Duck-typing invariant (`Vis` has no `.vis` attribute), keyword-only `name=`
+    signature, and method-surface presence each dedicated-tested.
+* **build123d glTF behaviour pinned** — `TestGltfMaterialPassthrough` documents
+  the real state today: `apply_to()` preserves only `baseColorFactor`; direct
+  `shape.material = m` reaches no glTF field at all. The tests fail the moment
+  build123d#1270 lands and changes either behavior — the signal to update docs.
+* **e2e test for `m.vis.mtlx.xml()`** — pins the 0.5 method shape against the
+  live mat-vis CDN (skips on outage).
+
+### Changed
+
+* `pymat.vis.adapters` docstring and the `test_vis.py` module-shape test both
+  reflect the polymorphic first-arg rename (`material` → `obj`, still
+  positional-compatible).
+
+### Architectural note
+
+The adapter asymmetry is intentional: module-level functions for `Material → format` transforms (open/closed, easy to add new formats without touching Material/Vis), method form for operations *on* a concrete object (`MtlxSource.xml()` etc.). The new `Vis.to_*` sugar is discoverability-only — see
+[mat-vis#93](https://github.com/MorePET/mat-vis/issues/93) for the architecturally-cleaner
+endgame where the payload object moves into `mat-vis-client`.
+
 ## [3.2.0] - 2026-04-19
 
 Adopts `mat-vis-client` 0.5.0 (closes [#73](https://github.com/MorePET/mat/issues/73); upstream: [mat-vis#85](https://github.com/MorePET/mat-vis/issues/85)). Also folds in the visual-regression pixel-diff framework ([#41](https://github.com/MorePET/mat/issues/41)) and infrastructure hygiene.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "py-materials"
-version = "3.2.0"
+version = "3.2.1"
 description = "Hierarchical material library for CAD applications with build123d integration"
 readme = "README.md"
 license = "MIT"

--- a/src/pymat/__init__.py
+++ b/src/pymat/__init__.py
@@ -56,7 +56,7 @@ from .properties import (
 )
 from .units import ureg
 
-__version__ = "3.2.0"  # x-release-please-version
+__version__ = "3.2.1"  # x-release-please-version
 __all__ = [
     "Material",
     "AllProperties",

--- a/uv.lock
+++ b/uv.lock
@@ -1311,7 +1311,7 @@ wheels = [
 
 [[package]]
 name = "py-materials"
-version = "3.2.0"
+version = "3.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "mat-vis-client" },


### PR DESCRIPTION
## Summary

Release cut for the `Vis.to_gltf()` / `.to_threejs()` / `.export_mtlx()` method sugar landed in #79 (closes #78).

Drop-in: every existing `pymat.vis.to_gltf(material)` call site keeps working. The new method form is additive — discoverability on `m.vis.<TAB>`, same output.

## Test plan

- [x] Full suite green locally — `299 passed, 18 skipped`.
- [x] Clean bump: `pyproject.toml`, `src/pymat/__init__.py`, CHANGELOG.