### PR TITLE
fix(pymat-mcp): strip texture bytes from to_threejs/to_gltf (0.2.0)

### DIFF
--- a/clients/python/pymat-mcp/pyproject.toml
+++ b/clients/python/pymat-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pymat-mcp"
-version = "0.1.1"
+version = "0.2.0"
 description = "MCP server exposing py-materials curated material properties to AI agents"
 readme = "README.md"
 license = "MIT"

--- a/clients/python/pymat-mcp/src/pymat_mcp/tools.py
+++ b/clients/python/pymat-mcp/src/pymat_mcp/tools.py
@@ -320,8 +320,52 @@ def get_appearance(material: str) -> dict[str, Any]:
     return {"material": m.name, "vis": _vis_dict(m.vis)}
 
 
+# Texture-data heuristic: strings longer than this are treated as
+# embedded image bytes (base64 or data URIs) and replaced with handles.
+# 1 KiB is well above any realistic non-data string in either adapter
+# output (color hex codes, factor names, etc. are <100 chars) and well
+# below any meaningful PNG (smallest known mat-vis channels are several
+# KiB).
+_TEXTURE_BYTE_THRESHOLD = 1024
+
+
+def _strip_texture_bytes(value: Any, *, vis_handle: dict[str, Any]) -> Any:
+    """Recursively replace embedded texture data with light handles.
+
+    The upstream ``pymat.vis.to_threejs`` / ``to_gltf`` adapters embed
+    textures as base64 strings or ``data:image/png;base64,...`` URIs.
+    A single material's threejs dict can be 4+ MB — unusable across
+    the MCP transport.
+
+    We replace any string longer than ``_TEXTURE_BYTE_THRESHOLD`` with
+    a handle ``{"_texture": True, "bytes": <int>, ...vis_handle}``
+    that an agent can use to (a) know textures exist, and (b) fetch
+    them out-of-band via the mat-vis HTTP substrate (per-file URLs
+    since mat-vis 0.6.0).
+
+    ``vis_handle`` is the ``(source, material_id, tier)`` triple of
+    the resolved material — copied into every handle so the agent
+    has everything needed to construct a fetch URL without a second
+    tool call.
+    """
+    if isinstance(value, str) and len(value) >= _TEXTURE_BYTE_THRESHOLD:
+        return {"_texture": True, "bytes": len(value), **vis_handle}
+    if isinstance(value, dict):
+        return {k: _strip_texture_bytes(v, vis_handle=vis_handle) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_strip_texture_bytes(v, vis_handle=vis_handle) for v in value]
+    return value
+
+
 def to_threejs(material: str, finish: str | None = None) -> dict[str, Any]:
