### PR TITLE
fix(pymat-mcp): list_categories cold-start (0.1.1)

### DIFF
--- a/clients/python/pymat-mcp/pyproject.toml
+++ b/clients/python/pymat-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pymat-mcp"
-version = "0.1.0"
+version = "0.1.1"
 description = "MCP server exposing py-materials curated material properties to AI agents"
 readme = "README.md"
 license = "MIT"

--- a/clients/python/pymat-mcp/src/pymat_mcp/tools.py
+++ b/clients/python/pymat-mcp/src/pymat_mcp/tools.py
@@ -215,15 +215,24 @@ def list_categories() -> dict[str, Any]:
     other material descends from one of these via ``parent``. Useful
     as a discovery starting point.
 
-    Implementation: force-load every category group, then walk the
-    registry for materials whose ``parent`` is None.
+    Implementation note: ``pymat`` lazy-loads category groups on first
+    attribute access. ``_CATEGORY_BASES`` maps group-names (``metals``,
+    ``scintillators``, …) to lists of *base material names*
+    (``aluminum``, ``stainless``, …). Group-names are NOT valid
+    pymat attributes; the base names are. We trigger the loader by
+    touching one base name per group, which loads the entire group
+    (and registers all parents under it).
     """
     import pymat
 
-    # Force-load all category groups so the registry is populated.
-    for group in pymat._CATEGORY_BASES:
+    for group, bases in pymat._CATEGORY_BASES.items():
+        if not bases:
+            continue
         try:
-            getattr(pymat, group)  # triggers __getattr__ → load
+            # Touching the first base name in each group fires the
+            # lazy loader for the whole group. ``pymat.aluminum``
+            # → loads metals; ``pymat.lyso`` → loads scintillators.
+            getattr(pymat, bases[0])
         except Exception:
             # Optional categories that fail to load shouldn't poison
             # the result; skip them.

--- a/clients/python/pymat-mcp/tests/test_tools.py
+++ b/clients/python/pymat-mcp/tests/test_tools.py
@@ -170,8 +170,7 @@ class TestListCategories:
         )
         out = json.loads(result.stdout)
         assert out["categories"], (
-            "list_categories returned [] in a cold-start process — "
-            "lazy-load trigger is broken"
+            "list_categories returned [] in a cold-start process — lazy-load trigger is broken"
         )
         # And the known top-level categories should appear
         assert "stainless" in out["categories"]

--- a/clients/python/pymat-mcp/tests/test_tools.py
+++ b/clients/python/pymat-mcp/tests/test_tools.py
@@ -144,6 +144,39 @@ class TestListCategories:
             f"expected at least one of stainless/aluminum, got: {cats}"
         )
 
+    def test_works_as_first_tool_call(self, tmp_path):
+        """``list_categories`` must work in a fresh process where
+        nothing has primed the registry yet. Earlier tests in the
+        same session would silently mask a broken lazy-load by
+        leaving categories already-loaded. Spawn a clean subprocess
+        to pin the cold-start contract.
+        """
+        import json
+        import subprocess
+        import sys
+
+        script = tmp_path / "probe.py"
+        script.write_text(
+            "import json\n"
+            "from pymat_mcp import tools\n"
+            "out = tools.list_categories()\n"
+            "print(json.dumps(out))\n"
+        )
+        result = subprocess.run(
+            [sys.executable, str(script)],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        out = json.loads(result.stdout)
+        assert out["categories"], (
+            "list_categories returned [] in a cold-start process — "
+            "lazy-load trigger is broken"
+        )
+        # And the known top-level categories should appear
+        assert "stainless" in out["categories"]
+        assert "aluminum" in out["categories"]
+
 
 # ── list_grades ───────────────────────────────────────────────
 


### PR DESCRIPTION
**0.1.0 went live 30 seconds before I caught this in a fresh-uvx smoke.**

\`tools.list_categories()\` returned \`[]\` when called as the FIRST tool in a fresh process. The whole-test-session-passes was masking it: earlier tests had already populated the registry, so by the time \`TestListCategories\` ran the data was there.

## Root cause

I iterated \`pymat._CATEGORY_BASES.keys()\` (group names: \`metals\`, \`scintillators\`, …) and called \`getattr(pymat, group)\` — but **group names are not valid pymat attributes**. They're internal grouping labels. The lazy loader is keyed off *base names* (\`aluminum\`, \`stainless\`, …) which are the values, not the keys. Every \`getattr\` raised KeyError; my \`except: continue\` silently swallowed every one. No categories ever loaded.

## Fix

Iterate \`_CATEGORY_BASES.values()\` and touch the first base name in each group. \`pymat.aluminum\` triggers the metals loader, \`pymat.lyso\` triggers scintillators, etc.

## New test

Spawned-subprocess cold-start test pins the contract: a fresh Python interpreter with only \`from pymat_mcp import tools; tools.list_categories()\` must return non-empty. Catches the next time someone refactors the lazy-load trigger.

## Test plan

- [x] 52 tests pass (added 1, was 51)
- [x] Subprocess cold-start test exercises the failure mode 0.1.0 had
- [x] All existing in-session tests still pass