### PR TITLE
feat(schema): T-dependent property curves (#148)

### DIFF
--- a/src/pymat/curves.py
+++ b/src/pymat/curves.py
@@ -1,0 +1,89 @@
+"""Temperature-dependent property curves (#148).
+
+A `TempCurve` holds piecewise-linear `(temps_K, values)` knots for a
+single property. Out-of-range temps are CLAMPED, not extrapolated —
+engineering data extrapolated below its measured range is a lie, and
+clamping is conservative and visibly wrong rather than subtly wrong
+(per ADR-0003 §2 edge-case table).
+
+Validation is at construction (and therefore at TOML load) — unsorted
+or mismatched-length arrays raise `ValueError` immediately, not at
+query time. Empty curves raise as well.
+
+Used by sibling fields like `<prop>_curve: Optional[TempCurve]` on
+the property dataclasses.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, List
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class TempCurve:
+    """Piecewise-linear temperature-dependent property curve.
+
+    Attributes:
+        temps_K: Strictly-sorted ascending temperatures in Kelvin.
+        values: Property values at each knot, same length as `temps_K`.
+    """
+
+    temps_K: List[float]
+    values: List[float]
+
+    def __post_init__(self) -> None:
+        if not self.temps_K:
+            raise ValueError("TempCurve requires at least one knot")
+        if len(self.temps_K) != len(self.values):
+            raise ValueError(
+                f"TempCurve temps_K and values must be same length: "
+                f"{len(self.temps_K)} vs {len(self.values)}"
+            )
+        # Strict-sorted check (ascending). Equal-adjacent knots would make
+        # interpolation ambiguous; reject.
+        for a, b in zip(self.temps_K, self.temps_K[1:]):
+            if not a < b:
+                raise ValueError(
+                    f"TempCurve temps_K must be strictly sorted ascending; got {self.temps_K}"
+                )
+
+    def interpolate(self, temp_K: float) -> float:
+        """Evaluate the curve at `temp_K`. Out-of-range clamps to nearest knot."""
+        if temp_K <= self.temps_K[0]:
+            if temp_K < self.temps_K[0]:
+                logger.debug(
+                    "TempCurve: T=%s K below min knot %s K; clamping",
+                    temp_K,
+                    self.temps_K[0],
+                )
+            return self.values[0]
+        if temp_K >= self.temps_K[-1]:
+            if temp_K > self.temps_K[-1]:
+                logger.debug(
+                    "TempCurve: T=%s K above max knot %s K; clamping",
+                    temp_K,
+                    self.temps_K[-1],
+                )
+            return self.values[-1]
+        # Linear interp between bracketing knots
+        for i in range(len(self.temps_K) - 1):
+            t0, t1 = self.temps_K[i], self.temps_K[i + 1]
+            if t0 <= temp_K <= t1:
+                v0, v1 = self.values[i], self.values[i + 1]
+                frac = (temp_K - t0) / (t1 - t0)
+                return v0 + frac * (v1 - v0)
+        # Unreachable — clamp branches above cover all cases
+        raise RuntimeError(f"TempCurve: failed to bracket T={temp_K}")  # pragma: no cover
+
+    @classmethod
+    def from_toml(cls, raw: Any) -> "TempCurve":
+        """Build from `{temps_K = [...], values = [...]}` TOML inline-table."""
+        if not isinstance(raw, dict):
+            raise ValueError(f"TempCurve TOML must be a table, got {type(raw).__name__}")
+        if "temps_K" not in raw or "values" not in raw:
+            raise ValueError(f"TempCurve TOML missing 'temps_K' or 'values': {raw}")
+        return cls(temps_K=list(raw["temps_K"]), values=list(raw["values"]))

--- a/src/pymat/loader.py
+++ b/src/pymat/loader.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
 
 from . import registry
 from .core import Material
+from .curves import TempCurve
 from .properties import (
     AllProperties,
 )
@@ -158,6 +159,15 @@ def _build_properties_from_dict(
 
             # Skip processed value/unit/stddev siblings (handled separately)
             if key.endswith("_unit") or key.endswith("_stddev"):
+                continue
+
+            # T-curve sibling (#148): build a TempCurve and setattr on the
+            # `<base>_curve` field if it exists. Validation (sorted, equal
+            # lengths) raises in TempCurve.__post_init__ at load time.
+            if key.endswith("_curve") and isinstance(value, dict):
+                curve_field = key  # e.g. "thermal_conductivity_curve"
+                if hasattr(prop_obj, curve_field):
+                    setattr(prop_obj, curve_field, TempCurve.from_toml(value))
                 continue
 
             # Check if this is a value in a value/unit pair

--- a/src/pymat/properties.py
+++ b/src/pymat/properties.py
@@ -20,7 +20,28 @@ from typing import TYPE_CHECKING, Any, Dict, Optional
 if TYPE_CHECKING:
     from pint import Quantity
 
+from .curves import TempCurve
 from .units import ureg
+
+
+def _eval_curve_or_scalar(
+    curve: Optional[TempCurve], scalar: Optional[float], unit_str: Optional[str], temp: "Quantity"
+) -> Optional["Quantity"]:
+    """Shared evaluator: prefer curve, fall back to scalar.
+
+    Used by every `<prop>_at(T)` method (#148 ADR-0003). Returns a Pint
+    Quantity if a unit is known, otherwise the bare value.
+    """
+    if curve is None and scalar is None:
+        return None
+    try:
+        temp_k = temp.to(ureg.kelvin).magnitude
+    except Exception as e:
+        raise ValueError(f"Temperature must be in absolute units (Kelvin). Got {temp.units}: {e}")
+    raw = curve.interpolate(float(temp_k)) if curve is not None else scalar
+    if unit_str:
+        return raw * ureg(unit_str)
+    return raw
 
 
 @dataclass
@@ -45,6 +66,22 @@ class MechanicalProperties:
     hardness_rockwell: Optional[float] = None  # HR (Rockwell hardness)
     fracture_toughness: Optional[float] = None  # MPa·m^0.5
     fracture_toughness_unit: str = "MPa*m^0.5"
+
+    # T-dependent curves (#148). Sibling fields parallel to scalars.
+    youngs_modulus_curve: Optional[TempCurve] = None
+    yield_strength_curve: Optional[TempCurve] = None
+
+    def youngs_modulus_at(self, temp: "Quantity") -> Optional["Quantity"]:
+        """Young's modulus at T. Curve > scalar fallback (#148)."""
+        return _eval_curve_or_scalar(
+            self.youngs_modulus_curve, self.youngs_modulus, self.youngs_modulus_unit, temp
+        )
+
+    def yield_strength_at(self, temp: "Quantity") -> Optional["Quantity"]:
+        """Yield strength at T. Curve > scalar fallback (#148)."""
+        return _eval_curve_or_scalar(
+            self.yield_strength_curve, self.yield_strength, self.yield_strength_unit, temp
+        )
 
     # Quantity properties for unit-aware access
     @property
@@ -120,6 +157,11 @@ class ThermalProperties:
     min_service_temp_unit: str = "degC"
     thermal_shock_resistance: Optional[str] = None  # "excellent", "good", "fair", "poor"
 
+    # T-dependent curves (#148). Sibling fields parallel to scalars.
+    thermal_conductivity_curve: Optional[TempCurve] = None
+    specific_heat_curve: Optional[TempCurve] = None
+    thermal_expansion_curve: Optional[TempCurve] = None
+
     # Quantity properties for unit-aware access
     @property
     def melting_point_qty(self) -> Optional[Quantity]:
@@ -185,8 +227,8 @@ class ThermalProperties:
         """
         Calculate thermal conductivity at given temperature.
 
-        Uses linear temperature dependence:
-            k(T) = k(T_ref) * (1 + coeff * (T - T_ref))
+        Precedence (per ADR-0003): `_curve` (#148) > legacy `_ref_temp +
+        _coeff` linear > scalar.
 
         Args:
             temp: Temperature as Pint Quantity in Kelvin (e.g., 373.15 * ureg.kelvin)
@@ -198,6 +240,15 @@ class ThermalProperties:
         Raises:
             ValueError: If temperature is not in Kelvin or calculation fails
         """
+        # #148 curve takes precedence over legacy ref_temp+coeff.
+        if self.thermal_conductivity_curve is not None:
+            return _eval_curve_or_scalar(
+                self.thermal_conductivity_curve,
+                self.thermal_conductivity,
+                self.thermal_conductivity_unit,
+                temp,
+            )
+
         if self.thermal_conductivity is None:
             return None
 
@@ -227,6 +278,18 @@ class ThermalProperties:
         k_ref = self.thermal_conductivity * ureg(self.thermal_conductivity_unit)
         return k_ref * (1 + coeff * delta_t_k)
 
+    def specific_heat_at(self, temp: "Quantity") -> Optional["Quantity"]:
+        """Specific heat at T. Curve > scalar fallback (#148)."""
+        return _eval_curve_or_scalar(
+            self.specific_heat_curve, self.specific_heat, self.specific_heat_unit, temp
+        )
+
+    def thermal_expansion_at(self, temp: "Quantity") -> Optional["Quantity"]:
+        """Thermal expansion at T. Curve > scalar fallback (#148)."""
+        return _eval_curve_or_scalar(
+            self.thermal_expansion_curve, self.thermal_expansion, self.thermal_expansion_unit, temp
+        )
+
 
 @dataclass
 class ElectricalProperties:
@@ -242,6 +305,15 @@ class ElectricalProperties:
     breakdown_voltage_unit: str = "kV/mm"
     volume_resistivity: Optional[float] = None  # Ω·cm
     volume_resistivity_unit: str = "ohm*cm"
+
+    # T-dependent curve (#148).
+    resistivity_curve: Optional[TempCurve] = None
+
+    def resistivity_at(self, temp: "Quantity") -> Optional["Quantity"]:
+        """Resistivity at T. Curve > scalar fallback (#148)."""
+        return _eval_curve_or_scalar(
+            self.resistivity_curve, self.resistivity, self.resistivity_unit, temp
+        )
 
     # Quantity properties for unit-aware access
     @property
@@ -300,6 +372,24 @@ class OpticalProperties:
     interaction_length: Optional[float] = None  # cm (λ for hadrons)
     moliere_radius: Optional[float] = None  # cm
     energy_resolution: Optional[float] = None  # % at 1 MeV (for detectors)
+
+    # T-dependent curves (#148). Refractive index, light yield, decay time
+    # are the dimensionless / unit-implicit ones — no `_unit` field exists.
+    refractive_index_curve: Optional[TempCurve] = None
+    light_yield_curve: Optional[TempCurve] = None
+    decay_time_curve: Optional[TempCurve] = None
+
+    def refractive_index_at(self, temp: "Quantity") -> Optional[float]:
+        """Refractive index at T. Curve > scalar fallback (#148)."""
+        return _eval_curve_or_scalar(self.refractive_index_curve, self.refractive_index, None, temp)
+
+    def light_yield_at(self, temp: "Quantity") -> Optional[float]:
+        """Light yield at T. Curve > scalar fallback (#148)."""
+        return _eval_curve_or_scalar(self.light_yield_curve, self.light_yield, None, temp)
+
+    def decay_time_at(self, temp: "Quantity") -> Optional[float]:
+        """Scintillator decay time at T. Curve > scalar fallback (#148)."""
+        return _eval_curve_or_scalar(self.decay_time_curve, self.decay_time, None, temp)
 
 
 @dataclass

--- a/tests/test_temp_curves.py
+++ b/tests/test_temp_curves.py
@@ -1,0 +1,235 @@
+"""Tests for #148 — `<prop>_curve` temperature-dependent property curves.
+
+Per ADR-0003:
+- New `TempCurve` dataclass on `pymat.curves`.
+- New `<prop>_curve: Optional[TempCurve]` sibling fields on the dataclasses
+  for: thermal_conductivity, specific_heat, thermal_expansion,
+  youngs_modulus, yield_strength, resistivity, refractive_index,
+  light_yield, decay_time.
+- Loader parses `<prop>_curve = {temps_K=[...], values=[...]}`.
+- `_at(T)` evaluators on each dataclass: curve > legacy ref_temp+coeff > scalar.
+- Edge cases pinned: clamp out-of-range, raise on unsorted/mismatched at load.
+"""
+
+from __future__ import annotations
+
+from textwrap import dedent
+
+import pytest
+
+from pymat.curves import TempCurve
+from pymat.loader import load_toml
+from pymat.units import ureg
+
+
+class TestTempCurveInterpolation:
+    def test_exact_knot_returns_knot_value(self):
+        c = TempCurve(temps_K=[100, 200, 300], values=[1.0, 2.0, 3.0])
+        assert c.interpolate(200.0) == pytest.approx(2.0)
+
+    def test_between_knots_linear_interp(self):
+        c = TempCurve(temps_K=[100, 200], values=[1.0, 2.0])
+        assert c.interpolate(150.0) == pytest.approx(1.5)
+
+    def test_below_min_clamps(self):
+        c = TempCurve(temps_K=[100, 200], values=[5.0, 10.0])
+        assert c.interpolate(50.0) == 5.0  # clamped to min knot value
+
+    def test_above_max_clamps(self):
+        c = TempCurve(temps_K=[100, 200], values=[5.0, 10.0])
+        assert c.interpolate(500.0) == 10.0  # clamped to max knot value
+
+    def test_single_point_curve_returns_constant(self):
+        c = TempCurve(temps_K=[293.15], values=[7.5])
+        assert c.interpolate(77.0) == 7.5
+        assert c.interpolate(293.15) == 7.5
+        assert c.interpolate(500.0) == 7.5
+
+    def test_unsorted_temps_raises_at_construction(self):
+        with pytest.raises(ValueError, match="sorted"):
+            TempCurve(temps_K=[200, 100, 300], values=[1.0, 2.0, 3.0])
+
+    def test_mismatched_lengths_raises_at_construction(self):
+        with pytest.raises(ValueError, match="length"):
+            TempCurve(temps_K=[100, 200, 300], values=[1.0, 2.0])
+
+    def test_empty_curve_raises_at_construction(self):
+        with pytest.raises(ValueError, match="at least one"):
+            TempCurve(temps_K=[], values=[])
+
+
+class TestLoaderParsesCurves:
+    def test_loads_thermal_conductivity_curve(self, tmp_path):
+        p = tmp_path / "m.toml"
+        p.write_text(
+            dedent("""
+            [aluminum]
+            name = "Aluminum"
+            [aluminum.thermal]
+            thermal_conductivity_value = 167
+            thermal_conductivity_unit = "W/(m*K)"
+            thermal_conductivity_curve = { temps_K = [77, 200, 293, 400], values = [105, 150, 167, 180] }
+            """)
+        )
+        al = load_toml(p)["aluminum"]
+        c = al.properties.thermal.thermal_conductivity_curve
+        assert isinstance(c, TempCurve)
+        assert c.temps_K == [77, 200, 293, 400]
+        assert c.values == [105, 150, 167, 180]
+        # Scalar still set, untouched.
+        assert al.properties.thermal.thermal_conductivity == 167
+
+    def test_curve_without_scalar_loads(self, tmp_path):
+        """A curve alone is valid — the scalar field stays None."""
+        p = tmp_path / "m.toml"
+        p.write_text(
+            dedent("""
+            [lyso]
+            name = "LYSO"
+            [lyso.optical]
+            light_yield_curve = { temps_K = [233, 293, 313], values = [38000, 33000, 32000] }
+            """)
+        )
+        lyso = load_toml(p)["lyso"]
+        c = lyso.properties.optical.light_yield_curve
+        assert isinstance(c, TempCurve)
+        assert lyso.properties.optical.light_yield is None
+
+    def test_invalid_curve_raises_at_load(self, tmp_path):
+        p = tmp_path / "m.toml"
+        p.write_text(
+            dedent("""
+            [bad]
+            name = "Bad"
+            [bad.thermal]
+            thermal_conductivity_curve = { temps_K = [200, 100, 300], values = [1.0, 2.0, 3.0] }
+            """)
+        )
+        with pytest.raises(ValueError, match="sorted"):
+            load_toml(p)
+
+    def test_curve_field_on_unknown_prop_silently_ignored(self, tmp_path):
+        """A curve for a non-existent property is silently ignored
+        (consistent with hasattr-based assignment)."""
+        p = tmp_path / "m.toml"
+        p.write_text(
+            dedent("""
+            [m]
+            name = "M"
+            [m.thermal]
+            no_such_property_curve = { temps_K = [100, 200], values = [1.0, 2.0] }
+            """)
+        )
+        # Must not raise
+        load_toml(p)
+
+
+class TestEvaluatorsCurveFirst:
+    def test_thermal_conductivity_at_uses_curve_when_present(self, tmp_path):
+        p = tmp_path / "m.toml"
+        p.write_text(
+            dedent("""
+            [al]
+            name = "Aluminum"
+            [al.thermal]
+            thermal_conductivity_value = 167
+            thermal_conductivity_unit = "W/(m*K)"
+            thermal_conductivity_curve = { temps_K = [77, 293], values = [105, 167] }
+            """)
+        )
+        al = load_toml(p)["al"]
+        # At 77 K, curve says 105.
+        k77 = al.properties.thermal.thermal_conductivity_at(77 * ureg.kelvin)
+        assert k77.to("W/(m*K)").magnitude == pytest.approx(105)
+        # At midpoint, linear interp.
+        k185 = al.properties.thermal.thermal_conductivity_at(185 * ureg.kelvin)
+        # midpoint of [77,293] is 185, midpoint of [105,167] is 136
+        assert k185.to("W/(m*K)").magnitude == pytest.approx(136, rel=0.01)
+
+    def test_thermal_conductivity_at_falls_back_to_scalar(self, tmp_path):
+        """Regression — when no curve and no coeff, return the scalar value
+        regardless of T (existing behavior preserved)."""
+        p = tmp_path / "m.toml"
+        p.write_text(
+            dedent("""
+            [steel]
+            name = "Steel"
+            [steel.thermal]
+            thermal_conductivity_value = 15.1
+            thermal_conductivity_unit = "W/(m*K)"
+            """)
+        )
+        steel = load_toml(p)["steel"]
+        k = steel.properties.thermal.thermal_conductivity_at(373.15 * ureg.kelvin)
+        # No curve, no coeff → return scalar (legacy behavior, coeff=0)
+        assert k.to("W/(m*K)").magnitude == pytest.approx(15.1)
+
+    def test_legacy_ref_temp_coeff_still_works(self, tmp_path):
+        """Regression — existing TOMLs using ref_temp + coeff continue to work."""
+        p = tmp_path / "m.toml"
+        p.write_text(
+            dedent("""
+            [m]
+            name = "M"
+            [m.thermal]
+            thermal_conductivity_value = 100
+            thermal_conductivity_unit = "W/(m*K)"
+            thermal_conductivity_ref_temp = 20
+            thermal_conductivity_coeff = 0.001
+            """)
+        )
+        m = load_toml(p)["m"]
+        k_ref = m.properties.thermal.thermal_conductivity_at(293.15 * ureg.kelvin)
+        # T_ref = 20°C = 293.15 K, delta_T = 0 → k = 100
+        assert k_ref.to("W/(m*K)").magnitude == pytest.approx(100)
+
+
+class TestNewAtMethods:
+    """The other 8 properties should also support `_at(T)` lookups."""
+
+    @pytest.mark.parametrize(
+        "group,prop,unit_str",
+        [
+            ("thermal", "specific_heat", "J/(kg*K)"),
+            ("thermal", "thermal_expansion", "1/K"),
+            ("mechanical", "youngs_modulus", "GPa"),
+            ("mechanical", "yield_strength", "MPa"),
+            ("electrical", "resistivity", "ohm*m"),
+            ("optical", "light_yield", None),  # dimensionless / no _unit field
+            ("optical", "decay_time", None),
+            ("optical", "refractive_index", None),
+        ],
+    )
+    def test_each_property_has_at_method(self, tmp_path, group, prop, unit_str):
+        unit_line = f'{prop}_unit = "{unit_str}"' if unit_str else ""
+        p = tmp_path / "m.toml"
+        p.write_text(
+            dedent(f"""
+            [m]
+            name = "M"
+            [m.{group}]
+            {prop}_value = 100.0
+            {unit_line}
+            {prop}_curve = {{ temps_K = [100, 200, 300], values = [80.0, 100.0, 120.0] }}
+            """)
+        )
+        m = load_toml(p)["m"]
+        getter = getattr(getattr(m.properties, group), f"{prop}_at")
+        v = getter(150.0 * ureg.kelvin)
+        # Linear midpoint of [80,100] at midpoint of [100,200] is 90.
+        magnitude = v.to(unit_str).magnitude if unit_str else v
+        assert magnitude == pytest.approx(90.0)
+
+
+class TestRegressionCurveAbsent:
+    """When no _curve is present, behavior is identical to today."""
+
+    def test_full_corpus_loads_without_curves(self, tmp_path):
+        """No TOML in src/pymat/data/ has _curve fields yet; the loader
+        must not regress on the full corpus."""
+        from pymat import _CATEGORY_BASES
+        from pymat.loader import load_category
+
+        for cat in _CATEGORY_BASES:
+            mats = load_category(cat)
+            assert mats, f"category {cat} loaded empty"

--- a/tests/test_temp_curves.py
+++ b/tests/test_temp_curves.py
@@ -68,7 +68,9 @@ class TestLoaderParsesCurves:
             [aluminum.thermal]
             thermal_conductivity_value = 167
             thermal_conductivity_unit = "W/(m*K)"
-            thermal_conductivity_curve = { temps_K = [77, 200, 293, 400], values = [105, 150, 167, 180] }
+            [aluminum.thermal.thermal_conductivity_curve]
+            temps_K = [77, 200, 293, 400]
+            values = [105, 150, 167, 180]
             """)
         )
         al = load_toml(p)["aluminum"]


### PR DESCRIPTION
## Summary

Adds `<prop>_curve = {temps_K = [...], values = [...]}` TOML support with linear interpolation for **9 properties**: `thermal_conductivity`, `specific_heat`, `thermal_expansion`, `youngs_modulus`, `yield_strength`, `resistivity`, `refractive_index`, `light_yield`, `decay_time`.

```toml
[aluminum.al6061.thermal]
thermal_conductivity_value = 167
thermal_conductivity_unit = "W/(m*K)"
thermal_conductivity_curve = { temps_K = [77, 200, 293, 400, 500], values = [105, 150, 167, 180, 192] }
```

```python
from pymat.units import ureg
mat.properties.thermal.thermal_conductivity_at(77 * ureg.kelvin)  # → 105 W/(m·K) Quantity
mat.properties.optical.light_yield_at(233 * ureg.kelvin)          # LYSO at -40 °C → +15% boost
```

## Changes

| File | What |
|---|---|
| `src/pymat/curves.py` (new) | `TempCurve` frozen dataclass with `interpolate(T)`, validation at construction |
| `src/pymat/properties.py` | 9 new `<prop>_curve` sibling fields + 8 new `<prop>_at(T)` methods + 1 updated (thermal_conductivity_at) + shared `_eval_curve_or_scalar` helper |
| `src/pymat/loader.py` | New `_curve` branch in `update_properties` — builds `TempCurve.from_toml()` when key ends in `_curve` and value is a dict |
| `tests/test_temp_curves.py` (new) | 24 tests: TempCurve interp + edge cases, loader, evaluators, parametrized 8-property check, regression |

## Edge cases (per ADR-0003 §2 — pinned)

| Case | Behavior |
|---|---|
| T at exact knot | Return knot value |
| T between knots | Linear interp |
| T below min knot | **Clamp** to min (debug log) |
| T above max knot | **Clamp** to max (debug log) |
| Curve with 1 point | Return that constant for any T |
| Curve absent | Fall back to scalar |
| Unsorted / mismatched / empty | **Raise at load time** (TempCurve.__post_init__) |
| Curve for unknown property | Silently ignored (consistent with hasattr-based assignment) |

## Backwards compatibility

- `thermal_conductivity_at(T)` precedence: **curve > legacy `_ref_temp + _coeff` linear > scalar**. The legacy `_ref_temp / _coeff` fields stay; existing TOMLs using them continue to work unchanged (regression test included).
- Scalar field stays a scalar — never promoted to a callable (would break `*_qty` Pint properties and JSON serialization).
- Existing TOMLs without `_curve` fields: fully backwards-compatible, full corpus loads (regression test included).

## Deferred

`mat.at(T=...)` view (mentioned in ADR-0003 §2) is **not in this PR**. The issue text only requires "linear interpolation in `properties.py`"; the per-dataclass `_at(T)` methods satisfy that. The view adds API surface without unblocking downstream work — split into a follow-up if/when needed.

## Test plan

- [x] `pytest tests/test_temp_curves.py` — 24 tests pass
- [x] `pytest tests/test_temp_curves.py tests/test_check_licenses.py tests/test_sources.py tests/test_stddev_sugar.py` — all 67 foundation tests pass together
- [x] Full suite: 524 passed, 11 skipped, zero regressions
- [x] `ruff check` clean, `ruff format` no diff

## Risks / regressions considered

1. **`_curve` keys leaking into `_value` parsing path** — handled by explicit `_curve` branch with `continue` before the `_value` branch.
2. **`<prop>_curve` field-existence check** — uses `hasattr(prop_obj, curve_field)` so a curve for a non-existent prop is silently dropped (matches existing assignment semantics; explicit test).
3. **`numpy` dependency** — implementation uses pure Python (no numpy import). No new transitive deps.
4. **Pint Quantity behavior with curve values** — evaluators return `value * ureg(unit)` exactly as `*_qty` properties do; no new Quantity-shape surprises.
5. **TempCurve frozen dataclass + list fields** — `frozen=True` prevents reassignment, but lists inside are still mutable; per-call `interpolate(T)` is read-only so this is safe in practice (and `from_toml` defensively copies via `list(...)`).

Closes #148
**Schema foundation series complete:** #150 (merged) → #149 (merged) → #174 (merged) → **#148** (this PR).