### PR TITLE
fix(vis): declare Vis as public API (3.9.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.9.1] - 2026-05-06
+
+Public-API contract clarification — no code change, just metadata +
+docs catching up to facts.
+
+### Fixed
+
+* **`Vis` is officially a public class**
+  ([#98](https://github.com/MorePET/mat/issues/98) /
+  [mat-vis #282](https://github.com/MorePET/mat-vis/issues/282)).
+  `Vis`, `VisDeltas`, and `FinishEntry` have been re-exported from
+  `pymat.vis` since 3.4 / 3.6 / 3.8 respectively, but their
+  `__module__` attribute still pointed at the private `pymat.vis._model`
+  location — so `type(material.vis)`, `repr`, IDE auto-import
+  suggestions, and Sphinx cross-references all surfaced the
+  underscore-prefixed path, pushing downstream code (build123d,
+  ocp_vscode) toward `from pymat.vis._model import Vis`. The
+  re-export site now rewrites `__module__` to `"pymat.vis"`, and the
+  `pymat.vis` docstring documents the public-API contract explicitly:
+  field names and constructor signatures of `Vis` / `VisDeltas` /
+  `FinishEntry` follow semver. The `Vis` field set mirrors glTF 2.0 /
+  Three.js MeshPhysicalMaterial — a stable external spec, so the
+  freeze cost is intentionally low. Underscore-prefixed names
+  (`Vis._finish`, `Vis._textures`, `pymat.vis._model`,
+  `pymat.vis._client`) remain private and may change without notice.
+
+  Pinned by `tests/test_vis.py::TestPublicApiContract` so a future
+  refactor that moves the implementation can't silently regress the
+  public path.
+
 ## [3.9.0] - 2026-05-05
 
 Two UX fixes surfaced via live MCP testing of the new

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "py-materials"
-version = "3.9.0"
+version = "3.9.1"
 description = "Hierarchical material library for CAD applications with build123d integration"
 readme = "README.md"
 license = "MIT"

--- a/src/pymat/__init__.py
+++ b/src/pymat/__init__.py
@@ -57,7 +57,7 @@ from .properties import (
 from .search import search
 from .units import ureg
 
-__version__ = "3.9.0"  # x-release-please-version
+__version__ = "3.9.1"  # x-release-please-version
 __all__ = [
     "Material",
     "AllProperties",

--- a/src/pymat/vis/__init__.py
+++ b/src/pymat/vis/__init__.py
@@ -69,6 +69,15 @@ from mat_vis_client import search as _client_search
 # without reaching into the private ``_model`` module.
 from pymat.vis._model import FinishEntry, Vis, VisDeltas
 
+# Material-accepting adapters: Three.js / glTF / MaterialX.
+# Re-exported at top level so ``from pymat.vis import to_threejs`` works
+# and tab completion on ``pymat.vis.`` surfaces the main cross-tool
+# handoff. Note: ``pymat.vis.adapters`` resolves to the local submodule
+# (Material signatures). Users who want mat-vis-client's primitive-
+# signature adapters (``(scalars_dict, textures_dict)``) should import
+# them explicitly: ``from mat_vis_client import adapters``.
+from pymat.vis.adapters import export_mtlx, to_gltf, to_threejs
+
 # Rewrite ``__module__`` to the public path. Without this,
 # ``type(m.vis)``, ``repr``, IDE auto-import, and Sphinx all surface
 # ``pymat.vis._model.Vis`` — the underscore-prefixed location reads as
@@ -79,15 +88,6 @@ from pymat.vis._model import FinishEntry, Vis, VisDeltas
 Vis.__module__ = "pymat.vis"
 VisDeltas.__module__ = "pymat.vis"
 FinishEntry.__module__ = "pymat.vis"
-
-# Material-accepting adapters: Three.js / glTF / MaterialX.
-# Re-exported at top level so ``from pymat.vis import to_threejs`` works
-# and tab completion on ``pymat.vis.`` surfaces the main cross-tool
-# handoff. Note: ``pymat.vis.adapters`` resolves to the local submodule
-# (Material signatures). Users who want mat-vis-client's primitive-
-# signature adapters (``(scalars_dict, textures_dict)``) should import
-# them explicitly: ``from mat_vis_client import adapters``.
-from pymat.vis.adapters import export_mtlx, to_gltf, to_threejs
 
 
 def fetch(

--- a/src/pymat/vis/__init__.py
+++ b/src/pymat/vis/__init__.py
@@ -24,6 +24,30 @@ Public API — all functions importable from ``pymat.vis`` directly::
 
 Powered by ``mat-vis-client`` (separate PyPI package). ``Material.vis``
 wires into this module for lazy texture loading; see ADR-0002.
+
+Public API contract
+-------------------
+The following names are part of the public API. Import them from
+``pymat.vis`` (not from any underscore-prefixed submodule) — the
+canonical module path is rewritten on the classes themselves so that
+``type(m.vis)``, ``repr``, IDE auto-imports, and Sphinx all surface
+``pymat.vis.Vis`` rather than the private ``_model`` location:
+
+- **Types**: ``Vis``, ``VisDeltas``, ``FinishEntry``
+- **Adapters**: ``to_threejs``, ``to_gltf``, ``export_mtlx``
+- **Discovery / fetch**: ``search``, ``fetch``, ``prefetch``,
+  ``rowmap_entry``, ``get_manifest``, ``seed_indexes``, ``client``,
+  ``MatVisClient``
+
+Stability promise: field names and constructor signatures of the public
+types follow semver — additive changes (new optional fields with
+defaults) are minor; renames or removals require a major bump with a
+deprecation cycle. The ``Vis`` field set mirrors the glTF 2.0 /
+Three.js MeshPhysicalMaterial spec, so it is intentionally stable.
+
+Underscore-prefixed names (``Vis._finish``, ``Vis._textures``,
+``pymat.vis._model``, ``pymat.vis._client``, etc.) remain private and
+may change without notice.
 """
 
 from typing import Any
@@ -44,6 +68,17 @@ from mat_vis_client import search as _client_search
 # Domain types: re-exported so consumers can construct or type-hint
 # without reaching into the private ``_model`` module.
 from pymat.vis._model import FinishEntry, Vis, VisDeltas
+
+# Rewrite ``__module__`` to the public path. Without this,
+# ``type(m.vis)``, ``repr``, IDE auto-import, and Sphinx all surface
+# ``pymat.vis._model.Vis`` — the underscore-prefixed location reads as
+# private and pushes downstream code (build123d, mat-vis #282, py-mat
+# #98) toward an import path we don't want to support. Public API
+# contract: import from ``pymat.vis``; the type's own metadata now
+# agrees.
+Vis.__module__ = "pymat.vis"
+VisDeltas.__module__ = "pymat.vis"
+FinishEntry.__module__ = "pymat.vis"
 
 # Material-accepting adapters: Three.js / glTF / MaterialX.
 # Re-exported at top level so ``from pymat.vis import to_threejs`` works

--- a/tests/test_vis.py
+++ b/tests/test_vis.py
@@ -747,6 +747,7 @@ class TestVisModuleApi:
         assert hasattr(vis, "rowmap_entry")
         assert hasattr(vis, "get_manifest")
 
+
     def test_get_manifest_returns_dict(self):
         from pymat import vis
 
@@ -891,3 +892,45 @@ class TestVisModuleApi:
         sentinel = object()
         monkeypatch.setattr(_client, "_client", sentinel)
         assert vis.client() is sentinel
+
+
+class TestPublicApiContract:
+    """``Vis`` / ``VisDeltas`` / ``FinishEntry`` are the public domain
+    types. Their canonical import path is ``pymat.vis``, not the
+    underscore-prefixed ``pymat.vis._model``. Closes #98 / mat-vis #282.
+
+    The ``__module__`` attribute is what ``type()``, ``repr``, IDE
+    auto-import suggestions, and Sphinx cross-references read — so
+    it has to agree with the public re-export, otherwise users get
+    pushed toward the private path even though we declared the type
+    public. A future refactor that moves the implementation must keep
+    these assertions green by re-pinning ``__module__`` at the public
+    re-export site.
+    """
+
+    def test_vis_module_path_is_public(self):
+        from pymat.vis import Vis
+
+        assert Vis.__module__ == "pymat.vis", (
+            f"Vis.__module__ leaks the private location {Vis.__module__!r}; "
+            "users get pushed toward 'from pymat.vis._model import Vis'."
+        )
+
+    def test_visdeltas_module_path_is_public(self):
+        from pymat.vis import VisDeltas
+
+        assert VisDeltas.__module__ == "pymat.vis"
+
+    def test_finishentry_module_path_is_public(self):
+        from pymat.vis import FinishEntry
+
+        assert FinishEntry.__module__ == "pymat.vis"
+
+    def test_repr_uses_public_path(self):
+        """``type(material.vis)`` is what users see in tracebacks and
+        REPLs — it must read as the public path."""
+        from pymat import stainless
+
+        # ``type(...).__module__`` flows from the class attribute we
+        # rewrote, so this is a behavioral pin on top of the metadata.
+        assert type(stainless.vis).__module__ == "pymat.vis"

--- a/tests/test_vis.py
+++ b/tests/test_vis.py
@@ -747,7 +747,6 @@ class TestVisModuleApi:
         assert hasattr(vis, "rowmap_entry")
         assert hasattr(vis, "get_manifest")
 
-
     def test_get_manifest_returns_dict(self):
         from pymat import vis
 

--- a/uv.lock
+++ b/uv.lock
@@ -1311,7 +1311,7 @@ wheels = [
 
 [[package]]
 name = "py-materials"
-version = "3.9.0"
+version = "3.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "mat-vis-client" },


### PR DESCRIPTION
## Summary

- Rewrites `Vis.__module__` / `VisDeltas.__module__` / `FinishEntry.__module__` to `"pymat.vis"` at the public re-export site, so `type(material.vis)`, `repr`, IDE auto-import suggestions, and Sphinx cross-references stop pointing at the private `pymat.vis._model` location.
- Adds a "Public API contract" section to the `pymat.vis` module docstring: field names and constructor signatures of `Vis` / `VisDeltas` / `FinishEntry` follow semver. The `Vis` field set mirrors glTF 2.0 / Three.js MeshPhysicalMaterial — stable external spec, low freeze cost.
- Pins the contract with `tests/test_vis.py::TestPublicApiContract` (4 tests).

No code change, no API change — metadata + docs catching up to facts. The classes have been in `pymat.vis.__all__` for three minor versions; this release just stops the underscore-prefixed import path from looking like the canonical one.

## Why

Bernhard hit this in build123d#1270 and filed [mat-vis #282](https://github.com/MorePET/mat-vis/issues/282) cross-referencing our [#98](https://github.com/MorePET/mat/issues/98). Closing both with a stake-in-the-ground rather than another quiet release.

## Test plan

- [x] `uv run pytest` — 576 passed, 18 skipped
- [x] New: `TestPublicApiContract::test_vis_module_path_is_public`
- [x] New: `TestPublicApiContract::test_visdeltas_module_path_is_public`
- [x] New: `TestPublicApiContract::test_finishentry_module_path_is_public`
- [x] New: `TestPublicApiContract::test_repr_uses_public_path` (behavioral pin via `type(stainless.vis).__module__`)

## After merge

release-please picks up the `fix:` commit → opens / updates Release PR → tag → PyPI publish via `release.yml` (OIDC trusted publisher).

Closes #98
Refs https://github.com/MorePET/mat-vis/issues/282