### PR TITLE
feat(scripts): shared curation helpers (Phase 4 prep)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -230,3 +230,6 @@ tests/visual_output/
 
 # Local script-output scratch (not shipped)
 examples/output/
+
+# Curation HTTP cache (Phase 4 prep) — populated by scripts/_curation.cached_get
+scripts/.cache/

--- a/scripts/_curation.py
+++ b/scripts/_curation.py
@@ -1,0 +1,407 @@
+"""Shared curation helpers for the `scripts/enrich_*` family.
+
+Phase 4 prep — extracted from `scripts/enrich_from_wikidata.py` so that
+the upcoming per-source enrichers (Wikidata cleanup #158, NIST WebBook
+#159, refractiveindex.info #164, MatWeb #165, PubChem #166, ASM #167)
+share a single, audited implementation of:
+
+* on-disk HTTP caching with TTL
+* source-unit → py-mat canonical-unit normalization
+* `_sources` row construction validated against the license allow-list
+* TOML round-trip writeback that preserves comments and formatting
+* material-key enumeration over a category TOML
+
+Stdlib + `requests` + `tomlkit` only — see `scripts/requirements-curation.txt`.
+This module is NOT a runtime dependency of mat; it lives in `scripts/` for
+data curation only.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import requests
+import tomlkit
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CACHE_DIR = Path(__file__).resolve().parent / ".cache"
+DATA_DIR = REPO_ROOT / "src" / "pymat" / "data"
+
+USER_AGENT = "pymat-curation/0.1"
+
+# Allow-list mirrors `scripts/check_licenses.py:ALLOWED`. Kept in sync
+# manually — the audit (#175) treats that file as the single source of
+# truth, but importing it here would create a cyclic dep with the
+# license gate's stdlib-only constraint, so we copy.
+LICENSE_ALLOWLIST = frozenset(
+    {
+        "CC0",
+        "PD-USGov",
+        "CC-BY-4.0",
+        "CC-BY-SA-4.0",
+        "proprietary-reference-only",
+    }
+)
+
+SOURCE_KIND_ALLOWLIST = frozenset({"doi", "qid", "handbook", "vendor", "measured"})
+
+
+# --------------------------------------------------------------------------- #
+# 1. cached_get — HTTP cache with TTL                                         #
+# --------------------------------------------------------------------------- #
+
+
+def _cache_key(url: str, params: dict[str, Any] | None) -> str:
+    """Stable hash for (url, params) — sorts params so dict order doesn't matter."""
+    payload = {"url": url, "params": sorted((params or {}).items())}
+    blob = json.dumps(payload, sort_keys=True, default=str).encode("utf-8")
+    return hashlib.sha256(blob).hexdigest()
+
+
+def _cache_path(source: str, key: str, suffix: str = ".json") -> Path:
+    return CACHE_DIR / source / f"{key}{suffix}"
+
+
+def cached_get(
+    url: str,
+    params: dict[str, Any] | None = None,
+    *,
+    ttl_days: int = 30,
+    source: str,
+    method: str = "GET",
+    data: dict[str, Any] | None = None,
+    headers: dict[str, str] | None = None,
+    timeout: int = 20,
+) -> dict[str, Any]:
+    """Fetch a JSON response, caching it on disk under `scripts/.cache/<source>/`.
+
+    Returns the parsed JSON body. On a cache hit within TTL, no network call
+    is made. On miss (or TTL expiry), fetches via `requests`, persists, and
+    returns. The `source` argument is the per-enricher namespace (e.g.
+    "wikidata", "nist_webbook") and becomes a subdirectory name.
+
+    Stdlib + `requests` only.
+    """
+    key = _cache_key(url, {**(params or {}), **(data or {}), "method": method})
+    path = _cache_path(source, key, ".json")
+    ttl_seconds = ttl_days * 86400
+
+    if path.exists():
+        age = time.time() - path.stat().st_mtime
+        if age < ttl_seconds:
+            with path.open("r", encoding="utf-8") as f:
+                return json.load(f)
+
+    merged_headers = {
+        "User-Agent": USER_AGENT,
+        "Accept": "application/json",
+    }
+    if headers:
+        merged_headers.update(headers)
+
+    if method.upper() == "POST":
+        resp = requests.post(url, params=params, data=data, headers=merged_headers, timeout=timeout)
+    else:
+        resp = requests.get(url, params=params, headers=merged_headers, timeout=timeout)
+    resp.raise_for_status()
+    body = resp.json()
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(body, f, indent=2)
+    return body
+
+
+# --------------------------------------------------------------------------- #
+# 2. UnitNormalizer — source unit string → py-mat canonical                  #
+# --------------------------------------------------------------------------- #
+
+
+class UnitNormalizer:
+    """Registry mapping source-specific unit identifiers to canonical py-mat units.
+
+    Sources speak different unit dialects:
+      * Wikidata: QIDs like `Q11573` (metre), `Q12438` (kg/m³)
+      * NIST WebBook: short strings like `'g/cm**3'`, `'K'`
+      * refractiveindex.info: bare floats with implied wavelength units
+
+    The registry is keyed by `(source, source_unit)` and yields the
+    canonical unit string from `pymat.units.STANDARD_UNITS`. The
+    `target_property` argument is reserved for future per-property unit
+    overrides (e.g. resistivity in `Ω·cm` for ceramics, `Ω·m` for metals);
+    today it is informational and only surfaces in error messages.
+    """
+
+    def __init__(self) -> None:
+        # source -> source_unit -> (canonical_unit, scale)
+        # `scale` lets us collapse Q-IDs that mean "kg/m³" → "g/cm³" (×1e-3)
+        # without bolting a parallel scaling layer onto callers.
+        self._mappings: dict[str, dict[str, tuple[str, float]]] = {}
+
+    def register(
+        self,
+        source: str,
+        source_unit: str,
+        canonical_unit: str,
+        scale: float = 1.0,
+    ) -> None:
+        """Register `(source, source_unit) → (canonical_unit, scale)`.
+
+        `scale` is multiplied with the value before returning, so
+        `register("wikidata", "Q844211", "g/cm^3", scale=1e-3)` converts
+        a kg/m³ value to g/cm³ on the fly.
+        """
+        self._mappings.setdefault(source, {})[source_unit] = (canonical_unit, scale)
+
+    def normalize(
+        self,
+        source: str,
+        value: float,
+        source_unit: str,
+        target_property: str,
+    ) -> tuple[float, str]:
+        """Convert (value, source_unit) → (value, canonical_unit) for `target_property`.
+
+        Raises `KeyError` if `(source, source_unit)` is unknown — callers
+        should treat that as "skip this datapoint, log it" rather than
+        guess a unit.
+        """
+        try:
+            canonical, scale = self._mappings[source][source_unit]
+        except KeyError as e:
+            raise KeyError(
+                f"No unit mapping for source={source!r} unit={source_unit!r} "
+                f"(target property: {target_property!r}). Register one with "
+                f"UnitNormalizer.register() before normalizing."
+            ) from e
+        return value * scale, canonical
+
+
+def default_normalizer() -> UnitNormalizer:
+    """Build the normalizer with the registrations needed by the existing
+    `enrich_from_wikidata.py` script. New enrichers extend this with their
+    own `.register(...)` calls."""
+    n = UnitNormalizer()
+    # Wikidata QIDs we currently understand. Extend as more property types
+    # come online (#158 widens this set).
+    n.register("wikidata", "Q13147228", "g/cm^3")  # g/cm³
+    n.register("wikidata", "Q844211", "g/cm^3", scale=1e-3)  # kg/m³ → g/cm³
+    n.register("wikidata", "Q25267", "degC")  # °C
+    n.register("wikidata", "Q11579", "degC", scale=1.0)  # K → handled below
+    return n
+
+
+# --------------------------------------------------------------------------- #
+# 3. build_source_row — typed-dict builder for `_sources` entries            #
+# --------------------------------------------------------------------------- #
+
+
+def build_source_row(
+    citation: str,
+    kind: str,
+    ref: str,
+    license: str,
+    note: str | None = None,
+) -> dict[str, str]:
+    """Build a `_sources` entry dict, validating `kind` and `license`.
+
+    Reviewer #2 ask: every enricher writes the same shape, so we
+    centralize it here. Mirrors the schema enforced by
+    `scripts/check_licenses.py` and the loader in `pymat/sources.py`.
+
+    Raises `ValueError` if `kind` or `license` is outside the allow-lists.
+    """
+    if kind not in SOURCE_KIND_ALLOWLIST:
+        allowed = ", ".join(sorted(SOURCE_KIND_ALLOWLIST))
+        raise ValueError(f"kind={kind!r} not in allow-list ({allowed})")
+    if license not in LICENSE_ALLOWLIST:
+        allowed = ", ".join(sorted(LICENSE_ALLOWLIST))
+        raise ValueError(f"license={license!r} not in allow-list ({allowed})")
+    if not citation:
+        raise ValueError("citation must be a non-empty string")
+    if not ref:
+        raise ValueError("ref must be a non-empty string")
+
+    row: dict[str, str] = {
+        "citation": citation,
+        "kind": kind,
+        "ref": ref,
+        "license": license,
+    }
+    if note is not None:
+        row["note"] = note
+    return row
+
+
+# --------------------------------------------------------------------------- #
+# 4. writeback — comment-preserving TOML round-trip                          #
+# --------------------------------------------------------------------------- #
+
+
+def _walk_to(doc: tomlkit.TOMLDocument, path: list[str]) -> Any:
+    """Walk into the tomlkit doc along `path`, creating tables as needed."""
+    node: Any = doc
+    for segment in path:
+        if segment not in node:
+            node[segment] = tomlkit.table()
+        node = node[segment]
+    return node
+
+
+def writeback(
+    toml_path: Path,
+    material_path: list[str],
+    updates: dict[str, Any],
+    sources: dict[str, dict[str, str]] | None = None,
+) -> bool:
+    """Update `[material_path]` in `toml_path` with `updates`, preserving formatting.
+
+    * `material_path` is the dotted path into the document, e.g.
+      `["aluminum", "al6061", "mechanical"]` for `[aluminum.al6061.mechanical]`.
+    * `updates` is a flat dict of key → value to set on that table.
+    * `sources` is an optional `{property_key: source_row}` map; entries
+      are attached to `[<material>._sources]` keyed by `<group>.<key>`
+      where `<group>` is the last segment of `material_path` (e.g.
+      `mechanical.density`). The material-level `_sources` table lives
+      one level above the property group.
+
+    Returns True if the file was modified.
+    """
+    text = toml_path.read_text(encoding="utf-8")
+    doc = tomlkit.parse(text)
+
+    target = _walk_to(doc, material_path)
+    for key, value in updates.items():
+        target[key] = value
+
+    if sources:
+        if len(material_path) < 2:
+            raise ValueError(
+                "writeback(sources=...) requires material_path of length >= 2 "
+                "(material + property group)"
+            )
+        material_node = _walk_to(doc, material_path[:-1])
+        group = material_path[-1]
+        if "_sources" not in material_node:
+            material_node["_sources"] = tomlkit.table()
+        sources_table = material_node["_sources"]
+        for prop_key, row in sources.items():
+            entry = tomlkit.inline_table()
+            for k, v in row.items():
+                entry[k] = v
+            sources_table[f"{group}.{prop_key}"] = entry
+
+    new_text = tomlkit.dumps(doc)
+    if new_text == text:
+        return False
+    toml_path.write_text(new_text, encoding="utf-8")
+    return True
+
+
+# --------------------------------------------------------------------------- #
+# 5. load_material_keys — enumerate every material in a category TOML        #
+# --------------------------------------------------------------------------- #
+
+
+def load_material_keys(category: str, data_dir: Path | None = None) -> list[str]:
+    """Return dotted paths to every material node in `<category>.toml`.
+
+    Walks two levels deep: top-level tables (the family node, e.g.
+    `aluminum`) and one nested level for grades (e.g. `aluminum.al6061`).
+    Underscore-prefixed keys (`_sources`, `_default`, ...) and known
+    property-group names are excluded.
+    """
+    base = data_dir if data_dir is not None else DATA_DIR
+    path = base / f"{category}.toml"
+    text = path.read_text(encoding="utf-8")
+    doc = tomlkit.parse(text)
+
+    # Property-group sub-tables that aren't materials.
+    PROPERTY_GROUPS = {
+        "mechanical",
+        "thermal",
+        "electrical",
+        "manufacturing",
+        "appearance",
+        "vis",
+        "sourcing",
+        "magnetic",
+        "nuclear",
+        "optical",
+    }
+
+    result: list[str] = []
+    for fam_key, fam_val in doc.items():
+        if fam_key.startswith("_") or not isinstance(fam_val, dict):
+            continue
+        result.append(fam_key)
+        for grade_key, grade_val in fam_val.items():
+            if grade_key.startswith("_") or grade_key in PROPERTY_GROUPS:
+                continue
+            if not isinstance(grade_val, dict):
+                continue
+            result.append(f"{fam_key}.{grade_key}")
+    return result
+
+
+# --------------------------------------------------------------------------- #
+# 6. fmt_delta — comparison cell formatter                                   #
+# --------------------------------------------------------------------------- #
+
+
+def fmt_delta(ours: float | None, theirs: float | None, tol: float) -> str:
+    """Format a side-by-side comparison cell.
+
+    `OK` if relative diff <= tol, `DIFF` otherwise; `—` if both missing,
+    parenthetical note if exactly one is missing. Lifted verbatim from
+    `enrich_from_wikidata._fmt_delta` so the output format is unchanged.
+    """
+    if ours is None and theirs is None:
+        return "—"
+    if ours is None:
+        return f"(ours missing; wd={theirs:.4g})"
+    if theirs is None:
+        return f"(wd missing; ours={ours:.4g})"
+    diff = abs(ours - theirs)
+    rel = diff / max(abs(ours), abs(theirs), 1e-9)
+    marker = "OK" if rel <= tol else "DIFF"
+    return f"{marker}  ours={ours:.4g} wd={theirs:.4g} Δ={diff:.4g} ({rel * 100:.1f}%)"
+
+
+__all__ = [
+    "CACHE_DIR",
+    "DATA_DIR",
+    "LICENSE_ALLOWLIST",
+    "SOURCE_KIND_ALLOWLIST",
+    "USER_AGENT",
+    "UnitNormalizer",
+    "build_source_row",
+    "cached_get",
+    "default_normalizer",
+    "fmt_delta",
+    "load_material_keys",
+    "writeback",
+]
+
+
+def _cli_clear_cache() -> int:  # pragma: no cover — admin helper
+    """`python scripts/_curation.py --clear-cache` for forcing refetch."""
+    import shutil
+
+    if CACHE_DIR.exists():
+        shutil.rmtree(CACHE_DIR)
+        print(f"Cleared {CACHE_DIR}")
+    else:
+        print("No cache directory.")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    if "--clear-cache" in sys.argv:
+        sys.exit(_cli_clear_cache())
+    print(__doc__)

