### PR TITLE
feat(schema): optical sub-table additions — scintillator/Geant4 (#153)

### DIFF
--- a/src/pymat/loader.py
+++ b/src/pymat/loader.py
@@ -131,10 +131,22 @@ def _build_properties_from_dict(
         # Track which stddev siblings we actually consumed; orphans raise.
         consumed_stddev = set()
 
+        # Keys that signal a uncertainty/range dict — anything else stays as-is.
+        _UFLOAT_KEYS = {"nominal", "stddev", "min", "max"}
+
         def assign(base_key: str, raw_value):
             """Parse a value (possibly a {nominal, stddev} dict), fold sibling
-            stddev if present, and setattr on prop_obj."""
-            parsed = _parse_value(raw_value) if isinstance(raw_value, dict) else raw_value
+            stddev if present, and setattr on prop_obj.
+
+            Only dicts whose top-level keys overlap with `_UFLOAT_KEYS` are
+            routed through `_parse_value`. Structured-data dicts (e.g.
+            `emission_spectrum = {wavelengths_nm, intensities}` from #153)
+            are passed through verbatim.
+            """
+            if isinstance(raw_value, dict) and (set(raw_value) & _UFLOAT_KEYS):
+                parsed = _parse_value(raw_value)
+            else:
+                parsed = raw_value
             sibling = stddev_map.get(base_key)
             if sibling is not None:
                 consumed_stddev.add(base_key)

--- a/src/pymat/properties.py
+++ b/src/pymat/properties.py
@@ -456,11 +456,47 @@ class OpticalProperties:
     moliere_radius: Optional[float] = None  # cm
     energy_resolution: Optional[float] = None  # % at 1 MeV (for detectors)
 
+    # Geant4 photon transport — both currently missing in schema (#153)
+    scattering_length: Optional[float] = None  # cm
+    scattering_length_unit: str = "cm"
+    rayleigh_length: Optional[float] = None  # cm
+    rayleigh_length_unit: str = "cm"
+
+    # Multi-component decay — LYSO has fast (~36 ns) + slow (~600 ns) (#153)
+    # Each entry: {tau_ns, fraction}. Sum of fractions ≈ 1.
+    decay_components: Optional[List[Dict[str, float]]] = None
+    # Emission spectrum for SiPM PDE matching (#153)
+    # Shape: {wavelengths_nm: [...], intensities: [...]} (same length)
+    emission_spectrum: Optional[Dict[str, List[float]]] = None
+    # Sellmeier-style dispersion for Geant4 ray tracing (#153)
+    # Shape: {wavelengths_nm: [...], n: [...]}
+    refractive_index_dispersion: Optional[Dict[str, List[float]]] = None
+
+    # Detector-physics scalars (#153)
+    afterglow_pct_at_3ms: Optional[float] = None  # count-rate ceiling
+    afterglow_pct_at_100ms: Optional[float] = None
+    non_proportionality: Optional[float] = None  # % deviation 10 keV → 1 MeV
+    intrinsic_resolution_pct_at_662keV: Optional[float] = None  # 137Cs photopeak FWHM
+    temperature_coefficient_light_yield: Optional[float] = None  # %/K
+    hygroscopic: Optional[bool] = None  # NaI:Tl yes, BGO/LYSO no
+
     # T-dependent curves (#148). Refractive index, light yield, decay time
     # are the dimensionless / unit-implicit ones — no `_unit` field exists.
     refractive_index_curve: Optional[TempCurve] = None
     light_yield_curve: Optional[TempCurve] = None
     decay_time_curve: Optional[TempCurve] = None
+
+    @property
+    def scattering_length_qty(self) -> Optional["Quantity"]:
+        if self.scattering_length is None:
+            return None
+        return self.scattering_length * ureg(self.scattering_length_unit)
+
+    @property
+    def rayleigh_length_qty(self) -> Optional["Quantity"]:
+        if self.rayleigh_length is None:
+            return None
+        return self.rayleigh_length * ureg(self.rayleigh_length_unit)
 
     def refractive_index_at(self, temp: "Quantity") -> Optional[float]:
         """Refractive index at T. Curve > scalar fallback (#148)."""

--- a/tests/test_optical_fields.py
+++ b/tests/test_optical_fields.py
@@ -1,0 +1,205 @@
+"""Tests for #153 — optical sub-table additions (scintillator-heavy).
+
+Mostly additive scalars + 3 structured fields:
+- decay_components — list[{tau_ns, fraction}] for multi-component decay
+- emission_spectrum — {wavelengths_nm, intensities} for SiPM PDE matching
+- refractive_index_dispersion — {wavelengths_nm, n} Sellmeier-style
+
+Geant4 ray-tracing currently has zero data here; this PR makes the schema
+ready to ingest it (data populates in Phase 4 via refractiveindex.info etc.).
+"""
+
+from __future__ import annotations
+
+from textwrap import dedent
+
+from pymat.loader import load_toml
+
+
+class TestOpticalScalars:
+    def test_scattering_and_rayleigh_lengths(self, tmp_path):
+        """Geant4 scintillator block needs both."""
+        p = tmp_path / "m.toml"
+        p.write_text(
+            dedent("""
+            [lyso]
+            name = "LYSO"
+            [lyso.optical]
+            scattering_length_value = 50
+            scattering_length_unit = "cm"
+            rayleigh_length_value = 100
+            rayleigh_length_unit = "cm"
+            """)
+        )
+        m = load_toml(p)["lyso"]
+        assert m.properties.optical.scattering_length == 50
+        assert m.properties.optical.rayleigh_length == 100
+
+    def test_afterglow_loads(self, tmp_path):
+        """Count-rate ceiling — fraction of light still emitted at 3ms / 100ms."""
+        p = tmp_path / "m.toml"
+        p.write_text(
+            dedent("""
+            [csi_tl]
+            name = "CsI:Tl"
+            [csi_tl.optical]
+            afterglow_pct_at_3ms = 0.5
+            afterglow_pct_at_100ms = 0.05
+            """)
+        )
+        m = load_toml(p)["csi_tl"]
+        assert m.properties.optical.afterglow_pct_at_3ms == 0.5
+        assert m.properties.optical.afterglow_pct_at_100ms == 0.05
+
+    def test_non_proportionality_and_resolution(self, tmp_path):
+        p = tmp_path / "m.toml"
+        p.write_text(
+            dedent("""
+            [m]
+            name = "M"
+            [m.optical]
+            non_proportionality = 4.5
+            intrinsic_resolution_pct_at_662keV = 3.5
+            """)
+        )
+        m = load_toml(p)["m"]
+        assert m.properties.optical.non_proportionality == 4.5
+        assert m.properties.optical.intrinsic_resolution_pct_at_662keV == 3.5
+
+    def test_temperature_coefficient_light_yield(self, tmp_path):
+        """LYSO ~+0.4%/K downward from 20°C (so cryo gives ~+15% by -40°C)."""
+        p = tmp_path / "m.toml"
+        p.write_text(
+            dedent("""
+            [lyso]
+            name = "LYSO"
+            [lyso.optical]
+            temperature_coefficient_light_yield = -0.4
+            """)
+        )
+        m = load_toml(p)["lyso"]
+        assert m.properties.optical.temperature_coefficient_light_yield == -0.4
+
+    def test_hygroscopic_bool(self, tmp_path):
+        p = tmp_path / "m.toml"
+        p.write_text(
+            dedent("""
+            [nai_tl]
+            name = "NaI:Tl"
+            [nai_tl.optical]
+            hygroscopic = true
+
+            [bgo]
+            name = "BGO"
+            [bgo.optical]
+            hygroscopic = false
+            """)
+        )
+        mats = load_toml(p)
+        assert mats["nai_tl"].properties.optical.hygroscopic is True
+        assert mats["bgo"].properties.optical.hygroscopic is False
+
+
+class TestOpticalStructured:
+    def test_decay_components_list(self, tmp_path):
+        """LYSO has fast (~36 ns) + slow (~600 ns) decay components."""
+        p = tmp_path / "m.toml"
+        p.write_text(
+            dedent("""
+            [lyso]
+            name = "LYSO"
+            [lyso.optical]
+            decay_components = [
+              { tau_ns = 36, fraction = 0.85 },
+              { tau_ns = 600, fraction = 0.15 },
+            ]
+            """)
+        )
+        m = load_toml(p)["lyso"]
+        comps = m.properties.optical.decay_components
+        assert isinstance(comps, list)
+        assert len(comps) == 2
+        assert comps[0] == {"tau_ns": 36, "fraction": 0.85}
+
+    def test_emission_spectrum_dict(self, tmp_path):
+        p = tmp_path / "m.toml"
+        p.write_text(
+            dedent("""
+            [lyso]
+            name = "LYSO"
+            [lyso.optical.emission_spectrum]
+            wavelengths_nm = [380, 400, 420, 440, 460]
+            intensities = [0.1, 0.6, 1.0, 0.7, 0.3]
+            """)
+        )
+        m = load_toml(p)["lyso"]
+        s = m.properties.optical.emission_spectrum
+        assert s == {
+            "wavelengths_nm": [380, 400, 420, 440, 460],
+            "intensities": [0.1, 0.6, 1.0, 0.7, 0.3],
+        }
+
+    def test_refractive_index_dispersion_dict(self, tmp_path):
+        """Sellmeier-style dispersion for Geant4 ray tracing."""
+        p = tmp_path / "m.toml"
+        p.write_text(
+            dedent("""
+            [sapphire]
+            name = "Sapphire"
+            [sapphire.optical.refractive_index_dispersion]
+            wavelengths_nm = [400, 500, 600, 700]
+            n = [1.79, 1.77, 1.76, 1.75]
+            """)
+        )
+        m = load_toml(p)["sapphire"]
+        d = m.properties.optical.refractive_index_dispersion
+        assert d == {
+            "wavelengths_nm": [400, 500, 600, 700],
+            "n": [1.79, 1.77, 1.76, 1.75],
+        }
+
+
+class TestPintQty:
+    def test_scattering_length_qty(self, tmp_path):
+        p = tmp_path / "m.toml"
+        p.write_text(
+            dedent("""
+            [m]
+            name = "M"
+            [m.optical]
+            scattering_length_value = 50
+            scattering_length_unit = "cm"
+            rayleigh_length_value = 100
+            rayleigh_length_unit = "cm"
+            """)
+        )
+        m = load_toml(p)["m"]
+        assert m.properties.optical.scattering_length_qty.to("cm").magnitude == 50
+        assert m.properties.optical.rayleigh_length_qty.to("cm").magnitude == 100
+
+
+class TestRegression:
+    def test_full_corpus_loads(self):
+        from pymat import _CATEGORY_BASES
+        from pymat.loader import load_category
+
+        for cat in _CATEGORY_BASES:
+            mats = load_category(cat)
+            assert mats, f"category {cat} loaded empty"
+
+    def test_existing_optical_fields_unchanged(self, tmp_path):
+        p = tmp_path / "m.toml"
+        p.write_text(
+            dedent("""
+            [lyso]
+            name = "LYSO"
+            [lyso.optical]
+            light_yield = 33000
+            decay_time = 36
+            refractive_index = 1.82
+            """)
+        )
+        lyso = load_toml(p)["lyso"]
+        assert lyso.properties.optical.light_yield == 33000
+        assert lyso.properties.optical.decay_time == 36
+        assert lyso.properties.optical.refractive_index == 1.82


### PR DESCRIPTION
## Summary

Adds 11 optical fields, mostly scintillator + Geant4 photon transport data that the schema currently has no slot for.

### Scalars
| Field | Unit | Use |
|---|---|---|
| `scattering_length` / `rayleigh_length` | cm | Geant4 photon transport (currently missing entirely) |
| `afterglow_pct_at_3ms` / `afterglow_pct_at_100ms` | % | count-rate ceiling |
| `non_proportionality` | % | deviation 10 keV → 1 MeV |
| `intrinsic_resolution_pct_at_662keV` | % | 137Cs photopeak FWHM |
| `temperature_coefficient_light_yield` | %/K | LYSO ≈ -0.4 |
| `hygroscopic` | bool | NaI:Tl yes, BGO/LYSO no |

### Structured (3 — plain dict / list[dict], no new dataclass)
| Field | Shape | Use |
|---|---|---|
| `decay_components` | `list[{tau_ns, fraction}]` | multi-component decay (LYSO fast+slow, TOF-PET) |
| `emission_spectrum` | `{wavelengths_nm: [...], intensities: [...]}` | SiPM PDE matching |
| `refractive_index_dispersion` | `{wavelengths_nm: [...], n: [...]}` | Sellmeier-style Geant4 ray tracing |

## Loader bug fix bundled

#149's loader sugar treated *every* dict-valued property as a `{nominal, stddev}` uncertainty dict — which would crash on `emission_spectrum = {wavelengths_nm=[...], intensities=[...]}`. Tightened the dict-shape detection: only route through `_parse_value` when the dict's keys overlap with `{nominal, stddev, min, max}`. Verified `tests/test_stddev_sugar.py` still passes (no regression on the ufloat path).

## Test plan
- [x] `pytest tests/test_optical_fields.py` — 11 tests pass
- [x] `pytest tests/test_stddev_sugar.py tests/test_temp_curves.py` — no regressions on adjacent loader logic
- [x] Full suite: 570 passed, 11 skipped, zero regressions
- [x] `ruff check` clean

Closes #153