### PR TITLE
feat(schema): new [magnetic] sub-table (#155)

### DIFF
--- a/clients/python/pymat-mcp/src/pymat_mcp/tools.py
+++ b/clients/python/pymat-mcp/src/pymat_mcp/tools.py
@@ -39,6 +39,7 @@ _ALL_DOMAINS = (
     "thermal",
     "electrical",
     "optical",
+    "magnetic",
     "manufacturing",
     "compliance",
     "sourcing",

--- a/src/pymat/loader.py
+++ b/src/pymat/loader.py
@@ -227,6 +227,8 @@ def _build_properties_from_dict(
         update_properties(props.electrical, data["electrical"], "electrical")
     if "optical" in data:
         update_properties(props.optical, data["optical"], "optical")
+    if "magnetic" in data:
+        update_properties(props.magnetic, data["magnetic"], "magnetic")
     if "pbr" in data:
         raise ValueError(
             "TOML [pbr] section is no longer supported in 3.0. "
@@ -284,6 +286,7 @@ def _resolve_material_node(
                 "thermal",
                 "electrical",
                 "optical",
+                "magnetic",
                 "pbr",
                 "manufacturing",
                 "compliance",
@@ -351,6 +354,7 @@ def _resolve_material_node(
                 "thermal",
                 "electrical",
                 "optical",
+                "magnetic",
                 "pbr",
                 "manufacturing",
                 "compliance",

--- a/src/pymat/properties.py
+++ b/src/pymat/properties.py
@@ -433,6 +433,27 @@ class OpticalProperties:
 
 
 @dataclass
+class MagneticProperties:
+    """Magnetic behavior for MR-PET hybrid systems and shielding (#155).
+
+    χ < ~10 ppm is the null-artifact threshold for MR-PET. Cu (-9.6e-6),
+    Ti (-1.8e-6) are MR-safe; mu-metal (μr ≈ 20000) is the high-permeability
+    soft-magnetic shield.
+    """
+
+    susceptibility_volumetric: Optional[float] = None  # χ_v, SI, dimensionless
+    permeability_relative: Optional[float] = None  # μr, dimensionless
+    saturation_field: Optional[float] = None  # T, ferromagnetics only
+    saturation_field_unit: str = "T"
+
+    @property
+    def saturation_field_qty(self) -> Optional["Quantity"]:
+        if self.saturation_field is None:
+            return None
+        return self.saturation_field * ureg(self.saturation_field_unit)
+
+
+@dataclass
 class ManufacturingProperties:
     """Machinability, weldability, printability."""
 
@@ -560,6 +581,7 @@ class AllProperties:
     thermal: ThermalProperties = field(default_factory=ThermalProperties)
     electrical: ElectricalProperties = field(default_factory=ElectricalProperties)
     optical: OpticalProperties = field(default_factory=OpticalProperties)
+    magnetic: MagneticProperties = field(default_factory=MagneticProperties)
     manufacturing: ManufacturingProperties = field(default_factory=ManufacturingProperties)
     compliance: ComplianceProperties = field(default_factory=ComplianceProperties)
     sourcing: SourcingProperties = field(default_factory=SourcingProperties)

--- a/tests/test_magnetic_subtable.py
+++ b/tests/test_magnetic_subtable.py
@@ -1,0 +1,106 @@
+"""Tests for #155 — new `[<material>.magnetic]` sub-table.
+
+Required for MR-PET hybrid systems (need χ < ~10 ppm for null artifacts).
+3 fields: susceptibility_volumetric (χ_v, SI, dimensionless),
+permeability_relative (μr), saturation_field (T, ferromagnetics only).
+"""
+
+from __future__ import annotations
+
+from textwrap import dedent
+
+from pymat.loader import load_toml
+
+
+class TestMagneticSubtable:
+    def test_diamagnetic_copper(self, tmp_path):
+        """Cu: χ_v ≈ -9.6e-6 (diamagnetic). Required for MR-PET cryostats."""
+        p = tmp_path / "m.toml"
+        p.write_text(
+            dedent("""
+            [copper]
+            name = "Copper"
+            [copper.magnetic]
+            susceptibility_volumetric = -9.6e-6
+            permeability_relative = 0.999990
+            """)
+        )
+        cu = load_toml(p)["copper"]
+        assert cu.properties.magnetic.susceptibility_volumetric == -9.6e-6
+        assert cu.properties.magnetic.permeability_relative == 0.999990
+
+    def test_ferromagnetic_mu_metal(self, tmp_path):
+        """Mu-metal: μr ≈ 20000, saturation around 0.8 T."""
+        p = tmp_path / "m.toml"
+        p.write_text(
+            dedent("""
+            [mumetal]
+            name = "Mu-metal"
+            [mumetal.magnetic]
+            permeability_relative = 20000
+            saturation_field_value = 0.8
+            saturation_field_unit = "T"
+            """)
+        )
+        mu = load_toml(p)["mumetal"]
+        assert mu.properties.magnetic.permeability_relative == 20000
+        assert mu.properties.magnetic.saturation_field == 0.8
+
+    def test_pint_qty_for_saturation(self, tmp_path):
+        p = tmp_path / "m.toml"
+        p.write_text(
+            dedent("""
+            [m]
+            name = "M"
+            [m.magnetic]
+            saturation_field_value = 1.6
+            saturation_field_unit = "T"
+            """)
+        )
+        m = load_toml(p)["m"]
+        assert m.properties.magnetic.saturation_field_qty.to("T").magnitude == 1.6
+
+    def test_inheritance_through_magnetic(self, tmp_path):
+        """Children inherit parent magnetic block, can override."""
+        p = tmp_path / "m.toml"
+        p.write_text(
+            dedent("""
+            [iron]
+            name = "Iron"
+            [iron.magnetic]
+            permeability_relative = 5000
+
+            [iron.cold_rolled]
+            name = "Iron — cold rolled"
+            [iron.cold_rolled.magnetic]
+            permeability_relative = 1500
+            """)
+        )
+        mats = load_toml(p)
+        assert mats["iron"].properties.magnetic.permeability_relative == 5000
+        assert mats["iron"].cold_rolled.properties.magnetic.permeability_relative == 1500
+
+    def test_full_corpus_loads(self):
+        from pymat import _CATEGORY_BASES
+        from pymat.loader import load_category
+
+        for cat in _CATEGORY_BASES:
+            mats = load_category(cat)
+            assert mats, f"category {cat} loaded empty"
+
+    def test_default_magnetic_is_empty(self, tmp_path):
+        """A material with no [magnetic] block still gets a MagneticProperties()."""
+        p = tmp_path / "m.toml"
+        p.write_text(
+            dedent("""
+            [steel]
+            name = "Steel"
+            [steel.mechanical]
+            density_value = 7.85
+            density_unit = "g/cm^3"
+            """)
+        )
+        steel = load_toml(p)["steel"]
+        assert steel.properties.magnetic.susceptibility_volumetric is None
+        assert steel.properties.magnetic.permeability_relative is None
+        assert steel.properties.magnetic.saturation_field is None

--- a/tests/test_toml_integrity.py
+++ b/tests/test_toml_integrity.py
@@ -43,6 +43,7 @@ _KNOWN_GROUPS = {
     "thermal",
     "electrical",
     "optical",
+    "magnetic",
     "manufacturing",
     "compliance",
     "sourcing",


### PR DESCRIPTION
Pure additive — new `MagneticProperties` dataclass for MR-PET hybrid systems and shielding analysis.

| Field | Unit | Reference |
|---|---|---|
| `susceptibility_volumetric` | χ_v, SI dimensionless | Cu -9.6e-6, Ti -1.8e-6 |
| `permeability_relative` | μr dimensionless | Mu-metal +20000 |
| `saturation_field` | T (ferromagnetics) | + Pint accessor |

Wired through:
- `AllProperties.magnetic` field
- Loader dispatch + child-skip whitelist
- `test_toml_integrity._KNOWN_GROUPS`
- pymat-mcp `_ALL_DOMAINS`

## Test plan
- [x] `pytest tests/test_magnetic_subtable.py` — 6 tests pass
- [x] Full corpus regression via `test_toml_integrity`
- [x] `ruff check` clean

Closes #155