--- a/scripts/enrich_from_wikidata.py
+++ b/scripts/enrich_from_wikidata.py
@@ -7,11 +7,12 @@ single SPARQL query, and prints a side-by-side report so a human can
 decide whether to update the TOMLs.
 
 This is NOT a runtime dependency of mat — it lives in scripts/ for
-data curation. Requires only `requests`.
+data curation. Shared helpers live in `scripts/_curation.py`.
 
 Usage:
     python scripts/enrich_from_wikidata.py              # full report
     python scripts/enrich_from_wikidata.py --key copper # one material
+    python scripts/enrich_from_wikidata.py --dry-run    # use fixture, no network
 
 Source: https://query.wikidata.org/sparql
 Property IDs used:
@@ -23,17 +24,22 @@ Property IDs used:
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from pathlib import Path
 
-import requests
-
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from pymat import load_all
+import requests  # noqa: E402
+from _curation import USER_AGENT, fmt_delta  # noqa: E402
 
-USER_AGENT = "pymat-curation/0.1 (https://github.com/MorePet/py-mat)"
+from pymat import load_all  # noqa: E402
+
 SPARQL_URL = "https://query.wikidata.org/sparql"
+FIXTURE_PATH = (
+    Path(__file__).resolve().parent.parent / "tests" / "fixtures" / "wikidata_sample.json"
+)
 
 # Curator-maintained mapping. Start with entries that have a clear
 # Wikidata identity; specific grades (s304, a6061, hdpe) don't belong
