### PR TITLE
feat(schema): new [vacuum] sub-table (#156)

### DIFF
--- a/clients/python/pymat-mcp/src/pymat_mcp/tools.py
+++ b/clients/python/pymat-mcp/src/pymat_mcp/tools.py
@@ -40,6 +40,7 @@ _ALL_DOMAINS = (
     "electrical",
     "optical",
     "magnetic",
+    "vacuum",
     "manufacturing",
     "compliance",
     "sourcing",

--- a/src/pymat/loader.py
+++ b/src/pymat/loader.py
@@ -241,6 +241,8 @@ def _build_properties_from_dict(
         update_properties(props.optical, data["optical"], "optical")
     if "magnetic" in data:
         update_properties(props.magnetic, data["magnetic"], "magnetic")
+    if "vacuum" in data:
+        update_properties(props.vacuum, data["vacuum"], "vacuum")
     if "pbr" in data:
         raise ValueError(
             "TOML [pbr] section is no longer supported in 3.0. "
@@ -299,6 +301,7 @@ def _resolve_material_node(
                 "electrical",
                 "optical",
                 "magnetic",
+                "vacuum",
                 "pbr",
                 "manufacturing",
                 "compliance",
@@ -367,6 +370,7 @@ def _resolve_material_node(
                 "electrical",
                 "optical",
                 "magnetic",
+                "vacuum",
                 "pbr",
                 "manufacturing",
                 "compliance",

--- a/src/pymat/properties.py
+++ b/src/pymat/properties.py
@@ -533,6 +533,31 @@ class MagneticProperties:
 
 
 @dataclass
+class VacuumProperties:
+    """UHV detector enclosure + Geant4 vacuum modeling (#156).
+
+    Particularly relevant for PEEK, Delrin (notably bad in UHV), Viton,
+    Kapton, all elastomers, and epoxies. Test methods: ASTM E595 / NASA
+    SP-R-0022 for TML/CVCM; outgassing rate via throughput method after
+    1h and 10h pump-down.
+    """
+
+    # Outgassing rate snapshots in torr·L/(s·cm²) — sparse, named beats list
+    outgassing_rate_1h: Optional[float] = None
+    outgassing_rate_10h: Optional[float] = None
+    # ASTM E595 / NASA SP-R-0022 — total mass loss + collected volatile
+    # condensable material, both in % at 125 °C / 24h / 5e-5 torr
+    tml_pct: Optional[float] = None
+    cvcm_pct: Optional[float] = None
+    # Maximum bakeout temperature (°C) before degradation
+    bakeout_temp_max_C: Optional[float] = None
+    # He permeation in cm³·mm/(cm²·s·atm)
+    permeation_he: Optional[float] = None
+    # Operational class hint: "UHV" | "HV" | "rough"
+    vacuum_class: Optional[str] = None
+
+
+@dataclass
 class ManufacturingProperties:
     """Machinability, weldability, printability."""
 
@@ -661,6 +686,7 @@ class AllProperties:
     electrical: ElectricalProperties = field(default_factory=ElectricalProperties)
     optical: OpticalProperties = field(default_factory=OpticalProperties)
     magnetic: MagneticProperties = field(default_factory=MagneticProperties)
+    vacuum: VacuumProperties = field(default_factory=VacuumProperties)
     manufacturing: ManufacturingProperties = field(default_factory=ManufacturingProperties)
     compliance: ComplianceProperties = field(default_factory=ComplianceProperties)
     sourcing: SourcingProperties = field(default_factory=SourcingProperties)

--- a/tests/test_toml_integrity.py
+++ b/tests/test_toml_integrity.py
@@ -44,6 +44,7 @@ _KNOWN_GROUPS = {
     "electrical",
     "optical",
     "magnetic",
+    "vacuum",
     "manufacturing",
     "compliance",
     "sourcing",

--- a/tests/test_vacuum_subtable.py
+++ b/tests/test_vacuum_subtable.py
@@ -1,0 +1,102 @@
+"""Tests for #156 — new `[<material>.vacuum]` sub-table.
+
+UHV detector enclosures + Geant4 vacuum modeling. Particularly relevant
+for PEEK, Delrin, Viton, Kapton, all elastomers, epoxies.
+"""
+
+from __future__ import annotations
+
+from textwrap import dedent
+
+from pymat.loader import load_toml
+
+
+class TestVacuumSubtable:
+    def test_outgassing_rates_load(self, tmp_path):
+        """Two named fields for the 1h/10h pumping snapshots — sparse, named beats list."""
+        p = tmp_path / "m.toml"
+        p.write_text(
+            dedent("""
+            [peek]
+            name = "PEEK"
+            [peek.vacuum]
+            outgassing_rate_1h = 5e-6
+            outgassing_rate_10h = 8e-7
+            """)
+        )
+        m = load_toml(p)["peek"]
+        assert m.properties.vacuum.outgassing_rate_1h == 5e-6
+        assert m.properties.vacuum.outgassing_rate_10h == 8e-7
+
+    def test_astm_e595_fields(self, tmp_path):
+        """TML and CVCM per ASTM E595 / NASA spec."""
+        p = tmp_path / "m.toml"
+        p.write_text(
+            dedent("""
+            [delrin]
+            name = "Delrin"
+            [delrin.vacuum]
+            tml_pct = 1.5
+            cvcm_pct = 0.05
+            """)
+        )
+        m = load_toml(p)["delrin"]
+        assert m.properties.vacuum.tml_pct == 1.5
+        assert m.properties.vacuum.cvcm_pct == 0.05
+
+    def test_bakeout_and_permeation(self, tmp_path):
+        p = tmp_path / "m.toml"
+        p.write_text(
+            dedent("""
+            [kapton]
+            name = "Kapton"
+            [kapton.vacuum]
+            bakeout_temp_max_C = 200
+            permeation_he = 1.2e-9
+            """)
+        )
+        m = load_toml(p)["kapton"]
+        assert m.properties.vacuum.bakeout_temp_max_C == 200
+        assert m.properties.vacuum.permeation_he == 1.2e-9
+
+    def test_vacuum_class_string(self, tmp_path):
+        p = tmp_path / "m.toml"
+        p.write_text(
+            dedent("""
+            [m]
+            name = "M"
+            [m.vacuum]
+            vacuum_class = "UHV"
+            """)
+        )
+        m = load_toml(p)["m"]
+        assert m.properties.vacuum.vacuum_class == "UHV"
+
+    def test_inheritance(self, tmp_path):
+        p = tmp_path / "m.toml"
+        p.write_text(
+            dedent("""
+            [base]
+            name = "Base"
+            [base.vacuum]
+            vacuum_class = "HV"
+            tml_pct = 0.5
+
+            [base.aged]
+            name = "Aged"
+            [base.aged.vacuum]
+            tml_pct = 1.2
+            """)
+        )
+        mats = load_toml(p)
+        # Inherits vacuum_class, overrides tml_pct
+        assert mats["base"].aged.properties.vacuum.vacuum_class == "HV"
+        assert mats["base"].aged.properties.vacuum.tml_pct == 1.2
+
+    def test_full_corpus_loads(self):
+        from pymat import _CATEGORY_BASES
+        from pymat.loader import load_category
+
+        for cat in _CATEGORY_BASES:
+            mats = load_category(cat)
+            assert mats, f"category {cat} loaded empty"


### PR DESCRIPTION
Pure additive — new `VacuumProperties` dataclass for UHV detector enclosures + Geant4 vacuum modeling. Relevant for PEEK, Delrin (notably bad in UHV), Viton, Kapton, elastomers, epoxies.

| Field | Unit | Source |
|---|---|---|
| `outgassing_rate_1h` | torr·L/(s·cm²) | throughput method, 1h pump-down |
| `outgassing_rate_10h` | torr·L/(s·cm²) | throughput method, 10h pump-down |
| `tml_pct` | % | ASTM E595 / NASA SP-R-0022 |
| `cvcm_pct` | % | ASTM E595 / NASA SP-R-0022 |
| `bakeout_temp_max_C` | °C | bakeout limit |
| `permeation_he` | cm³·mm/(cm²·s·atm) | He permeation |
| `vacuum_class` | str | "UHV" / "HV" / "rough" |

Wired through `AllProperties`, loader, `_KNOWN_GROUPS`, MCP `_ALL_DOMAINS`.

## Test plan
- [x] `pytest tests/test_vacuum_subtable.py` — 6 tests pass
- [x] Full corpus regression via `test_toml_integrity`
- [x] `ruff check` clean

Closes #156