### PR TITLE
feat(schema): mechanical sub-table additions (#151)

### DIFF
--- a/src/pymat/properties.py
+++ b/src/pymat/properties.py
@@ -15,7 +15,7 @@ Organized by physical/engineering domain:
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 if TYPE_CHECKING:
     from pint import Quantity
@@ -66,6 +66,22 @@ class MechanicalProperties:
     hardness_rockwell: Optional[float] = None  # HR (Rockwell hardness)
     fracture_toughness: Optional[float] = None  # MPa·m^0.5
     fracture_toughness_unit: str = "MPa*m^0.5"
+
+    # Plastics & ceramics flexural performance (#151)
+    flexural_modulus: Optional[float] = None  # MPa
+    flexural_modulus_unit: str = "MPa"
+    flexural_strength: Optional[float] = None  # MPa
+    flexural_strength_unit: str = "MPa"
+    # Cyclic-load endurance (#151)
+    fatigue_limit: Optional[float] = None  # MPa
+    fatigue_limit_unit: str = "MPa"
+    # Comparative tracking index for PCB substrates (#151)
+    cti: Optional[float] = None  # V
+    cti_unit: str = "V"
+    # Anisotropic CTE for non-cubic crystals like sapphire/quartz (#151)
+    cte_anisotropic: Optional[List[float]] = None  # [a, b, c] in ppm/K
+    # Sparse creep-rate measurements: list of {temp_K, stress_MPa, strain_per_hr} (#151)
+    creep_rate: Optional[List[Dict[str, float]]] = None
 
     # T-dependent curves (#148). Sibling fields parallel to scalars.
     youngs_modulus_curve: Optional[TempCurve] = None
@@ -132,6 +148,30 @@ class MechanicalProperties:
         if self.fracture_toughness is None:
             return None
         return self.fracture_toughness * ureg(self.fracture_toughness_unit)
+
+    @property
+    def flexural_modulus_qty(self) -> Optional[Quantity]:
+        if self.flexural_modulus is None:
+            return None
+        return self.flexural_modulus * ureg(self.flexural_modulus_unit)
+
+    @property
+    def flexural_strength_qty(self) -> Optional[Quantity]:
+        if self.flexural_strength is None:
+            return None
+        return self.flexural_strength * ureg(self.flexural_strength_unit)
+
+    @property
+    def fatigue_limit_qty(self) -> Optional[Quantity]:
+        if self.fatigue_limit is None:
+            return None
+        return self.fatigue_limit * ureg(self.fatigue_limit_unit)
+
+    @property
+    def cti_qty(self) -> Optional[Quantity]:
+        if self.cti is None:
+            return None
+        return self.cti * ureg(self.cti_unit)
 
 
 @dataclass

--- a/tests/test_mechanical_fields.py
+++ b/tests/test_mechanical_fields.py
@@ -1,0 +1,146 @@
+"""Tests for #151 — mechanical sub-table additions.
+
+Pure additive: 5 new scalar/list fields on `MechanicalProperties`.
+- `flexural_modulus` / `flexural_strength` (MPa)
+- `fatigue_limit` (MPa)
+- `cte_anisotropic = [a, b, c]` (ppm/K, list-of-3 for non-cubic crystals)
+- `creep_rate = [{temp_K, stress_MPa, strain_per_hr}, ...]` (sparse points)
+- `cti` (V)
+
+No build123d-visible behavior change. No backwards-compat concern (additive).
+"""
+
+from __future__ import annotations
+
+from textwrap import dedent
+
+from pymat.loader import load_toml
+
+
+class TestNewMechanicalFields:
+    def test_flexural_modulus_loads(self, tmp_path):
+        p = tmp_path / "m.toml"
+        p.write_text(
+            dedent("""
+            [m]
+            name = "M"
+            [m.mechanical]
+            flexural_modulus_value = 3500
+            flexural_modulus_unit = "MPa"
+            flexural_strength_value = 95
+            flexural_strength_unit = "MPa"
+            """)
+        )
+        m = load_toml(p)["m"]
+        assert m.properties.mechanical.flexural_modulus == 3500
+        assert m.properties.mechanical.flexural_modulus_unit == "MPa"
+        assert m.properties.mechanical.flexural_strength == 95
+
+    def test_fatigue_limit_loads(self, tmp_path):
+        p = tmp_path / "m.toml"
+        p.write_text(
+            dedent("""
+            [m]
+            name = "M"
+            [m.mechanical]
+            fatigue_limit_value = 200
+            fatigue_limit_unit = "MPa"
+            """)
+        )
+        m = load_toml(p)["m"]
+        assert m.properties.mechanical.fatigue_limit == 200
+
+    def test_cte_anisotropic_loads_as_list(self, tmp_path):
+        """Sapphire / quartz have direction-dependent CTE."""
+        p = tmp_path / "m.toml"
+        p.write_text(
+            dedent("""
+            [sapphire]
+            name = "Sapphire"
+            [sapphire.mechanical]
+            cte_anisotropic = [5.3, 5.3, 6.2]
+            """)
+        )
+        sap = load_toml(p)["sapphire"]
+        assert sap.properties.mechanical.cte_anisotropic == [5.3, 5.3, 6.2]
+
+    def test_creep_rate_sparse_points(self, tmp_path):
+        p = tmp_path / "m.toml"
+        p.write_text(
+            dedent("""
+            [m]
+            name = "M"
+            [m.mechanical]
+            creep_rate = [
+              { temp_K = 77, stress_MPa = 100, strain_per_hr = 1e-9 },
+              { temp_K = 293, stress_MPa = 100, strain_per_hr = 5e-7 },
+              { temp_K = 293, stress_MPa = 200, strain_per_hr = 8e-6 },
+            ]
+            """)
+        )
+        m = load_toml(p)["m"]
+        cr = m.properties.mechanical.creep_rate
+        assert isinstance(cr, list)
+        assert len(cr) == 3
+        assert cr[0] == {"temp_K": 77, "stress_MPa": 100, "strain_per_hr": 1e-9}
+
+    def test_cti_loads(self, tmp_path):
+        """CTI for PCB substrate selection (V)."""
+        p = tmp_path / "m.toml"
+        p.write_text(
+            dedent("""
+            [fr4]
+            name = "FR4"
+            [fr4.mechanical]
+            cti_value = 175
+            cti_unit = "V"
+            """)
+        )
+        fr4 = load_toml(p)["fr4"]
+        assert fr4.properties.mechanical.cti == 175
+
+    def test_pint_qty_for_new_scalars(self, tmp_path):
+        """The `*_qty` accessors should also work for the new scalar fields."""
+        p = tmp_path / "m.toml"
+        p.write_text(
+            dedent("""
+            [m]
+            name = "M"
+            [m.mechanical]
+            flexural_modulus_value = 3500
+            flexural_modulus_unit = "MPa"
+            fatigue_limit_value = 200
+            fatigue_limit_unit = "MPa"
+            cti_value = 175
+            cti_unit = "V"
+            """)
+        )
+        m = load_toml(p)["m"]
+        assert m.properties.mechanical.flexural_modulus_qty.to("MPa").magnitude == 3500
+        assert m.properties.mechanical.fatigue_limit_qty.to("MPa").magnitude == 200
+        assert m.properties.mechanical.cti_qty.to("V").magnitude == 175
+
+
+class TestRegression:
+    def test_full_corpus_loads(self):
+        """Adding new fields must not break loading any shipped TOML."""
+        from pymat import _CATEGORY_BASES
+        from pymat.loader import load_category
+
+        for cat in _CATEGORY_BASES:
+            mats = load_category(cat)
+            assert mats, f"category {cat} loaded empty"
+
+    def test_existing_density_unchanged(self, tmp_path):
+        p = tmp_path / "m.toml"
+        p.write_text(
+            dedent("""
+            [steel]
+            name = "Steel"
+            [steel.mechanical]
+            density_value = 7.85
+            density_unit = "g/cm^3"
+            """)
+        )
+        steel = load_toml(p)["steel"]
+        assert steel.properties.mechanical.density == 7.85


### PR DESCRIPTION
## Summary

Pure additive — 5 new optional fields on `MechanicalProperties`. No backwards-compat concern, no API surface change.

| Field | Unit | Use case |
|---|---|---|
| `flexural_modulus` | MPa | plastics & ceramics datasheets |
| `flexural_strength` | MPa | plastics & ceramics datasheets |
| `fatigue_limit` | MPa | cyclic gantry loads |
| `cti` | V | PCB substrate selection (Comparative Tracking Index) |
| `cte_anisotropic` | ppm/K | `[a, b, c]` for non-cubic crystals (sapphire, quartz) |
| `creep_rate` | — | `[{temp_K, stress_MPa, strain_per_hr}, ...]` sparse points for cryostat long-term loads |

Plus matching `*_qty` Pint-Quantity accessors for the 4 new scalar fields.

`creep_rate` is stored as a plain `list[dict]` rather than a new dataclass — points are sparse and heterogeneous; consumers index by temp/stress as needed. Promotable to a structured type later if a real consumer surfaces.

## Test plan

- [x] `pytest tests/test_mechanical_fields.py` — 8 tests pass
- [x] Full suite: 552 passed, 11 skipped, zero regressions
- [x] `ruff check` clean, `ruff format` no diff

Closes #151