### PR TITLE
feat(schema): electrical sub-table additions (#154)

### DIFF
--- a/src/pymat/properties.py
+++ b/src/pymat/properties.py
@@ -305,6 +305,12 @@ class ElectricalProperties:
     breakdown_voltage_unit: str = "kV/mm"
     volume_resistivity: Optional[float] = None  # Ω·cm
     volume_resistivity_unit: str = "ohm*cm"
+    # Surface resistivity, distinct from volume_resistivity (#154)
+    surface_resistivity: Optional[float] = None  # Ω/sq
+    surface_resistivity_unit: str = "ohm"
+    # Arc resistance for HV detector feedthroughs (#154)
+    arc_resistance: Optional[float] = None  # seconds
+    arc_resistance_unit: str = "s"
 
     # T-dependent curve (#148).
     resistivity_curve: Optional[TempCurve] = None
@@ -343,6 +349,18 @@ class ElectricalProperties:
         if self.volume_resistivity is None:
             return None
         return self.volume_resistivity * ureg(self.volume_resistivity_unit)
+
+    @property
+    def surface_resistivity_qty(self) -> Optional[Quantity]:
+        if self.surface_resistivity is None:
+            return None
+        return self.surface_resistivity * ureg(self.surface_resistivity_unit)
+
+    @property
+    def arc_resistance_qty(self) -> Optional[Quantity]:
+        if self.arc_resistance is None:
+            return None
+        return self.arc_resistance * ureg(self.arc_resistance_unit)
 
 
 @dataclass

--- a/tests/test_electrical_fields.py
+++ b/tests/test_electrical_fields.py
@@ -1,0 +1,67 @@
+"""Tests for #154 — electrical sub-table additions.
+
+Pure additive: 2 new optional fields on `ElectricalProperties`.
+- `surface_resistivity` (Ω/sq) — distinct from volume_resistivity
+- `arc_resistance` (s) — HV detector feedthroughs
+"""
+
+from __future__ import annotations
+
+from textwrap import dedent
+
+from pymat.loader import load_toml
+
+
+class TestNewElectricalFields:
+    def test_surface_resistivity_loads(self, tmp_path):
+        p = tmp_path / "m.toml"
+        p.write_text(
+            dedent("""
+            [m]
+            name = "M"
+            [m.electrical]
+            surface_resistivity_value = 1e12
+            surface_resistivity_unit = "ohm"
+            """)
+        )
+        m = load_toml(p)["m"]
+        assert m.properties.electrical.surface_resistivity == 1e12
+
+    def test_arc_resistance_loads(self, tmp_path):
+        p = tmp_path / "m.toml"
+        p.write_text(
+            dedent("""
+            [m]
+            name = "M"
+            [m.electrical]
+            arc_resistance_value = 180
+            arc_resistance_unit = "s"
+            """)
+        )
+        m = load_toml(p)["m"]
+        assert m.properties.electrical.arc_resistance == 180
+
+    def test_pint_qty(self, tmp_path):
+        p = tmp_path / "m.toml"
+        p.write_text(
+            dedent("""
+            [m]
+            name = "M"
+            [m.electrical]
+            surface_resistivity_value = 1e12
+            surface_resistivity_unit = "ohm"
+            arc_resistance_value = 180
+            arc_resistance_unit = "s"
+            """)
+        )
+        m = load_toml(p)["m"]
+        assert m.properties.electrical.surface_resistivity_qty.to("ohm").magnitude == 1e12
+        assert m.properties.electrical.arc_resistance_qty.to("s").magnitude == 180
+
+    def test_full_corpus_loads(self):
+        from pymat import _CATEGORY_BASES
+        from pymat.loader import load_category
+
+        for cat in _CATEGORY_BASES:
+            mats = load_category(cat)
+            assert mats, f"category {cat} loaded empty"


### PR DESCRIPTION
Pure additive — 2 fields on ElectricalProperties:

- `surface_resistivity` (Ω/sq) — distinct from volume_resistivity
- `arc_resistance` (s) — HV detector feedthroughs (ASTM D495)

Plus `*_qty` Pint accessors.

## Test plan
- [x] `pytest tests/test_electrical_fields.py` — 4 tests pass
- [x] Full corpus regression
- [x] `ruff check` clean

Closes #154