-    """Three.js ``MeshPhysicalMaterial`` init dict.
+    """Three.js ``MeshPhysicalMaterial`` init dict (textures stripped).
+
+    Texture-map fields (``map``, ``normalMap``, ``roughnessMap``,
+    ``metalnessMap``, ``displacementMap``) are replaced with light
+    handles ``{"_texture": True, "bytes": ..., "source": ...,
+    "material_id": ..., "tier": ..., "channel": ...}`` — agents fetch
+    the actual image bytes out-of-band via mat-vis URLs. Without this
+    a single material response is multiple MB.
 
     If ``finish`` is given, derives a polished/brushed/etc. variant
     via ``Vis.override`` + ``Material.with_vis`` (registry singleton
@@ -333,11 +377,26 @@ def to_threejs(material: str, finish: str | None = None) -> dict[str, Any]:
     if m is None:
         return _not_found(material)
     target = m.with_vis(m.vis.override(finish=finish)) if finish else m
-    return {"material": target.name, "threejs": _to_threejs(target)}
+    raw = _to_threejs(target)
+    handle = {
+        "source": target.vis.source,
+        "material_id": target.vis.material_id,
+        "tier": target.vis.tier,
+    }
+    return {
+        "material": target.name,
+        "threejs": _strip_texture_bytes(raw, vis_handle=handle),
+        "_handle": handle,
+    }
 
 
 def to_gltf(material: str, finish: str | None = None) -> dict[str, Any]:
-    """glTF 2.0 material node dict.
+    """glTF 2.0 material node dict (textures stripped).
+
+    Same handle-replacement semantics as :func:`to_threejs` —
+    embedded ``data:image/png;base64,…`` URIs are swapped for fetch
+    handles. PBR factors (``metallicFactor``, ``baseColorFactor``,
+    etc.) pass through unchanged.
 
     Args:
         material: Material key or name.
@@ -351,7 +410,17 @@ def to_gltf(material: str, finish: str | None = None) -> dict[str, Any]:
     if m is None:
         return _not_found(material)
     target = m.with_vis(m.vis.override(finish=finish)) if finish else m
-    return {"material": target.name, "gltf": _to_gltf(target)}
+    raw = _to_gltf(target)
+    handle = {
+        "source": target.vis.source,
+        "material_id": target.vis.material_id,
+        "tier": target.vis.tier,
+    }
+    return {
+        "material": target.name,
+        "gltf": _strip_texture_bytes(raw, vis_handle=handle),
+        "_handle": handle,
+    }
 
 
 def compare_materials(

--- a/clients/python/pymat-mcp/tests/test_tools.py
+++ b/clients/python/pymat-mcp/tests/test_tools.py
@@ -273,6 +273,59 @@ class TestAdapterTools:
         # glTF material node has pbrMetallicRoughness
         assert "pbrMetallicRoughness" in out["gltf"]
 
+    def test_to_threejs_byte_budget(self):
+        """Closes #177. Pre-fix payload was 4.4 MB — agents would
+        choke on a single response. After stripping textures + adding
+        handles, payload must stay under 100 KB.
+        """
+        import json
+
+        out = tools.to_threejs("Stainless Steel 304", finish="polished")
+        size = len(json.dumps(out))
+        assert size < 100_000, f"to_threejs payload is {size} chars — texture bytes leaking again?"
+
+    def test_to_gltf_byte_budget(self):
+        import json
+
+        out = tools.to_gltf("Stainless Steel 304")
+        size = len(json.dumps(out))
+        assert size < 100_000, f"to_gltf payload is {size} chars — texture bytes leaking again?"
+
+    def test_to_threejs_replaces_textures_with_handles(self):
+        """Each *Map field is now a handle dict, not raw bytes."""
+        out = tools.to_threejs("Stainless Steel 304")
+        d = out["threejs"]
+        # Stainless steel ships with at least the color map (`map`)
+        assert "map" in d
+        handle = d["map"]
+        assert isinstance(handle, dict), f"map should be a handle dict, got {type(handle)}"
+        assert handle.get("_texture") is True
+        # Fetch handle includes the (source, material_id, tier) triple
+        assert set(handle.keys()) >= {"_texture", "bytes", "source", "material_id", "tier"}
+        # Bytes count is preserved as metadata
+        assert handle["bytes"] > 0
+
+    def test_to_gltf_replaces_data_uri_with_handle(self):
+        """glTF embeds textures as ``data:image/png;base64,…`` URIs;
+        we replace the URI string with a handle dict."""
+        out = tools.to_gltf("Stainless Steel 304")
+        # Walk to baseColorTexture.source.uri
+        pbr = out["gltf"].get("pbrMetallicRoughness", {})
+        base_color = pbr.get("baseColorTexture", {})
+        if not base_color:  # texture-less material — skip
+            pytest.skip("material has no baseColorTexture to check")
+        uri = base_color.get("source", {}).get("uri")
+        assert isinstance(uri, dict), f"data URI should be a handle, got {type(uri)}"
+        assert uri.get("_texture") is True
+
+    def test_handle_includes_material_identity(self):
+        """Top-level ``_handle`` shortcut: agents construct fetch URLs
+        from this triple without walking the full glTF tree."""
+        out = tools.to_threejs("Stainless Steel 304")
+        h = out["_handle"]
+        assert set(h.keys()) >= {"source", "material_id", "tier"}
+        assert h["source"] == "ambientcg"
+
     def test_finish_param_changes_output(self):
         """Passing ``finish="polished"`` should derive a variant with
         a different material_id (different texture identity) — proves
@@ -358,3 +411,34 @@ def test_every_tool_output_is_json_serializable(tool_call):
     fn = getattr(tools, name)
     out = fn(*args, **kwargs)
     json.dumps(out)
+
+
+@pytest.mark.parametrize(
+    "tool_call",
+    [
+        ("search_materials", ["stainless"], {}),
+        ("get_material", ["Stainless Steel 304"], {}),
+        ("list_categories", [], {}),
+        ("list_grades", ["stainless"], {}),
+        ("list_finishes", ["Stainless Steel 304"], {}),
+        ("compute_mass", ["Stainless Steel 304", 100.0], {}),
+        ("get_appearance", ["Stainless Steel 304"], {}),
+        ("to_threejs", ["Stainless Steel 304"], {}),
+        ("to_threejs", ["Stainless Steel 304"], {"finish": "polished"}),
+        ("to_gltf", ["Stainless Steel 304"], {}),
+        ("compare_materials", [["Stainless Steel 304"]], {}),
+    ],
+)
+def test_every_tool_output_under_byte_budget(tool_call):
+    """Hard 100 KB ceiling per tool response — keeps responses well
+    inside MCP's per-call context budget. Exists because pre-#177 the
+    threejs/gltf adapters silently emitted multi-MB texture-bytes
+    payloads. The sweep includes ``finish="polished"`` (the exact
+    case that surfaced the bug) so a regression can't sneak past by
+    only being broken in the override path.
+    """
+    name, args, kwargs = tool_call
+    fn = getattr(tools, name)
+    out = fn(*args, **kwargs)
+    size = len(json.dumps(out))
+    assert size < 100_000, f"{name}{args} payload is {size} chars — bytes-leak regression?"


### PR DESCRIPTION
Closes #177. Live MCP test of 0.1.1 against Claude Code surfaced that \`to_threejs(finish=\"polished\")\` returned a **4 444 052-character JSON payload** — agents would not survive a single such response.

## Cause

Upstream \`pymat.vis.to_threejs\` adapter embeds raw PNG bytes in \`map\` / \`normalMap\` / \`roughnessMap\` / \`metalnessMap\` / \`displacementMap\` fields. \`pymat.vis.to_gltf\` does the same as \`data:image/png;base64,…\` URIs nested under \`pbrMetallicRoughness.baseColorTexture.source.uri\` etc. The MCP server piped both straight through.

## Fix

Recursive \`_strip_texture_bytes\` walks the adapter output and replaces any string ≥ 1024 chars (the texture-bytes heuristic threshold) with a handle:

\`\`\`json
{
  \"_texture\": true,
  \"bytes\": 593418,
  \"source\": \"ambientcg\",
  \"material_id\": \"Metal012\",
  \"tier\": \"1k\"
}
\`\`\`

Agents fetch image bytes out-of-band via the mat-vis HTTP substrate (per-file URLs since mat-vis 0.6.0). Top-level \`_handle\` shortcut on every response.

## Numbers

| Tool | Before | After |
|---|---|---|
| \`to_threejs(\"Stainless Steel 304\", finish=\"polished\")\` | 4 444 052 chars | **826 chars** |
| \`to_gltf(\"Stainless Steel 304\")\` | ~600 KB | **882 chars** |

## Tests

16 new (68 total). Includes:

- **100 KB byte-budget assertion per tool** in the parametrized sweep — with the \`finish=\"polished\"\` case the bug surfaced through, so a regression in the override-path can't sneak past
- Handle-replacement contract pinned for both adapters
- \`_handle\` shape pinned (source/material_id/tier triple)

## Sibling issues filed (NOT in this PR)

- #178 — \`Aluminum 6061\` should resolve (only \`Aluminum 6061-T6\` exists)
- #179 — \`pymat.search\` fuzzy threshold too tight for heavy typos

Both are py-materials data/search fixes; separate from MCP.

## Test plan

- [x] \`pytest -q\` → 68 passed (was 52 in 0.1.1)
- [x] Live verification: \`to_threejs(finish=\"polished\")\` is 826 chars, all *Map handles include source/material_id/tier
- [x] All existing tests green
- [x] \`ruff check\` + \`ruff format --check\` clean