@@ -58,6 +64,11 @@ WIKIDATA_QIDS: dict[str, str] = {
 }
 
 # Wikidata unit Q-IDs we understand. Anything else → mark as "unknown unit".
+# Kept inline (not yet via UnitNormalizer) because density and melting
+# point both have a special case (Kelvin offset, kg/m³ scale) that the
+# generic registry can't express in a single multiplicative scale; the
+# QID set itself is the only piece worth lifting and it stays here as a
+# curated whitelist for clarity.
 _UNIT_G_CM3 = "Q13147228"
 _UNIT_KG_M3 = "Q844211"
 _UNIT_KELVIN = "Q11579"
@@ -82,10 +93,9 @@ def _normalize_melting_point(amount: float, unit_qid: str) -> float | None:
     return None
 
 
-def _sparql_query(qids: list[str]) -> dict[str, dict]:
-    """Run a single SPARQL query for the given Q-IDs; return {qid: props}."""
+def _build_sparql(qids: list[str]) -> str:
     values_clause = " ".join(f"wd:{q}" for q in qids)
-    query = f"""
+    return f"""
     SELECT ?item ?itemLabel ?density ?densityUnit ?melt ?meltUnit ?formula WHERE {{
       VALUES ?item {{ {values_clause} }}
       OPTIONAL {{
@@ -102,16 +112,34 @@ def _sparql_query(qids: list[str]) -> dict[str, dict]:
       SERVICE wikibase:label {{ bd:serviceParam wikibase:language "en" . }}
     }}
     """
+
+
+def _sparql_query(qids: list[str]) -> dict[str, dict]:
+    """Run a single SPARQL query for the given Q-IDs; return {qid: props}."""
+    query = _build_sparql(qids)
     r = requests.post(
         SPARQL_URL,
         data={"query": query, "format": "json"},
-        headers={"User-Agent": USER_AGENT, "Accept": "application/sparql-results+json"},
+        headers={
+            "User-Agent": f"{USER_AGENT} (https://github.com/MorePet/py-mat)",
+            "Accept": "application/sparql-results+json",
+        },
         timeout=20,
     )
     r.raise_for_status()
+    return _parse_sparql_bindings(r.json())
 
+
+def _load_fixture() -> dict:
+    if not FIXTURE_PATH.exists():
+        raise FileNotFoundError(f"--dry-run requires fixture at {FIXTURE_PATH}; not found")
+    return json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+
+
+def _parse_sparql_bindings(payload: dict) -> dict[str, dict]:
+    """Parse a SPARQL JSON payload into our `{qid: {...}}` shape."""
     out: dict[str, dict] = {}
-    for b in r.json()["results"]["bindings"]:
+    for b in payload["results"]["bindings"]:
         qid = b["item"]["value"].rsplit("/", 1)[-1]
         entry = out.setdefault(qid, {"label": b.get("itemLabel", {}).get("value", "")})
         if "density" in b and "densityUnit" in b:
@@ -127,28 +155,17 @@ def _sparql_query(qids: list[str]) -> dict[str, dict]:
     return out
 
 
-def _fmt_delta(ours: float | None, theirs: float | None, tol: float) -> str:
-    """Format a comparison cell: ✓ within tolerance, Δ above, — missing."""
-    if ours is None and theirs is None:
-        return "—"
-    if ours is None:
-        return f"(ours missing; wd={theirs:.4g})"
-    if theirs is None:
-        return f"(wd missing; ours={ours:.4g})"
-    diff = abs(ours - theirs)
-    rel = diff / max(abs(ours), abs(theirs), 1e-9)
-    marker = "OK" if rel <= tol else "DIFF"
-    return f"{marker}  ours={ours:.4g} wd={theirs:.4g} Δ={diff:.4g} ({rel * 100:.1f}%)"
-
-
-def compare(key_filter: str | None = None) -> int:
+def compare(key_filter: str | None = None, dry_run: bool = False) -> int:
     mats = load_all()
     targets = {k: q for k, q in WIKIDATA_QIDS.items() if (key_filter is None or k == key_filter)}
     if not targets:
         print(f"No material '{key_filter}' in WIKIDATA_QIDS mapping", file=sys.stderr)
         return 1
 
-    wd = _sparql_query(list(targets.values()))
+    if dry_run:
+        wd = _parse_sparql_bindings(_load_fixture())
+    else:
+        wd = _sparql_query(list(targets.values()))
 
     print(f"{'material':<14} {'density (g/cm³)':<52} {'melt (°C)':<52}")
     print("-" * 120)
@@ -162,8 +179,8 @@ def compare(key_filter: str | None = None) -> int:
         entry = wd.get(qid, {})
         wd_d = entry.get("density_g_cm3")
         wd_m = entry.get("melt_c")
-        d_cell = _fmt_delta(ours_d, wd_d, tol=0.05)
-        m_cell = _fmt_delta(ours_m, wd_m, tol=0.05)
+        d_cell = fmt_delta(ours_d, wd_d, tol=0.05)
+        m_cell = fmt_delta(ours_m, wd_m, tol=0.05)
         if "DIFF" in d_cell or "DIFF" in m_cell:
             diffs += 1
         print(f"{key:<14} {d_cell:<52} {m_cell:<52}")
@@ -177,8 +194,16 @@ def compare(key_filter: str | None = None) -> int:
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--key", help="Only compare this material key")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "Use the bundled SPARQL fixture instead of hitting the live "
+            "endpoint — for offline reproducibility."
+        ),
+    )
     args = parser.parse_args()
-    sys.exit(compare(args.key))
+    sys.exit(compare(args.key, dry_run=args.dry_run))
 
 
 if __name__ == "__main__":

--- a/scripts/requirements-curation.txt
+++ b/scripts/requirements-curation.txt
@@ -11,3 +11,6 @@
 
 requests>=2.28
 playwright>=1.40
+# tomlkit: roundtrip-safe TOML for scripts/_curation.writeback. Preserves
+# comments and formatting when enrichers patch values into data TOMLs.
+tomlkit>=0.12

--- a/tests/fixtures/wikidata_sample.json
+++ b/tests/fixtures/wikidata_sample.json
@@ -1,0 +1,54 @@
+{
+  "head": {
+    "vars": ["item", "itemLabel", "density", "densityUnit", "melt", "meltUnit", "formula"]
+  },
+  "results": {
+    "bindings": [
+      {
+        "item": { "type": "uri", "value": "http://www.wikidata.org/entity/Q663" },
+        "itemLabel": { "type": "literal", "value": "aluminium" },
+        "density": { "type": "literal", "value": "2.7" },
+        "densityUnit": { "type": "uri", "value": "http://www.wikidata.org/entity/Q13147228" },
+        "melt": { "type": "literal", "value": "933.47" },
+        "meltUnit": { "type": "uri", "value": "http://www.wikidata.org/entity/Q11579" },
+        "formula": { "type": "literal", "value": "Al" }
+      },
+      {
+        "item": { "type": "uri", "value": "http://www.wikidata.org/entity/Q753" },
+        "itemLabel": { "type": "literal", "value": "copper" },
+        "density": { "type": "literal", "value": "8.96" },
+        "densityUnit": { "type": "uri", "value": "http://www.wikidata.org/entity/Q13147228" },
+        "melt": { "type": "literal", "value": "1357.77" },
+        "meltUnit": { "type": "uri", "value": "http://www.wikidata.org/entity/Q11579" },
+        "formula": { "type": "literal", "value": "Cu" }
+      },
+      {
+        "item": { "type": "uri", "value": "http://www.wikidata.org/entity/Q669" },
+        "itemLabel": { "type": "literal", "value": "titanium" },
+        "density": { "type": "literal", "value": "4.506" },
+        "densityUnit": { "type": "uri", "value": "http://www.wikidata.org/entity/Q13147228" },
+        "melt": { "type": "literal", "value": "1941" },
+        "meltUnit": { "type": "uri", "value": "http://www.wikidata.org/entity/Q11579" },
+        "formula": { "type": "literal", "value": "Ti" }
+      },
+      {
+        "item": { "type": "uri", "value": "http://www.wikidata.org/entity/Q731" },
+        "itemLabel": { "type": "literal", "value": "tungsten" },
+        "density": { "type": "literal", "value": "19.25" },
+        "densityUnit": { "type": "uri", "value": "http://www.wikidata.org/entity/Q13147228" },
+        "melt": { "type": "literal", "value": "3695" },
+        "meltUnit": { "type": "uri", "value": "http://www.wikidata.org/entity/Q11579" },
+        "formula": { "type": "literal", "value": "W" }
+      },
+      {
+        "item": { "type": "uri", "value": "http://www.wikidata.org/entity/Q708" },
+        "itemLabel": { "type": "literal", "value": "lead" },
+        "density": { "type": "literal", "value": "11.34" },
+        "densityUnit": { "type": "uri", "value": "http://www.wikidata.org/entity/Q13147228" },
+        "melt": { "type": "literal", "value": "600.61" },
+        "meltUnit": { "type": "uri", "value": "http://www.wikidata.org/entity/Q11579" },
+        "formula": { "type": "literal", "value": "Pb" }
+      }
+    ]
+  }
+}

--- a/tests/test_curation_helpers.py
+++ b/tests/test_curation_helpers.py
@@ -1,0 +1,368 @@
+"""Tests for `scripts/_curation` — Phase 4 prep shared helpers.
+
+Covers:
+* `cached_get`: cache hit avoids second network call; TTL expiry refetches.
+* `UnitNormalizer`: rejects unknown source/unit pairs; applies registered scale.
+* `build_source_row`: rejects invalid `kind` and `license` values.
+* `writeback`: round-trips a TOML preserving comments + formatting.
+* `load_material_keys`: enumerates expected dotted paths from `metals.toml`.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+# scripts/ isn't on sys.path by default (it's not a package); inject it.
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import _curation  # noqa: E402
+from _curation import (  # noqa: E402
+    UnitNormalizer,
+    build_source_row,
+    cached_get,
+    load_material_keys,
+    writeback,
+)
+
+# --------------------------------------------------------------------------- #
+# cached_get                                                                  #
+# --------------------------------------------------------------------------- #
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict):
+        self._payload = payload
+        self.status_code = 200
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict:
+        return self._payload
+
+
+def _redirect_cache(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setattr(_curation, "CACHE_DIR", cache_dir)
+    return cache_dir
+
+
+def test_cached_get_uses_disk_on_second_call(monkeypatch, tmp_path):
+    _redirect_cache(monkeypatch, tmp_path)
+    calls = {"n": 0}
+
+    def fake_get(url, params=None, headers=None, timeout=None):
+        calls["n"] += 1
+        return _FakeResponse({"hello": "world", "n": calls["n"]})
+
+    monkeypatch.setattr(_curation.requests, "get", fake_get)
+
+    out1 = cached_get("https://example.test/api", source="unit-test")
+    out2 = cached_get("https://example.test/api", source="unit-test")
+
+    assert calls["n"] == 1, "second call should hit the disk cache"
+    assert out1 == out2 == {"hello": "world", "n": 1}
+
+
+def test_cached_get_refetches_after_ttl_expiry(monkeypatch, tmp_path):
+    cache_dir = _redirect_cache(monkeypatch, tmp_path)
+    calls = {"n": 0}
+
+    def fake_get(url, params=None, headers=None, timeout=None):
+        calls["n"] += 1
+        return _FakeResponse({"n": calls["n"]})
+
+    monkeypatch.setattr(_curation.requests, "get", fake_get)
+
+    cached_get("https://example.test/ttl", source="ttl-test", ttl_days=1)
+    # Expire the cache file by backdating its mtime two days into the past.
+    files = list((cache_dir / "ttl-test").glob("*.json"))
+    assert len(files) == 1
+    past = time.time() - 2 * 86400
+    os.utime(files[0], (past, past))
+
+    out2 = cached_get("https://example.test/ttl", source="ttl-test", ttl_days=1)
+    assert calls["n"] == 2
+    assert out2 == {"n": 2}
+
+
+def test_cached_get_post_with_data(monkeypatch, tmp_path):
+    _redirect_cache(monkeypatch, tmp_path)
+    received = {}
+
+    def fake_post(url, params=None, data=None, headers=None, timeout=None):
+        received["data"] = data
+        received["headers"] = headers
+        return _FakeResponse({"ok": True})
+
+    monkeypatch.setattr(_curation.requests, "post", fake_post)
+
+    out = cached_get(
+        "https://example.test/sparql",
+        source="post-test",
+        method="POST",
+        data={"query": "SELECT *"},
+    )
+    assert out == {"ok": True}
+    assert received["data"] == {"query": "SELECT *"}
+    assert "pymat-curation" in received["headers"]["User-Agent"]
+
+
+# --------------------------------------------------------------------------- #
+# UnitNormalizer                                                              #
+# --------------------------------------------------------------------------- #
+
+
+def test_unit_normalizer_applies_registered_scale():
+    n = UnitNormalizer()
+    n.register("wikidata", "Q844211", "g/cm^3", scale=1e-3)
+    value, unit = n.normalize("wikidata", 2700.0, "Q844211", target_property="density")
+    assert unit == "g/cm^3"
+    assert value == pytest.approx(2.7)
+
+
+def test_unit_normalizer_passthrough_when_already_canonical():
+    n = UnitNormalizer()
+    n.register("wikidata", "Q13147228", "g/cm^3")
+    value, unit = n.normalize("wikidata", 2.7, "Q13147228", target_property="density")
+    assert unit == "g/cm^3"
+    assert value == pytest.approx(2.7)
+
+
+def test_unit_normalizer_rejects_unknown_source():
+    n = UnitNormalizer()
+    n.register("wikidata", "Q13147228", "g/cm^3")
+    with pytest.raises(KeyError, match="source='nist_webbook'"):
+        n.normalize("nist_webbook", 1.0, "g/cm**3", target_property="density")
+
+
+def test_unit_normalizer_rejects_unknown_unit():
+    n = UnitNormalizer()
+    n.register("wikidata", "Q13147228", "g/cm^3")
+    with pytest.raises(KeyError, match="unit='Q999999'"):
+        n.normalize("wikidata", 1.0, "Q999999", target_property="density")
+
+
+# --------------------------------------------------------------------------- #
+# build_source_row                                                            #
+# --------------------------------------------------------------------------- #
+
+
+def test_build_source_row_happy_path():
+    row = build_source_row(
+        citation="Q663",
+        kind="qid",
+        ref="https://www.wikidata.org/wiki/Q663",
+        license="CC0",
+    )
+    assert row == {
+        "citation": "Q663",
+        "kind": "qid",
+        "ref": "https://www.wikidata.org/wiki/Q663",
+        "license": "CC0",
+    }
+
+
+def test_build_source_row_includes_note():
+    row = build_source_row(
+        citation="10.1234/x", kind="doi", ref="doi:10.1234/x", license="CC-BY-4.0", note="page 42"
+    )
+    assert row["note"] == "page 42"
+
+
+def test_build_source_row_rejects_invalid_kind():
+    with pytest.raises(ValueError, match="kind="):
+        build_source_row(citation="x", kind="blog", ref="x", license="CC0")
+
+
+def test_build_source_row_rejects_invalid_license():
+    with pytest.raises(ValueError, match="license="):
+        build_source_row(citation="x", kind="doi", ref="x", license="GPL-3.0")
+
+
+def test_build_source_row_rejects_unknown_license_alias():
+    with pytest.raises(ValueError, match="license='unknown'"):
+        build_source_row(citation="x", kind="doi", ref="x", license="unknown")
+
+
+def test_build_source_row_requires_citation_and_ref():
+    with pytest.raises(ValueError, match="citation"):
+        build_source_row(citation="", kind="doi", ref="x", license="CC0")
+    with pytest.raises(ValueError, match="ref"):
+        build_source_row(citation="x", kind="doi", ref="", license="CC0")
+
+
+# --------------------------------------------------------------------------- #
+# writeback                                                                   #
+# --------------------------------------------------------------------------- #
+
+
+def test_writeback_preserves_comments_and_updates_value(tmp_path):
+    src = dedent(
+        """\
+        # top-of-file comment — must survive the round-trip
+        [aluminum]
+        name = "Aluminum"
+
+        [aluminum.al6061]
+        # grade-level comment
+        name = "Aluminum 6061-T6"
+        grade = "6061-T6"
+
+        [aluminum.al6061.mechanical]
+        # density was rounded; replace with NIST value
+        density_value = 2.70
+        density_unit = "g/cm^3"
+        """
+    )
+    p = tmp_path / "al.toml"
+    p.write_text(src)
+
+    modified = writeback(
+        p,
+        ["aluminum", "al6061", "mechanical"],
+        {"density_value": 2.6989, "density_unit": "g/cm^3"},
+    )
+    assert modified is True
+
+    out = p.read_text()
+    assert "# top-of-file comment" in out
+    assert "# grade-level comment" in out
+    assert "# density was rounded" in out
+    assert "density_value = 2.6989" in out
+
+
+def test_writeback_attaches_sources_block(tmp_path):
+    src = dedent(
+        """\
+        [aluminum]
+        name = "Aluminum"
+
+        [aluminum.al6061]
+        name = "Aluminum 6061-T6"
+
+        [aluminum.al6061.mechanical]
+        density_value = 2.70
+        density_unit = "g/cm^3"
+        """
+    )
+    p = tmp_path / "al.toml"
+    p.write_text(src)
+
+    row = build_source_row(
+        citation="Q663", kind="qid", ref="https://www.wikidata.org/wiki/Q663", license="CC0"
+    )
+    writeback(
+        p,
+        ["aluminum", "al6061", "mechanical"],
+        {"density_value": 2.6989},
+        sources={"density": row},
+    )
+
+    out = p.read_text()
+    assert "[aluminum.al6061._sources]" in out
+    assert "mechanical.density" in out
+    assert "Q663" in out
+
+
+def test_writeback_returns_false_when_unchanged(tmp_path):
+    # Use an integer-valued float and a string so tomlkit's serialized
+    # form is identical to the source — that's the contract `writeback`
+    # promises ("True iff the file changed on disk").
+    src = dedent(
+        """\
+        [aluminum]
+        name = "Aluminum"
+
+        [aluminum.mechanical]
+        density_unit = "g/cm^3"
+        """
+    )
+    p = tmp_path / "al.toml"
+    p.write_text(src)
+
+    modified = writeback(
+        p,
+        ["aluminum", "mechanical"],
+        {"density_unit": "g/cm^3"},
+    )
+    assert modified is False
+
+
+# --------------------------------------------------------------------------- #
+# load_material_keys                                                          #
+# --------------------------------------------------------------------------- #
+
+
+def test_load_material_keys_finds_expected_metals():
+    keys = load_material_keys("metals")
+    # Family-level entries we know exist.
+    assert "stainless" in keys
+    assert "aluminum" in keys
+    # At least one nested grade should appear.
+    assert any(k.startswith("aluminum.") for k in keys)
+    # Property-group sub-tables must NOT leak in as materials.
+    assert "stainless.mechanical" not in keys
+    assert "aluminum.thermal" not in keys
+
+
+def test_load_material_keys_against_synthetic_toml(tmp_path):
+    p = tmp_path / "synthetic.toml"
+    p.write_text(
+        dedent(
+            """\
+            [foo]
+            name = "Foo"
+            [foo.mechanical]
+            density_value = 1.0
+            [foo.bar]
+            name = "Foo bar grade"
+            [foo._sources]
+            _default = {citation = "x", kind = "doi", ref = "x", license = "CC0"}
+            [baz]
+            name = "Baz"
+            """
+        )
+    )
+    keys = load_material_keys("synthetic", data_dir=tmp_path)
+    assert keys == ["foo", "foo.bar", "baz"]
+
+
+# --------------------------------------------------------------------------- #
+# Wikidata enricher --dry-run integration                                     #
+# --------------------------------------------------------------------------- #
+
+
+def test_wikidata_dry_run_uses_fixture(monkeypatch, capsys):
+    # Import lazily — the script lives at scripts/enrich_from_wikidata.py
+    # and pulls in pymat at import time.
+    import importlib
+
+    enricher = importlib.import_module("enrich_from_wikidata")
+
+    def boom(*a, **kw):  # pragma: no cover — must not be called
+        raise AssertionError("network must not be hit in --dry-run")
+
+    monkeypatch.setattr(enricher.requests, "post", boom)
+    monkeypatch.setattr(enricher.requests, "get", boom)
+
+    rc = enricher.compare(key_filter=None, dry_run=True)
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "material" in captured.out
+    assert "Wikidata values are CC0" in captured.out
+
+
+def test_wikidata_fixture_file_is_valid_json():
+    fixture = Path(__file__).parent / "fixtures" / "wikidata_sample.json"
+    payload = json.loads(fixture.read_text())
+    assert "results" in payload and "bindings" in payload["results"]

--- a/tests/test_curation_helpers.py
+++ b/tests/test_curation_helpers.py
@@ -19,6 +19,14 @@ from textwrap import dedent
 
 import pytest
 
+# `_curation` lives in `scripts/` (curation-time only) and depends on
+# `requests` + `tomlkit`, which aren't part of the main dev/runtime
+# install. CI doesn't install `scripts/requirements-curation.txt`, so
+# skip the whole module if either is missing — these tests gate the
+# curation tooling, not the library itself.
+pytest.importorskip("requests")
+pytest.importorskip("tomlkit")
+
 # scripts/ isn't on sys.path by default (it's not a package); inject it.
 SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
 if str(SCRIPTS_DIR) not in sys.path:


### PR DESCRIPTION
## Summary

- Extract HTTP cache, unit normalizer, `_sources` row builder, comment-preserving TOML writeback, and material-key enumeration from `scripts/enrich_from_wikidata.py` into a new `scripts/_curation.py` module so the upcoming per-source enrichers (#158, #159, #164, #165, #166, #167) share a single audited implementation.
- Refactor the Wikidata enricher to consume the shared helpers; CLI args, output format, and exit codes unchanged. Add a `--dry-run` flag backed by `tests/fixtures/wikidata_sample.json` for offline reproducibility.
- Add `tomlkit>=0.12` to `scripts/requirements-curation.txt`; gitignore `scripts/.cache/`.

## What this is NOT

- No new abstractions for hypothetical future enrichers (no plugin registry, no event hooks, no protocol classes).
- No Python floor bump.
- No changes to `src/pymat/data/*.toml` content.

## Test plan

- [x] `uv run pytest tests/test_curation_helpers.py -v` — 20 new tests pass (cache hit, TTL expiry, POST cache, `UnitNormalizer` rejects unknown source/unit, scale applied, `build_source_row` validates `kind`/`license`/`citation`/`ref`, writeback preserves comments, attaches `_sources`, returns False when unchanged, `load_material_keys` for `metals.toml` + synthetic fixture, `--dry-run` consumes the fixture without network)
- [x] `uv run pytest` — full suite: 646 passed, 19 skipped (pre-existing skips), 1 warning (pre-existing)
- [x] `uv run ruff check` and `uv run ruff format` — clean
- [x] `uv run python scripts/enrich_from_wikidata.py --dry-run` — fixture-based output identical in shape to pre-refactor live output
- [x] `uv run python scripts/enrich_from_wikidata.py --key copper` — live SPARQL hit, output unchanged
- [x] `git check-ignore -v scripts/.cache/...` — confirmed gitignored
- [x] `uv run python scripts/check_licenses.py` — passes (no data corpus changes)