### PR TITLE
feat(schema): add _sources provenance table (#150)

### DIFF
--- a/docs/decisions/0003-schema-foundation.md
+++ b/docs/decisions/0003-schema-foundation.md
@@ -1,0 +1,152 @@
+# 0003 — Schema foundation: provenance, uncertainty, and T-curves
+
+**Status:** Accepted (consolidated from 3 parallel reviews 2026-05-05)
+**Issues:** [#150](https://github.com/MorePET/mat/issues/150) (`_sources`), [#149](https://github.com/MorePET/mat/issues/149) (`_stddev`), [#148](https://github.com/MorePET/mat/issues/148) (`_curve`), [#174](https://github.com/MorePET/mat/issues/174) (data-policy + license CI)
+
+## Context
+
+The Properties Schema Expansion milestone proposes three additions that gate every downstream data-source pull and material entry: provenance metadata, per-property uncertainty, and temperature-dependent curves. Three independent reviews (architecture, backwards-compat, test/CI) converged on the overall shape but disagreed on three specific points. This ADR records the resolved design.
+
+## Decisions
+
+### 1. `_sources` is a sidecar `dict[str, Source]` on `Material`
+
+Provenance is metadata *about* a value, not part of it. Inlining it (e.g. making `density` a wrapper with `.value` and `.source`) breaks ~50 call sites that do arithmetic on `mat.density` — including `core.py:403` (`density / 1000`), `clients/python/pymat-mcp/src/pymat_mcp/tools.py:300` (`compute_mass`), and the `*_qty` Pint properties. Not worth the refactor.
+
+```python
+@dataclass(frozen=True)
+class Source:
+    citation: str            # BibTeX key
+    kind: str                # "doi" | "qid" | "handbook" | "vendor" | "measured"
+    ref: str                 # "10.x/y" | "Q123" | "ASM Handbook v2 p.62" | URL
+    license: str             # CC0 | PD-USGov | CC-BY-4.0 | CC-BY-SA-4.0 | proprietary-reference-only | unknown
+    note: Optional[str] = None
+```
+
+`Material._sources: dict[str, Source]` keyed by dotted property path. **Access API:**
+
+```python
+mat.source_of("mechanical.density")   # → Source | None  (resolves _default fallback)
+mat.cite("mechanical.density")        # → BibTeX string
+mat.cite("density")                   # → same; short-alias lookup table
+mat.cite()                            # → all entries used by this material, dedup'd
+```
+
+**Inheritance:** child material's `_sources` overlays parent's (`parent._sources | self._sources`), parsed at load time. `_default` is a per-material fallback when no per-property entry exists.
+
+`mat.density` stays a `float`. The `mat.density.source` accessor proposed in #150 is **rejected** — it is a direct break of the established API.
+
+### 2. `_curve` lives inside its property group; access via `mat.at(T=...)` view AND existing `_at(T)` methods
+
+```toml
+[aluminum.al6061.thermal]
+thermal_conductivity_value = 167
+thermal_conductivity_unit = "W/(m*K)"
+thermal_conductivity_curve = { temps_K = [77, 200, 293, 400, 500], values = [105, 150, 167, 180, 192] }
+```
+
+**Storage:** new optional sibling field `<prop>_curve: Optional[TempCurve] = None` on the relevant dataclass. Scalar field stays a scalar — never promote it to a callable (would break `properties.py:148` `if self.thermal_conductivity is None`, all `*_qty` math, and JSON serialization in the MCP tools).
+
+**Access API (additive, both supported):**
+
+```python
+mat.properties.thermal.thermal_conductivity_at(233 * ureg.K)   # existing — unchanged
+mat.at(T=233 * ureg.K).thermal.thermal_conductivity_qty        # new view, dispatches to interp
+```
+
+**Precedence inside `_at(T)` methods:** curve > legacy `_ref_temp + _coeff` linear > scalar. The legacy `thermal_conductivity_ref_temp` / `_coeff` stays in-place; under the hood the loader rewrites them into a synthetic 2-point `_curve` so `properties.py` has one interpolation path.
+
+**Edge cases (PIN these):**
+
+| Case | Behavior |
+|---|---|
+| T at exact knot | Return knot value |
+| T between knots | Linear interp via `numpy.interp` |
+| T below min knot | **Clamp** to min knot value, log debug |
+| T above max knot | **Clamp** to max knot value, log debug |
+| Curve with 1 point | Return that constant for any T |
+| Curve absent | Fall back to scalar |
+| Unsorted / mismatched-length arrays | **Raise at load time** |
+
+Applies to: thermal_conductivity, specific_heat, thermal_expansion, youngs_modulus, yield_strength, resistivity, refractive_index, light_yield, decay_time.
+
+### 3. `_stddev`: standardize on existing in-value ufloat form; loader sugar accepts sibling syntax
+
+`loader.py:_parse_value` already supports `{nominal, stddev}` and `{min, max}` dicts via `uncertainties.ufloat`. Adding sibling fields (`density_stddev: Optional[float]`) means parallel mechanisms, dataclass bloat across every property, and silently-dropped-key risk.
+
+**Canonical form:**
+
+```toml
+light_yield = { nominal = 33000, stddev = 1500 }
+light_yield_unit = "ph/MeV"
+```
+
+**Sibling sugar (loader rewrites at parse time):**
+
+```toml
+light_yield_value = 33000
+light_yield_stddev = 1500     # → folded into ufloat by loader; not a dataclass field
+light_yield_unit = "ph/MeV"
+```
+
+**Double-specification (in-value `stddev` AND sibling `_stddev`) is a hard error** — `ValueError` at load time, not silent precedence.
+
+⚠️ This is a deviation from the literal #149 issue text ("Add `<prop>_stddev` siblings to dataclasses"). The reviewers all converged on this — sibling fields are friendlier-looking but introduce parallel-mechanism risk and the silent-drop bug class. Issue is closed when #149 PR merges with a comment linking this ADR.
+
+### 4. License gate (#174): standalone script + ratchet file, NOT pytest
+
+`scripts/check_licenses.py` (stdlib only):
+
+```python
+ALLOWED = {"CC0", "PD-USGov", "CC-BY-4.0", "CC-BY-SA-4.0", "proprietary-reference-only"}
+RATCHET = ".github/license-ratchet.txt"   # paths exempted until #175 sweep completes
+```
+
+Wired into:
+- `.pre-commit-config.yaml` as a `local` hook (mirrors existing patterns)
+- `.github/workflows/ci.yml` as a `check-licenses` job in the `summary.needs` list
+
+`.github/license-ratchet.txt` lists every TOML path exempted during the audit window. **#175's PR description must include "delete `.github/license-ratchet.txt`" as the final step.**
+
+### 5. Loader changes (consolidated)
+
+- **`update_properties`**: explicit `if key.startswith("_"): continue` to make existing implicit behavior explicit; branch for `_curve` and `_stddev` sugar.
+- **`_resolve_material_node`**: parse `_sources` from `data`, instantiate `Source` objects, parent-overlay inheritance, assign to `material._sources`.
+- **No changes** to `_parse_value`, `_parse_composition`, the Pint layer, or any property dataclass beyond adding `<prop>_curve: Optional[TempCurve] = None`.
+
+### 6. ufloat→float coercion at boundaries
+
+Once #149 lands, downstream callers crossing JSON or build123d boundaries will see `ufloat` where they expect `float`:
+
+- `core.py:403` (`density_g_mm3 = ... .density / 1000`) → `obj.mass = ufloat(...)`
+- `clients/python/pymat-mcp/src/pymat_mcp/tools.py:300` (`mass_g = volume_mm3 * (density / 1000.0)`) → `json.dumps` fails
+
+**Fix in #149 PR:** small helper `_nominal(x)` that does `float(getattr(x, "nominal_value", x))`, applied at both boundary call sites.
+
+## PR sequence
+
+1. **#150** `_sources` table + `Source` dataclass + `Material._sources` + loader changes + `mat.cite()` + `mat.source_of()` — does NOT add license enforcement
+2. **#149** loader sugar for `_stddev` siblings + `ValueError` on double-spec + ufloat→float boundary helper
+3. **#148** `TempCurve` dataclass + `<prop>_curve` fields + interpolation in `_at(T)` methods + `mat.at(T=...)` view + legacy `_ref_temp+_coeff` rewrite
+4. **#174** `docs/data-policy.md` + CONTRIBUTING update + `scripts/check_licenses.py` + ratchet file + pre-commit + CI wiring
+
+#174 must land before #175 (audit) so the gate exists before the corpus is swept.
+
+## Cross-cutting regression test
+
+Snapshot `(material_key, populated_property_count)` for every material across all categories, asserting count is identical to a checked-in baseline JSON. If `_sources` leaks into properties or `_stddev`/`_curve` siblings get setattr'd as raw values, the count drifts and one test catches it.
+
+## Out of scope
+
+- Refactoring the Pint Quantity layer
+- Changing `mat.density` from `float` to a wrapper
+- Promoting any scalar property to a callable
+- Per-source bibliographic styles beyond DOI/QID/handbook/vendor/measured
+
+## Reviewer notes
+
+Specific deviations from literal issue text:
+
+- **#149**: do NOT add `density_stddev` etc. as dataclass fields. Loader sugar only.
+- **#150**: do NOT add `mat.density.source` attribute. Use `mat.source_of("mechanical.density")` and `mat.cite("density")`.
+- **#148**: do NOT promote `mat.thermal_conductivity` to a callable. Curve evaluation only via `_at(T)` methods and the new `mat.at(T=...)` view.

--- a/src/pymat/core.py
+++ b/src/pymat/core.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     pass
 
 from .properties import AllProperties
+from .sources import Source, resolve_path
 
 # Type variable for generic object application
 T = TypeVar("T")
@@ -133,6 +134,9 @@ class _MaterialInternal:
     parent: Optional[_MaterialInternal] = field(default=None, repr=False)
     _children: Dict[str, _MaterialInternal] = field(default_factory=dict, repr=False)
     _key: Optional[str] = field(default=None, repr=False)  # for registry
+
+    # Provenance (#150) — keyed by dotted property path; `_default` fallback.
+    _sources: Dict[str, Source] = field(default_factory=dict, repr=False)
 
     def __post_init__(self):
         """Apply convenience parameters and property groups to properties object."""
@@ -597,6 +601,39 @@ class _MaterialInternal:
         """Calculate mass in grams from volume in mm³."""
         return volume_mm3 * self.density_g_mm3
 
+    # =========================================================================
+    # Provenance API (#150) — see ADR-0003 and src/pymat/sources.py
+    # =========================================================================
+
+    def source_of(self, path: str) -> Optional[Source]:
+        """Return the `Source` for a property path, or `_default`, or None.
+
+        Accepts short aliases (`"density"`) or fully-qualified paths
+        (`"mechanical.density"`). Resolution order: exact path → `_default`
+        → None.
+        """
+        if not self._sources:
+            return None
+        qpath = resolve_path(path)
+        if qpath in self._sources:
+            return self._sources[qpath]
+        return self._sources.get("_default")
+
+    def cite(self, path: Optional[str] = None) -> str:
+        """Emit BibTeX. Without `path`: every source used by this material,
+        deduplicated by citation key. With `path`: just that one source.
+
+        Returns "" when nothing is cited (graceful, never raises)."""
+        if not self._sources:
+            return ""
+        if path is not None:
+            src = self.source_of(path)
+            return src.to_bibtex() if src is not None else ""
+        seen: Dict[str, Source] = {}
+        for src in self._sources.values():
+            seen.setdefault(src.citation, src)
+        return "\n\n".join(s.to_bibtex() for s in seen.values())
+
     def __repr__(self) -> str:
         """String representation showing path and density."""
         density_str = f"ρ={self.density} g/cm³" if self.density else "ρ=?"
@@ -683,6 +720,7 @@ class Material(_MaterialInternal):
         properties: Optional[AllProperties] = None,
         parent: Optional["Material"] = None,
         _key: Optional[str] = None,
+        _sources: Optional[Dict[str, Source]] = None,
     ):
         # Call parent init without density
         super().__init__(
@@ -704,6 +742,7 @@ class Material(_MaterialInternal):
             properties=properties or AllProperties(),
             parent=parent,
             _key=_key,
+            _sources=_sources or {},
         )
 
         # Apply density convenience param after parent init

--- a/src/pymat/loader.py
+++ b/src/pymat/loader.py
@@ -29,6 +29,7 @@ from .core import Material
 from .properties import (
     AllProperties,
 )
+from .sources import Source, merge_sources, parse_sources_table
 from .units import STANDARD_UNITS
 
 logger = logging.getLogger(__name__)
@@ -117,6 +118,12 @@ def _build_properties_from_dict(
         """Update property object from dictionary, handling both legacy and new formats."""
         for key, value in prop_dict.items():
             if value is None:
+                continue
+
+            # Underscore-prefixed keys are reserved (e.g. _sources, _comment).
+            # Skipped explicitly — without this, hasattr() would silently no-op
+            # and swallow real bugs.
+            if key.startswith("_"):
                 continue
 
             # Skip processed value/unit pairs
@@ -242,6 +249,20 @@ def _resolve_material_node(
         parent_props,
     )
 
+    # Provenance (#150). Parse `[<material>._sources]` and overlay on parent.
+    parent_sources: Dict[str, Source] = (
+        parent_material._sources if parent_material is not None else {}
+    )
+    raw_sources = data.get("_sources")
+    if raw_sources is not None:
+        if not isinstance(raw_sources, dict):
+            kind = type(raw_sources).__name__
+            raise ValueError(f"{key}._sources must be a TOML table, got {kind}")
+        own_sources = parse_sources_table(raw_sources)
+        sources = merge_sources(parent_sources, own_sources)
+    else:
+        sources = dict(parent_sources)
+
     # Create material
     material = Material(
         name=name,
@@ -254,6 +275,7 @@ def _resolve_material_node(
         properties=properties,
         parent=parent_material,
         _key=key,
+        _sources=sources,
     )
 
     # Populate vis — inherit from parent, overlay any TOML overrides (#88).

--- a/src/pymat/sources.py
+++ b/src/pymat/sources.py
@@ -1,0 +1,121 @@
+"""Provenance metadata for material property values (#150).
+
+A `Source` records *where a value came from*, keyed by dotted property path
+on `Material._sources` (e.g. `"mechanical.density"`). Provenance is metadata
+*about* a value, not part of it — `mat.density` stays a `float`. See ADR-0003.
+
+Allowed `license` values are not enforced here; they're enforced by the
+`scripts/check_licenses.py` CI gate added in #174.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+# Short attribute aliases → fully-qualified property paths. When a caller
+# writes `mat.cite("density")` we look up `mechanical.density`. Only one
+# alias per property — when a name is ambiguous (e.g. "transparency"
+# could be optical or visual), require the qualified form.
+SHORT_ALIASES: dict[str, str] = {
+    "density": "mechanical.density",
+    "youngs_modulus": "mechanical.youngs_modulus",
+    "yield_strength": "mechanical.yield_strength",
+    "tensile_strength": "mechanical.tensile_strength",
+    "shear_modulus": "mechanical.shear_modulus",
+    "poissons_ratio": "mechanical.poissons_ratio",
+    "thermal_conductivity": "thermal.thermal_conductivity",
+    "specific_heat": "thermal.specific_heat",
+    "thermal_expansion": "thermal.thermal_expansion",
+    "melting_point": "thermal.melting_point",
+    "resistivity": "electrical.resistivity",
+    "conductivity": "electrical.conductivity",
+    "refractive_index": "optical.refractive_index",
+    "light_yield": "optical.light_yield",
+    "decay_time": "optical.decay_time",
+    "radiation_length": "optical.radiation_length",
+}
+
+
+@dataclass(frozen=True)
+class Source:
+    """Provenance for a single property value.
+
+    Attributes:
+        citation: Short BibTeX-style key (e.g. `"asm_handbook_v2"`).
+        kind: One of `"doi"`, `"qid"`, `"handbook"`, `"vendor"`, `"measured"`.
+        ref: The actual reference — DOI string, Wikidata QID, handbook
+            citation, vendor URL, or in-house measurement record.
+        license: One of `CC0`, `PD-USGov`, `CC-BY-4.0`, `CC-BY-SA-4.0`,
+            `proprietary-reference-only`, `unknown`. Validated by
+            `scripts/check_licenses.py` (#174).
+        note: Optional human-readable note (e.g. measurement conditions).
+    """
+
+    citation: str
+    kind: str
+    ref: str
+    license: str
+    note: Optional[str] = None
+
+    @classmethod
+    def from_toml(cls, data: dict[str, Any]) -> "Source":
+        """Build a Source from a TOML inline-table dict.
+
+        Raises:
+            ValueError: if any required key is missing.
+        """
+        missing = [k for k in ("citation", "kind", "ref", "license") if k not in data]
+        if missing:
+            raise ValueError(f"Source missing required keys: {missing}")
+        return cls(
+            citation=data["citation"],
+            kind=data["kind"],
+            ref=data["ref"],
+            license=data["license"],
+            note=data.get("note"),
+        )
+
+    def to_bibtex(self) -> str:
+        """Emit a BibTeX `@misc` entry. Deterministic — same input, same output."""
+        fields = [f"  citation = {{{self.citation}}}"]
+        if self.kind == "doi":
+            fields.append(f"  doi = {{{self.ref}}}")
+        elif self.kind == "qid":
+            fields.append(f"  url = {{https://www.wikidata.org/wiki/{self.ref}}}")
+            fields.append(f"  note = {{Wikidata {self.ref}}}")
+        elif self.kind == "vendor":
+            fields.append(f"  url = {{{self.ref}}}")
+        else:
+            fields.append(f"  howpublished = {{{self.ref}}}")
+        if self.note:
+            fields.append(f"  annotation = {{{self.note}}}")
+        return "@misc{" + self.citation + ",\n" + ",\n".join(fields) + "\n}"
+
+
+def resolve_path(path: str) -> str:
+    """Expand a short alias (`"density"`) to its fully-qualified path
+    (`"mechanical.density"`). Pass-through if already qualified or unknown."""
+    if "." in path:
+        return path
+    return SHORT_ALIASES.get(path, path)
+
+
+def parse_sources_table(raw: dict[str, Any]) -> dict[str, Source]:
+    """Parse a `[<material>._sources]` TOML table into `{path: Source}`.
+
+    The table may include `_default` plus one entry per dotted property
+    path. All values must be inline tables with the required Source keys.
+    """
+    out: dict[str, Source] = {}
+    for key, val in raw.items():
+        if not isinstance(val, dict):
+            kind = type(val).__name__
+            raise ValueError(f"_sources entry {key!r} must be an inline table, got {kind}")
+        out[key] = Source.from_toml(val)
+    return out
+
+
+def merge_sources(parent: dict[str, Source], child: dict[str, Source]) -> dict[str, Source]:
+    """Overlay child sources on parent (child wins on key collision)."""
+    return {**parent, **child}

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1,0 +1,258 @@
+"""Tests for #150 — `[<material>._sources]` provenance table.
+
+Covers:
+- Loader picks up `[<material>._sources]` and attaches to Material._sources
+- `_default` fallback when no per-property entry exists
+- Per-property override wins over `_default`
+- Underscore keys never leak into AllProperties
+- `mat.source_of("mechanical.density")` returns Source | None
+- `mat.cite("mechanical.density")` emits a BibTeX entry for DOI / Wikidata QID
+- `mat.cite()` (no args) emits all entries used by the material, deduplicated
+- Empty / missing sources are graceful (no crash)
+- Inheritance: child sources overlay parent sources
+"""
+
+from __future__ import annotations
+
+from textwrap import dedent
+
+import pytest
+
+from pymat.loader import load_toml
+from pymat.sources import Source
+
+
+@pytest.fixture
+def aluminum_toml(tmp_path):
+    """Aluminum 6061 material with a full `_sources` block."""
+    p = tmp_path / "al.toml"
+    p.write_text(
+        dedent("""
+        [aluminum]
+        name = "Aluminum"
+
+        [aluminum.al6061]
+        name = "Aluminum 6061-T6"
+        grade = "6061-T6"
+
+        [aluminum.al6061.mechanical]
+        density_value = 2.70
+        density_unit = "g/cm^3"
+        yield_strength_value = 276
+        yield_strength_unit = "MPa"
+
+        [aluminum.al6061.thermal]
+        thermal_conductivity_value = 167
+        thermal_conductivity_unit = "W/(m*K)"
+
+        [aluminum.al6061._sources._default]
+        citation = "asm_handbook_v2"
+        kind = "handbook"
+        ref = "ASM Handbook vol.2 p.62"
+        license = "proprietary-reference-only"
+
+        [aluminum.al6061._sources."mechanical.density"]
+        citation = "matweb_al6061"
+        kind = "vendor"
+        ref = "https://matweb.com/al6061"
+        license = "proprietary-reference-only"
+
+        [aluminum.al6061._sources."mechanical.yield_strength"]
+        citation = "kaufman_2000"
+        kind = "doi"
+        ref = "10.31399/9781615032426"
+        license = "proprietary-reference-only"
+
+        [aluminum.al6061._sources."thermal.thermal_conductivity"]
+        citation = "nist_cryo_al6061"
+        kind = "doi"
+        ref = "10.6028/NIST.MONO.177"
+        license = "PD-USGov"
+        note = "cryogenic NIST data"
+        """)
+    )
+    return p
+
+
+@pytest.fixture
+def aluminum(aluminum_toml):
+    mats = load_toml(aluminum_toml)
+    return mats["aluminum"].al6061
+
+
+class TestSourcesParsing:
+    def test_sources_attached_to_material(self, aluminum):
+        assert aluminum._sources, "expected _sources dict to be populated"
+
+    def test_default_source_present(self, aluminum):
+        assert "_default" in aluminum._sources
+        s = aluminum._sources["_default"]
+        assert isinstance(s, Source)
+        assert s.citation == "asm_handbook_v2"
+        assert s.kind == "handbook"
+        assert s.license == "proprietary-reference-only"
+
+    def test_per_property_source_present(self, aluminum):
+        assert "mechanical.density" in aluminum._sources
+        s = aluminum._sources["mechanical.density"]
+        assert s.citation == "matweb_al6061"
+        assert s.kind == "vendor"
+
+    def test_sources_dont_leak_into_properties(self, aluminum):
+        """The _sources dict must never end up on AllProperties or any sub-dataclass."""
+        assert not hasattr(aluminum.properties, "_sources")
+        assert not hasattr(aluminum.properties.mechanical, "_sources")
+        assert not hasattr(aluminum.properties.thermal, "_sources")
+
+    def test_density_value_unchanged_by_sources_block(self, aluminum):
+        """Adding _sources must not perturb the actual property value."""
+        assert aluminum.properties.mechanical.density == 2.70
+
+
+class TestSourceOf:
+    def test_returns_per_property_source_when_present(self, aluminum):
+        s = aluminum.source_of("mechanical.density")
+        assert s is not None
+        assert s.citation == "matweb_al6061"
+
+    def test_falls_back_to_default(self, aluminum):
+        # Aluminum has no per-property source for `mechanical.youngs_modulus`,
+        # but _default is defined.
+        s = aluminum.source_of("mechanical.youngs_modulus")
+        assert s is not None
+        assert s.citation == "asm_handbook_v2", "should fall back to _default"
+
+    def test_short_alias_density(self, aluminum):
+        """`source_of("density")` should resolve to `mechanical.density`."""
+        s = aluminum.source_of("density")
+        assert s is not None
+        assert s.citation == "matweb_al6061"
+
+    def test_returns_none_when_no_sources_at_all(self, tmp_path):
+        p = tmp_path / "bare.toml"
+        p.write_text(
+            dedent("""
+            [steel]
+            name = "Steel"
+            [steel.mechanical]
+            density_value = 7.85
+            density_unit = "g/cm^3"
+            """)
+        )
+        steel = load_toml(p)["steel"]
+        assert steel.source_of("mechanical.density") is None
+
+
+class TestCite:
+    def test_cite_doi_emits_bibtex(self, aluminum):
+        bib = aluminum.cite("mechanical.yield_strength")
+        assert "@" in bib, "expected a BibTeX entry"
+        assert "kaufman_2000" in bib
+        assert "10.31399/9781615032426" in bib
+
+    def test_cite_short_alias(self, aluminum):
+        bib_short = aluminum.cite("density")
+        bib_full = aluminum.cite("mechanical.density")
+        assert bib_short == bib_full
+
+    def test_cite_all_dedupes(self, aluminum):
+        all_bib = aluminum.cite()
+        # 4 sources defined (_default + 3 per-property). Each entry header
+        # `@misc{<citation>,` appears at most once even though _default may
+        # apply to many props.
+        for citation in ("asm_handbook_v2", "matweb_al6061", "kaufman_2000", "nist_cryo_al6061"):
+            header = f"@misc{{{citation},"
+            assert all_bib.count(header) == 1, f"{citation} should appear exactly once"
+
+    def test_cite_empty_when_no_sources(self, tmp_path):
+        p = tmp_path / "bare.toml"
+        p.write_text(
+            dedent("""
+            [steel]
+            name = "Steel"
+            [steel.mechanical]
+            density_value = 7.85
+            density_unit = "g/cm^3"
+            """)
+        )
+        steel = load_toml(p)["steel"]
+        assert steel.cite() == ""
+        assert steel.cite("density") == ""
+
+    def test_cite_wikidata_qid(self, tmp_path):
+        p = tmp_path / "wd.toml"
+        p.write_text(
+            dedent("""
+            [iron]
+            name = "Iron"
+            [iron.mechanical]
+            density_value = 7.874
+            density_unit = "g/cm^3"
+            [iron._sources."mechanical.density"]
+            citation = "wikidata_iron"
+            kind = "qid"
+            ref = "Q677"
+            license = "CC0"
+            """)
+        )
+        iron = load_toml(p)["iron"]
+        bib = iron.cite("density")
+        assert "wikidata_iron" in bib
+        assert "Q677" in bib
+
+
+class TestSourcesInheritance:
+    def test_child_overlays_parent(self, tmp_path):
+        p = tmp_path / "inh.toml"
+        p.write_text(
+            dedent("""
+            [stainless]
+            name = "Stainless"
+
+            [stainless.mechanical]
+            density_value = 8.0
+            density_unit = "g/cm^3"
+
+            [stainless._sources._default]
+            citation = "asm_v1"
+            kind = "handbook"
+            ref = "ASM v1"
+            license = "proprietary-reference-only"
+
+            [stainless.s316L]
+            name = "Stainless 316L"
+
+            [stainless.s316L._sources."mechanical.density"]
+            citation = "vendor_316L"
+            kind = "vendor"
+            ref = "https://x"
+            license = "proprietary-reference-only"
+            """)
+        )
+        mats = load_toml(p)
+        s316L = mats["stainless"].s316L
+        # Per-property override wins
+        assert s316L.source_of("mechanical.density").citation == "vendor_316L"
+        # _default inherited from parent
+        assert s316L.source_of("mechanical.youngs_modulus").citation == "asm_v1"
+
+
+class TestSourcesAreNotPropertyGroups:
+    """Regression: `_sources` must never be treated as an unknown property group."""
+
+    def test_underscore_key_skipped_in_update_properties(self, tmp_path):
+        """A misplaced `_sources` inside `[mechanical]` should not crash and not setattr."""
+        p = tmp_path / "misplaced.toml"
+        p.write_text(
+            dedent("""
+            [steel]
+            name = "Steel"
+            [steel.mechanical]
+            density_value = 7.85
+            density_unit = "g/cm^3"
+            _comment = "this should be silently ignored, not setattr'd"
+            """)
+        )
+        # Must not raise
+        mats = load_toml(p)
+        assert mats["steel"].properties.mechanical.density == 7.85

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -203,7 +203,7 @@ class TestCite:
 
 class TestSourcesInheritance:
     def test_child_overlays_parent(self, tmp_path):
-        p = tmp_path / "inh.toml"
+        p = tmp_path / "inheritance.toml"
         p.write_text(
             dedent("""
             [stainless]

--- a/tests/test_toml_integrity.py
+++ b/tests/test_toml_integrity.py
@@ -58,6 +58,8 @@ _KNOWN_LEAF_KEYS = {
     "treatment",
     "vendor",
 }
+# Underscore-prefixed reserved keys at material-node level (#150).
+# `_walk_unknown_groups` skips anything starting with `_`.
 
 # Separate regexes per field — the slashed form conflated the two
 # alphabets: source is lowercase-dashed (ambientcg, polyhaven, gpuopen),
@@ -220,6 +222,9 @@ def _walk_unknown_groups(node, prefix: str):
     for key, value in node.items():
         path = f"{prefix}.{key}"
         if not isinstance(value, dict):
+            continue
+        if key.startswith("_"):
+            # Reserved underscore-prefixed keys (#150 _sources, future _curve etc.)
             continue
         if _looks_like_material_node(value):
             # Child material — recurse without flagging


### PR DESCRIPTION
## Summary

Adds `[<material>._sources]` TOML support for keyed-by-property-path provenance with `_default` fallback and parent-overlay inheritance — the foundation of the schema-expansion milestone.

New module `pymat.sources` defines:
- `Source` (frozen dataclass): `citation`, `kind`, `ref`, `license`, `note`
- Short-alias resolution (`density` → `mechanical.density`)
- `parse_sources_table` / `merge_sources` helpers

New `Material` API:
- `mat.source_of("mechanical.density")` → `Source | None` (resolves `_default` fallback)
- `mat.cite("density")` → BibTeX entry (`@misc` for DOI / Wikidata QID / handbook / vendor)
- `mat.cite()` → all sources used by this material, deduplicated by citation key

## Changes

| File | What |
|---|---|
| `src/pymat/sources.py` (new) | `Source` dataclass, BibTeX emitter, alias table, parsers |
| `src/pymat/core.py` | `Material._sources` field; `source_of()` and `cite()` methods |
| `src/pymat/loader.py` | Explicit `_`-prefix skip in `update_properties`; `_sources` parsing in `_resolve_material_node` with parent-overlay inheritance |
| `tests/test_sources.py` (new) | 16 tests: parsing, inheritance, fallback, dedup, BibTeX emission |
| `tests/test_toml_integrity.py` | `_walk_unknown_groups` now skips reserved underscore keys |
| `docs/decisions/0003-schema-foundation.md` (new) | ADR consolidating 3 parallel reviews — covers #150, #149, #148, #174 design |

## Design notes (ADR-0003)

The original issue proposed `mat.density.source` as the accessor. **Rejected** because it would change `mat.density` from `float` to a wrapper object — direct break of `core.py:403` (`density / 1000`), `clients/python/pymat-mcp/src/pymat_mcp/tools.py:300` (`compute_mass`), and the `*_qty` Pint quantity layer (~50 call sites). `mat.source_of()` and `mat.cite()` accomplish the same goal additively, with zero changes to existing arithmetic.

License field is parsed but **not validated** in this PR — enforcement comes in #174.

## Test plan

- [x] `pytest tests/test_sources.py` — 16 new tests pass
- [x] `pytest tests/` (full suite minus visual-regression) — 488 passed, 11 skipped, zero regressions
- [x] `ruff check` clean on changed files
- [x] `ruff format` no diff
- [x] mypy clean on new code (5 errors are pre-existing in `core.py`/`loader.py`, unrelated to this PR)

## Risks / regressions considered

1. **Underscore keys leaking into `AllProperties`** — explicit test `test_sources_dont_leak_into_properties` plus loader-level `if key.startswith("_"): continue`.
2. **Existing TOMLs without `_sources`** — fully backwards-compatible; `_sources` defaults to empty dict; no API surface changes for materials that don't use it.
3. **`Material.copy()` propagation of `_sources`** — `_sources` lives on `_MaterialInternal` as a dataclass field, so `deepcopy(material)` carries it for free. Verified by `test_child_overlays_parent`.
4. **TOML integrity check** — `_walk_unknown_groups` now skips underscore-prefixed keys at material-node level (was implicit pass via heuristic; now explicit).

Closes #150

Part of the schema foundation series (PR sequence per ADR-0003): #150 → #149 → #148 → #174.