### PR TITLE
feat(schema): _stddev sibling sugar + ufloat boundary helper (#149)

### DIFF
--- a/clients/python/pymat-mcp/src/pymat_mcp/tools.py
+++ b/clients/python/pymat-mcp/src/pymat_mcp/tools.py
@@ -20,6 +20,20 @@ from typing import Any
 # ── Helpers ────────────────────────────────────────────────────────
 
 
+def _nominal(x: Any) -> Any:
+    """Coerce a possibly-ufloat value to a plain float for JSON.
+
+    py-materials values may be `uncertainties.UFloat` when authored
+    with `{nominal, stddev}` or `<prop>_stddev` sibling sugar (#149).
+    JSON can't serialize ufloats; we keep the nominal value and drop
+    uncertainty at the wire boundary.
+    """
+    if x is None:
+        return None
+    nominal = getattr(x, "nominal_value", None)
+    return float(nominal) if nominal is not None else x
+
+
 _ALL_DOMAINS = (
     "mechanical",
     "thermal",
@@ -68,6 +82,8 @@ def _props_dict(props: Any, domains: list[str] | None = None) -> dict[str, dict[
             # custom field) renders to its magnitude.
             if hasattr(value, "magnitude"):
                 value = value.magnitude
+            # ufloat → nominal at the JSON boundary (#149)
+            value = _nominal(value)
             group_out[field_name] = value
         if group_out:
             out[group_name] = group_out
@@ -107,7 +123,7 @@ def _brief(material: Any) -> dict[str, Any]:
         "name": material.name,
         "grade": material.grade,
         "category": _category_of(material),
-        "density": material.properties.mechanical.density,
+        "density": _nominal(material.properties.mechanical.density),
     }
 
 
@@ -290,7 +306,7 @@ def compute_mass(material: str, volume_mm3: float) -> dict[str, Any]:
     m = _resolve(material)
     if m is None:
         return _not_found(material)
-    density = m.properties.mechanical.density
+    density = _nominal(m.properties.mechanical.density)
     if density is None:
         return {
             "error": f"{m.name!r} has no curated density (mechanical.density is None)",

--- a/clients/python/pymat-mcp/tests/test_tools.py
+++ b/clients/python/pymat-mcp/tests/test_tools.py
@@ -242,6 +242,26 @@ class TestComputeMass:
         out = tools.compute_mass("not_real", 100.0)
         assert "error" in out
 
+    def test_ufloat_density_returns_plain_floats(self):
+        """If a curated density is a ufloat (#149), the JSON payload must
+        still be plain floats — agents/JSON can't handle ufloats."""
+        import json
+
+        from uncertainties import ufloat
+
+        import pymat
+
+        steel = pymat["Stainless Steel 304"]
+        original = steel.properties.mechanical.density
+        steel.properties.mechanical.density = ufloat(7.99, 0.05)
+        try:
+            out = tools.compute_mass("Stainless Steel 304", 1000.0)
+            assert isinstance(out["mass_g"], float)
+            assert isinstance(out["density_g_per_cm3"], float)
+            json.dumps(out)  # must be JSON-serializable end-to-end
+        finally:
+            steel.properties.mechanical.density = original
+
 
 # ── get_appearance ────────────────────────────────────────────
 

--- a/src/pymat/core.py
+++ b/src/pymat/core.py
@@ -556,11 +556,17 @@ class _MaterialInternal:
 
     @property
     def density_g_mm3(self) -> float:
-        """Density in g/mm³ (for build123d calculations)."""
+        """Density in g/mm³ (for build123d calculations).
+
+        Always returns a plain float — if the underlying density is a
+        ufloat (#149), the nominal value is taken so build123d/JSON
+        boundaries don't see a ufloat they can't handle.
+        """
         mech_density = self.properties.mechanical.density
         if not mech_density:
             return 0.0
-        return mech_density / 1000
+        nominal = float(getattr(mech_density, "nominal_value", mech_density))
+        return nominal / 1000
 
     @property
     def molar_mass(self) -> Optional[float]:

--- a/src/pymat/loader.py
+++ b/src/pymat/loader.py
@@ -19,7 +19,7 @@ if sys.version_info >= (3, 11):
 else:
     import tomli as tomllib
 
-from uncertainties import ufloat
+from uncertainties import UFloat, ufloat
 
 if TYPE_CHECKING:
     from .core import Material
@@ -115,7 +115,37 @@ def _build_properties_from_dict(
 
     # Helper to safely get and update nested properties
     def update_properties(prop_obj, prop_dict, prop_name):
-        """Update property object from dictionary, handling both legacy and new formats."""
+        """Update property object from dictionary, handling both legacy and new formats.
+
+        Supports (#149) sibling `<base>_stddev` siblings as sugar — folded into
+        a ufloat with the base value at parse time. Double-spec (in-value
+        `{nominal, stddev}` AND sibling `_stddev`) is a hard error.
+        """
+        # Pass 1: collect _stddev siblings into {base_key: stddev}.
+        stddev_map = {}
+        for key, value in prop_dict.items():
+            if key.endswith("_stddev") and not key.startswith("_"):
+                stddev_map[key[:-7]] = value  # strip "_stddev"
+
+        # Track which stddev siblings we actually consumed; orphans raise.
+        consumed_stddev = set()
+
+        def assign(base_key: str, raw_value):
+            """Parse a value (possibly a {nominal, stddev} dict), fold sibling
+            stddev if present, and setattr on prop_obj."""
+            parsed = _parse_value(raw_value) if isinstance(raw_value, dict) else raw_value
+            sibling = stddev_map.get(base_key)
+            if sibling is not None:
+                consumed_stddev.add(base_key)
+                if isinstance(parsed, UFloat):
+                    raise ValueError(
+                        f"{prop_name}.{base_key}: double-specification — "
+                        f"both in-value stddev and sibling {base_key}_stddev are set"
+                    )
+                parsed = ufloat(float(parsed), float(sibling))
+            if hasattr(prop_obj, base_key):
+                setattr(prop_obj, base_key, parsed)
+
         for key, value in prop_dict.items():
             if value is None:
                 continue
@@ -126,8 +156,8 @@ def _build_properties_from_dict(
             if key.startswith("_"):
                 continue
 
-            # Skip processed value/unit pairs
-            if key.endswith("_unit"):
+            # Skip processed value/unit/stddev siblings (handled separately)
+            if key.endswith("_unit") or key.endswith("_stddev"):
                 continue
 
             # Check if this is a value in a value/unit pair
@@ -151,15 +181,14 @@ def _build_properties_from_dict(
                         unit = None
 
                 # Set both value and unit
-                if hasattr(prop_obj, base_key):
-                    setattr(prop_obj, base_key, value)
+                assign(base_key, value)
                 if unit and hasattr(prop_obj, unit_key):
                     setattr(prop_obj, unit_key, unit)
 
             # Legacy format: single value (not a value/unit pair)
-            elif not key.endswith("_unit"):
+            else:
                 if hasattr(prop_obj, key):
-                    setattr(prop_obj, key, value)
+                    assign(key, value)
                     # Try to set default unit
                     unit_key = f"{key}_unit"
                     if hasattr(prop_obj, unit_key):
@@ -172,6 +201,12 @@ def _build_properties_from_dict(
                                 key,
                                 default_unit,
                             )
+
+        # Orphan stddev siblings (no matching base value) are a typo signal.
+        orphans = set(stddev_map) - consumed_stddev
+        if orphans:
+            names = ", ".join(f"{prop_name}.{n}_stddev" for n in sorted(orphans))
+            raise ValueError(f"orphan stddev sibling(s) with no matching base value: {names}")
 
     # Parse each property group
     if "mechanical" in data:

--- a/tests/test_stddev_sugar.py
+++ b/tests/test_stddev_sugar.py
@@ -1,0 +1,212 @@
+"""Tests for #149 — `<prop>_stddev` sibling sugar + boundary helpers.
+
+Per ADR-0003, `_stddev` is loader sugar that folds sibling stddev into the
+existing ufloat mechanism — NOT a parallel set of dataclass fields. Both
+forms work; double-specification is a hard error.
+
+Also covers: ufloat → float coercion at the build123d / JSON boundary
+(`Material.density_g_mm3`).
+"""
+
+from __future__ import annotations
+
+from textwrap import dedent
+
+import pytest
+from uncertainties import UFloat
+
+from pymat.loader import load_toml
+
+
+class TestStddevSiblingSugar:
+    def test_value_form_with_sibling_stddev_produces_ufloat(self, tmp_path):
+        p = tmp_path / "m.toml"
+        p.write_text(
+            dedent("""
+            [steel]
+            name = "Steel"
+            [steel.mechanical]
+            density_value = 7.85
+            density_unit = "g/cm^3"
+            density_stddev = 0.05
+            """)
+        )
+        steel = load_toml(p)["steel"]
+        d = steel.properties.mechanical.density
+        assert isinstance(d, UFloat), f"expected ufloat, got {type(d).__name__}"
+        assert d.nominal_value == pytest.approx(7.85)
+        assert d.std_dev == pytest.approx(0.05)
+
+    def test_legacy_bare_form_with_sibling_stddev_produces_ufloat(self, tmp_path):
+        p = tmp_path / "m.toml"
+        p.write_text(
+            dedent("""
+            [steel]
+            name = "Steel"
+            [steel.mechanical]
+            density = 7.85
+            density_stddev = 0.05
+            """)
+        )
+        steel = load_toml(p)["steel"]
+        d = steel.properties.mechanical.density
+        assert isinstance(d, UFloat)
+        assert d.nominal_value == pytest.approx(7.85)
+        assert d.std_dev == pytest.approx(0.05)
+
+    def test_in_value_form_still_works(self, tmp_path):
+        """Regression — the existing {nominal, stddev} form must keep working."""
+        p = tmp_path / "m.toml"
+        p.write_text(
+            dedent("""
+            [steel]
+            name = "Steel"
+            [steel.mechanical]
+            density = { nominal = 7.85, stddev = 0.05 }
+            """)
+        )
+        steel = load_toml(p)["steel"]
+        d = steel.properties.mechanical.density
+        assert isinstance(d, UFloat)
+        assert d.nominal_value == pytest.approx(7.85)
+        assert d.std_dev == pytest.approx(0.05)
+
+    def test_double_specification_raises(self, tmp_path):
+        """Both in-value `stddev` AND sibling `_stddev` is a hard error."""
+        p = tmp_path / "m.toml"
+        p.write_text(
+            dedent("""
+            [steel]
+            name = "Steel"
+            [steel.mechanical]
+            density = { nominal = 7.85, stddev = 0.05 }
+            density_stddev = 0.10
+            """)
+        )
+        with pytest.raises(ValueError, match="double-specification"):
+            load_toml(p)
+
+    def test_stddev_without_base_value_raises(self, tmp_path):
+        """A `_stddev` sibling with no matching base value is a typo signal."""
+        p = tmp_path / "m.toml"
+        p.write_text(
+            dedent("""
+            [steel]
+            name = "Steel"
+            [steel.mechanical]
+            density_stddev = 0.05
+            """)
+        )
+        with pytest.raises(ValueError, match="density_stddev"):
+            load_toml(p)
+
+    def test_stddev_zero_still_produces_ufloat(self, tmp_path):
+        """Explicit stddev=0 is a valid declaration of certainty."""
+        p = tmp_path / "m.toml"
+        p.write_text(
+            dedent("""
+            [steel]
+            name = "Steel"
+            [steel.mechanical]
+            density_value = 7.85
+            density_unit = "g/cm^3"
+            density_stddev = 0.0
+            """)
+        )
+        steel = load_toml(p)["steel"]
+        d = steel.properties.mechanical.density
+        assert isinstance(d, UFloat)
+        assert d.std_dev == 0.0
+
+
+class TestBoundaryCoercion:
+    """ufloat → float at build123d / JSON boundaries (Material.density_g_mm3)."""
+
+    def test_density_g_mm3_returns_float_when_density_is_ufloat(self, tmp_path):
+        p = tmp_path / "m.toml"
+        p.write_text(
+            dedent("""
+            [steel]
+            name = "Steel"
+            [steel.mechanical]
+            density_value = 7.85
+            density_unit = "g/cm^3"
+            density_stddev = 0.05
+            """)
+        )
+        steel = load_toml(p)["steel"]
+        # density is a ufloat (#149 sugar), but density_g_mm3 must
+        # return a plain float — build123d can't accept ufloats.
+        result = steel.density_g_mm3
+        assert isinstance(result, float), f"expected float, got {type(result).__name__}"
+        assert result == pytest.approx(0.00785)
+
+    def test_density_g_mm3_unchanged_for_plain_float(self, tmp_path):
+        """Regression — no behavior change for materials without uncertainty."""
+        p = tmp_path / "m.toml"
+        p.write_text(
+            dedent("""
+            [steel]
+            name = "Steel"
+            [steel.mechanical]
+            density_value = 7.85
+            density_unit = "g/cm^3"
+            """)
+        )
+        steel = load_toml(p)["steel"]
+        assert isinstance(steel.density_g_mm3, float)
+        assert steel.density_g_mm3 == pytest.approx(0.00785)
+
+    def test_density_g_mm3_zero_when_density_missing(self, tmp_path):
+        """Existing contract — no density yields 0.0, not raises."""
+        p = tmp_path / "m.toml"
+        p.write_text(
+            dedent("""
+            [steel]
+            name = "Steel"
+            """)
+        )
+        steel = load_toml(p)["steel"]
+        assert steel.density_g_mm3 == 0.0
+
+    def test_mass_from_volume_mm3_returns_float_for_ufloat_density(self, tmp_path):
+        p = tmp_path / "m.toml"
+        p.write_text(
+            dedent("""
+            [steel]
+            name = "Steel"
+            [steel.mechanical]
+            density_value = 7.85
+            density_unit = "g/cm^3"
+            density_stddev = 0.05
+            """)
+        )
+        steel = load_toml(p)["steel"]
+        m = steel.mass_from_volume_mm3(1000.0)
+        assert isinstance(m, float)
+        assert m == pytest.approx(7.85)
+
+
+class TestMultipleStddevFields:
+    """A material can declare uncertainty on multiple properties."""
+
+    def test_multiple_stddev_siblings_in_one_group(self, tmp_path):
+        p = tmp_path / "m.toml"
+        p.write_text(
+            dedent("""
+            [steel]
+            name = "Steel"
+            [steel.mechanical]
+            density_value = 7.85
+            density_unit = "g/cm^3"
+            density_stddev = 0.05
+            yield_strength_value = 250
+            yield_strength_unit = "MPa"
+            yield_strength_stddev = 15
+            """)
+        )
+        steel = load_toml(p)["steel"]
+        assert isinstance(steel.properties.mechanical.density, UFloat)
+        assert steel.properties.mechanical.density.std_dev == pytest.approx(0.05)
+        assert isinstance(steel.properties.mechanical.yield_strength, UFloat)
+        assert steel.properties.mechanical.yield_strength.std_dev == pytest.approx(15)


### PR DESCRIPTION
## Summary

Per [ADR-0003](https://github.com/MorePET/mat/blob/main/docs/decisions/0003-schema-foundation.md), `_stddev` lands as **loader sugar**, not as parallel dataclass fields. The existing in-value `{nominal, stddev}` form is now also routed through `_parse_value` for property scalars (it already worked for compositions). Sibling sugar exists for hand-edited TOML ergonomics. Both forms work; double-specification is a hard error.

```toml
# Canonical (works everywhere now)
density = { nominal = 7.85, stddev = 0.05 }

# Sibling sugar (folded into a ufloat at parse time)
density_value = 7.85
density_unit = "g/cm^3"
density_stddev = 0.05

# Hard error — double-specification
density = { nominal = 7.85, stddev = 0.05 }
density_stddev = 0.10        # ValueError("double-specification ...")
```

## Loader changes (`src/pymat/loader.py`)

Two-pass `update_properties`:
1. **Pass 1**: collect `<base>_stddev` siblings into `{base_key: stddev}`.
2. **Pass 2**: route each property value through `_parse_value` (so dict forms work for scalars too), then fold sibling stddev into a ufloat at assignment.

Hard errors:
- Double-specification (in-value AND sibling) → `ValueError`
- Orphan `_stddev` (no matching base value) → `ValueError`

## Boundary helpers (per ADR-0003 §6)

Once contributors actually populate uncertainties, downstream callers crossing JSON or build123d boundaries will see `ufloat` where they expect `float`:

| Site | Fix |
|---|---|
| `Material.density_g_mm3` | Coerce ufloat → nominal float (build123d can't handle ufloats) |
| pymat-mcp `_props_dict` | `_nominal()` helper applied after the existing Pint-magnitude unwrap |
| pymat-mcp `_brief` | Same |
| pymat-mcp `compute_mass` | Same — `density_g_per_cm3` and `mass_g` both become plain floats |

## Test plan

- [x] `tests/test_stddev_sugar.py` (11 tests): sibling sugar + value form + double-spec + orphan + zero stddev + multiple fields + `density_g_mm3` boundary + `mass_from_volume_mm3` boundary
- [x] `clients/python/pymat-mcp/tests/test_tools.py::TestComputeMass::test_ufloat_density_returns_plain_floats`: end-to-end JSON round-trip with a ufloat density
- [x] Full suite: 499 passed, 11 skipped, zero regressions
- [x] `ruff check` clean
- [x] `ruff format` no diff

## Risks / regressions considered

1. **Existing TOMLs that already use `{nominal, stddev}` for property scalars** — there are none in the corpus today (the form only worked for compositions until now). New routing is purely additive for them.
2. **Existing TOMLs with `<prop>_stddev`-named legacy fields that aren't intended as siblings** — none exist; verified by full suite + `test_toml_integrity` passing.
3. **`uncertainties` import on cold path** — already imported by loader for `_parse_value`; no new dependency surface.
4. **Pint `*_qty` properties when value is ufloat** — Pint+ufloat interop is intact (Pint accepts ufloat as magnitude); `density_qty.to('kg/m^3')` works, `.magnitude` is a ufloat. Lossy coercion only at JSON/build123d boundaries.

Closes #149
Part of the schema foundation series: #150 (merged) → **#149** → #148 → #174.