### PR TITLE
feat(scripts): extend Wikidata enricher to compounds + new properties (#158)

### DIFF
--- a/scripts/enrich_from_wikidata.py
+++ b/scripts/enrich_from_wikidata.py
@@ -1,38 +1,74 @@
 #!/usr/bin/env python3
-"""Compare mat's mechanical/thermal properties against Wikidata reference values.
+"""Compare mat's thermal/mechanical properties against Wikidata reference values.
 
 Wikidata is CC0 and has no auth — ideal for curation-time cross-checks.
-This script takes a mapping of (material_key → Wikidata Q-ID), runs a
-single SPARQL query, and prints a side-by-side report so a human can
-decide whether to update the TOMLs.
+This script enumerates every material in `src/pymat/data/*.toml`, looks
+up its Wikidata QID (from `[<material>.sourcing].wikidata` or the
+curator-maintained fallback dict below), runs a single SPARQL query
+batch, and produces a side-by-side report.
+
+With `--write`, the enricher applies a *conservative add-only* writeback:
+it never overwrites an existing TOML value, but if our value is missing
+and Wikidata has one, it writes the value and a paired `_sources` row
+keyed by the dotted property path (e.g. `mechanical.density`) under
+`[<material>._sources]`.
 
 This is NOT a runtime dependency of mat — it lives in scripts/ for
 data curation. Shared helpers live in `scripts/_curation.py`.
 
 Usage:
-    python scripts/enrich_from_wikidata.py              # full report
-    python scripts/enrich_from_wikidata.py --key copper # one material
-    python scripts/enrich_from_wikidata.py --dry-run    # use fixture, no network
+    python scripts/enrich_from_wikidata.py                 # comparison report
+    python scripts/enrich_from_wikidata.py --key copper    # one material
+    python scripts/enrich_from_wikidata.py --dry-run       # use fixture, no network
+    python scripts/enrich_from_wikidata.py --write         # apply add-only writeback
+    python scripts/enrich_from_wikidata.py --report out.md # write report to file
 
 Source: https://query.wikidata.org/sparql
 Property IDs used:
-    P2054 — density       (unit Q13147228 = g/cm³, Q844211 = kg/m³)
-    P2101 — melting point (unit Q11579 = K, Q25267 = °C)
-    P274  — chemical formula
+    P2054 — density            (units: Q13147228 g/cm³, Q844211 kg/m³)
+    P2101 — melting point      (units: Q11579 K, Q25267 °C)
+    P2102 — boiling point      (units: Q11579 K, Q25267 °C) — REPORT ONLY
+    P2068 — thermal conductivity (units: Q748857 W/(m·K))
+    P2056 — heat capacity      (units: Q752197 J/(kg·K), Q21075844 J/(g·K))
+
+Deferred (issue #158 scope discipline):
+    P2153 — Young's modulus  — needs per-grade resolution; revisit in a
+                                follow-up after the alloy-grade matrix
+                                is settled.
+    P2055 — electrical resistivity — Wikidata mixes Ω·m and Ω·cm by
+                                domain (metals vs. ceramics) and has no
+                                clean per-grade story; revisit after
+                                #170/#171 ceramics work lands.
+
+Boiling point (P2102) is fetched and reported, but the schema has no
+`boiling_point` field today (`pymat.properties.ThermalProperties`), so
+the writeback path skips it. Adding the schema field is out of scope —
+this PR is curation tooling only.
 """
 
 from __future__ import annotations
 
 import argparse
+import datetime as _dt
 import json
 import sys
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 import requests  # noqa: E402
-from _curation import USER_AGENT, fmt_delta  # noqa: E402
+import tomlkit  # noqa: E402
+from _curation import (  # noqa: E402
+    DATA_DIR,
+    USER_AGENT,
+    build_source_row,
+    fmt_delta,
+    load_material_keys,
+    writeback,
+)
 
 from pymat import load_all  # noqa: E402
 
@@ -41,9 +77,10 @@ FIXTURE_PATH = (
     Path(__file__).resolve().parent.parent / "tests" / "fixtures" / "wikidata_sample.json"
 )
 
-# Curator-maintained mapping. Start with entries that have a clear
-# Wikidata identity; specific grades (s304, a6061, hdpe) don't belong
-# here — cross-check the base polymer/element instead.
+# Curator-maintained fallback mapping. Used when a TOML material has no
+# `[<material>.sourcing].wikidata` field. Specific grades (s304, a6061,
+# hdpe) intentionally don't appear here — they cross-check against the
+# parent element/polymer.
 WIKIDATA_QIDS: dict[str, str] = {
     # Metals & alloys
     "aluminum": "Q663",  # aluminium (element)
@@ -63,16 +100,25 @@ WIKIDATA_QIDS: dict[str, str] = {
     "delrin": "Q146139",  # polyoxymethylene
 }
 
-# Wikidata unit Q-IDs we understand. Anything else → mark as "unknown unit".
-# Kept inline (not yet via UnitNormalizer) because density and melting
-# point both have a special case (Kelvin offset, kg/m³ scale) that the
-# generic registry can't express in a single multiplicative scale; the
-# QID set itself is the only piece worth lifting and it stays here as a
-# curated whitelist for clarity.
+# Wikidata unit QIDs we understand. Anything else → log and skip the
+# datapoint. Keeping the whitelist explicit (rather than a generic
+# UnitNormalizer registration) because melting/boiling points need a
+# Kelvin offset — multiplicative scale alone can't express that.
 _UNIT_G_CM3 = "Q13147228"
 _UNIT_KG_M3 = "Q844211"
 _UNIT_KELVIN = "Q11579"
 _UNIT_CELSIUS = "Q25267"
+_UNIT_W_M_K = "Q748857"  # watt per metre-kelvin
+_UNIT_J_KG_K = "Q752197"  # joule per kilogram-kelvin
+_UNIT_J_G_K = "Q21075844"  # joule per gram-kelvin (×1000 → J/(kg·K))
+# Molar heat capacity (J/(mol·K), Q13035094) is intentionally NOT
+# normalized: converting requires the material's molar mass and brings
+# in molecule-vs-formula-unit ambiguity that's out of scope for #158.
+
+
+# --------------------------------------------------------------------------- #
+# Unit normalization                                                          #
+# --------------------------------------------------------------------------- #
 
 
 def _normalize_density(amount: float, unit_qid: str) -> float | None:
@@ -84,8 +130,8 @@ def _normalize_density(amount: float, unit_qid: str) -> float | None:
     return None
 
 
-def _normalize_melting_point(amount: float, unit_qid: str) -> float | None:
-    """Normalize melting point to °C."""
+def _normalize_temperature_c(amount: float, unit_qid: str) -> float | None:
+    """Normalize temperature to °C (used for melting + boiling)."""
     if unit_qid == _UNIT_CELSIUS:
         return amount
     if unit_qid == _UNIT_KELVIN:
@@ -93,10 +139,42 @@ def _normalize_melting_point(amount: float, unit_qid: str) -> float | None:
     return None
 
 
+def _normalize_thermal_conductivity(amount: float, unit_qid: str) -> float | None:
+    """Normalize thermal conductivity to W/(m·K)."""
+    if unit_qid == _UNIT_W_M_K:
+        return amount
+    return None
+
+
+def _normalize_specific_heat(amount: float, unit_qid: str) -> float | None:
+    """Normalize specific heat to J/(kg·K).
+
+    Wikidata mixes J/(g·K) and J/(mol·K); the latter would need a molar
+    mass lookup which is out of scope (see module docstring).
+    """
+    if unit_qid == _UNIT_J_KG_K:
+        return amount
+    if unit_qid == _UNIT_J_G_K:
+        return amount * 1000.0
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# SPARQL                                                                      #
+# --------------------------------------------------------------------------- #
+
+
 def _build_sparql(qids: list[str]) -> str:
+    """Build the SPARQL query for our property set.
+
+    Kept readable (not auto-generated) so a curator can paste it into
+    https://query.wikidata.org/ and tweak interactively.
+    """
     values_clause = " ".join(f"wd:{q}" for q in qids)
     return f"""
-    SELECT ?item ?itemLabel ?density ?densityUnit ?melt ?meltUnit ?formula WHERE {{
+    SELECT ?item ?itemLabel ?density ?densityUnit
+           ?melt ?meltUnit ?boil ?boilUnit
+           ?tcond ?tcondUnit ?cp ?cpUnit ?formula WHERE {{
       VALUES ?item {{ {values_clause} }}
       OPTIONAL {{
         ?item p:P2054 ?dStmt . ?dStmt psv:P2054 ?dv .
@@ -108,6 +186,21 @@ def _build_sparql(qids: list[str]) -> str:
         ?mv wikibase:quantityAmount ?melt .
         ?mv wikibase:quantityUnit ?meltUnit .
       }}
+      OPTIONAL {{
+        ?item p:P2102 ?bStmt . ?bStmt psv:P2102 ?bv .
+        ?bv wikibase:quantityAmount ?boil .
+        ?bv wikibase:quantityUnit ?boilUnit .
+      }}
+      OPTIONAL {{
+        ?item p:P2068 ?kStmt . ?kStmt psv:P2068 ?kv .
+        ?kv wikibase:quantityAmount ?tcond .
+        ?kv wikibase:quantityUnit ?tcondUnit .
+      }}
+      OPTIONAL {{
+        ?item p:P2056 ?cStmt . ?cStmt psv:P2056 ?cv .
+        ?cv wikibase:quantityAmount ?cp .
+        ?cv wikibase:quantityUnit ?cpUnit .
+      }}
       OPTIONAL {{ ?item wdt:P274 ?formula . }}
       SERVICE wikibase:label {{ bd:serviceParam wikibase:language "en" . }}
     }}
@@ -116,6 +209,8 @@ def _build_sparql(qids: list[str]) -> str:
 
 def _sparql_query(qids: list[str]) -> dict[str, dict]:
     """Run a single SPARQL query for the given Q-IDs; return {qid: props}."""
+    if not qids:
+        return {}
     query = _build_sparql(qids)
     r = requests.post(
         SPARQL_URL,
@@ -124,7 +219,7 @@ def _sparql_query(qids: list[str]) -> dict[str, dict]:
             "User-Agent": f"{USER_AGENT} (https://github.com/MorePet/py-mat)",
             "Accept": "application/sparql-results+json",
         },
-        timeout=20,
+        timeout=30,
     )
     r.raise_for_status()
     return _parse_sparql_bindings(r.json())
@@ -137,7 +232,12 @@ def _load_fixture() -> dict:
 
 
 def _parse_sparql_bindings(payload: dict) -> dict[str, dict]:
-    """Parse a SPARQL JSON payload into our `{qid: {...}}` shape."""
+    """Parse a SPARQL JSON payload into our `{qid: {...}}` shape.
+
+    Each key in the returned dict yields normalized scalar values where
+    possible. Unparseable units are silently dropped — they surface as
+    `None` and the report logs them as missing rather than wrong.
+    """
     out: dict[str, dict] = {}
     for b in payload["results"]["bindings"]:
         qid = b["item"]["value"].rsplit("/", 1)[-1]
@@ -148,46 +248,363 @@ def _parse_sparql_bindings(payload: dict) -> dict[str, dict]:
             entry["density_raw"] = (float(b["density"]["value"]), unit)
         if "melt" in b and "meltUnit" in b:
             unit = b["meltUnit"]["value"].rsplit("/", 1)[-1]
-            entry["melt_c"] = _normalize_melting_point(float(b["melt"]["value"]), unit)
+            entry["melt_c"] = _normalize_temperature_c(float(b["melt"]["value"]), unit)
             entry["melt_raw"] = (float(b["melt"]["value"]), unit)
+        if "boil" in b and "boilUnit" in b:
+            unit = b["boilUnit"]["value"].rsplit("/", 1)[-1]
+            entry["boil_c"] = _normalize_temperature_c(float(b["boil"]["value"]), unit)
+            entry["boil_raw"] = (float(b["boil"]["value"]), unit)
+        if "tcond" in b and "tcondUnit" in b:
+            unit = b["tcondUnit"]["value"].rsplit("/", 1)[-1]
+            entry["thermal_conductivity_w_m_k"] = _normalize_thermal_conductivity(
+                float(b["tcond"]["value"]), unit
+            )
+            entry["thermal_conductivity_raw"] = (float(b["tcond"]["value"]), unit)
+        if "cp" in b and "cpUnit" in b:
+            unit = b["cpUnit"]["value"].rsplit("/", 1)[-1]
+            entry["specific_heat_j_kg_k"] = _normalize_specific_heat(float(b["cp"]["value"]), unit)
+            entry["specific_heat_raw"] = (float(b["cp"]["value"]), unit)
         if "formula" in b:
             entry["formula"] = b["formula"]["value"]
     return out
 
 
-def compare(key_filter: str | None = None, dry_run: bool = False) -> int:
+# --------------------------------------------------------------------------- #
+# Property mapping (TOML field → Wikidata key, group, unit)                   #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class PropertySpec:
+    """Maps a Wikidata-derived value onto a `[<material>.<group>]` field."""
+
+    group: str  # "mechanical" or "thermal"
+    field: str  # "density", "melting_point", ...
+    wd_key: str  # key in the parsed binding dict
+    canonical_unit: str  # value to write into <field>_unit
+    pid: str  # Wikidata property ID for the source note
+    writable: bool = True  # False → report only, never writeback
+
+
+# Order matters only for report column order.
+_PROPERTIES: list[PropertySpec] = [
+    PropertySpec("mechanical", "density", "density_g_cm3", "g/cm^3", "P2054"),
+    PropertySpec("thermal", "melting_point", "melt_c", "degC", "P2101"),
+    # Boiling point isn't in the schema today (no boiling_point field on
+    # ThermalProperties). Keep it report-only — adding the schema field
+    # is out of scope for #158.
+    PropertySpec("thermal", "boiling_point", "boil_c", "degC", "P2102", writable=False),
+    PropertySpec(
+        "thermal",
+        "thermal_conductivity",
+        "thermal_conductivity_w_m_k",
+        "W/(m*K)",
+        "P2068",
+    ),
+    PropertySpec("thermal", "specific_heat", "specific_heat_j_kg_k", "J/(kg*K)", "P2056"),
+]
+
+
+# --------------------------------------------------------------------------- #
+# QID resolution: TOML sourcing block first, fallback dict second             #
+# --------------------------------------------------------------------------- #
+
+
+def _read_doc(toml_path: Path) -> tomlkit.TOMLDocument:
+    return tomlkit.parse(toml_path.read_text(encoding="utf-8"))
+
+
+def _walk(doc: Any, dotted: str) -> Any | None:
+    """Walk `doc` down `dotted` (e.g. 'aluminum.a6061'); return None if absent."""
+    node: Any = doc
+    for seg in dotted.split("."):
+        if not isinstance(node, dict) or seg not in node:
+            return None
+        node = node[seg]
+    return node
+
+
+def _resolve_qid(doc: Any, material_key: str) -> str | None:
+    """Look up the Wikidata QID for `material_key`.
+
+    Preference order:
+    1. `[<material_key>.sourcing].wikidata` in the TOML
+    2. `WIKIDATA_QIDS[material_key]` (curator-maintained fallback)
+    3. None — caller skips
+    """
+    node = _walk(doc, material_key)
+    if isinstance(node, dict):
+        sourcing = node.get("sourcing")
+        if isinstance(sourcing, dict):
+            wd = sourcing.get("wikidata")
+            if isinstance(wd, str) and wd.startswith("Q"):
+                return wd
+    return WIKIDATA_QIDS.get(material_key)
+
+
+# --------------------------------------------------------------------------- #
+# Comparison + writeback                                                      #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class Row:
+    """One material's comparison row in the diff report."""
+
+    category: str
+    key: str
+    qid: str
+    cells: dict[str, str]  # field name → formatted comparison cell
+    diffs: list[str]  # field names with DIFF flag
+    missing: list[str]  # field names where ours is None and wd has a value
+
+
+def _category_for_key(material_key: str) -> str | None:
+    """Find which `<category>.toml` defines `material_key`."""
+    for cat_path in DATA_DIR.glob("*.toml"):
+        doc = _read_doc(cat_path)
+        if _walk(doc, material_key) is not None:
+            return cat_path.stem
+    return None
+
+
+def _ours_value(mat: Any, group: str, field: str) -> float | None:
+    """Read the loaded scalar value for (group, field), or None."""
+    if mat is None:
+        return None
+    props = getattr(mat, "properties", None)
+    if props is None:
+        return None
+    grp = getattr(props, group, None)
+    if grp is None:
+        return None
+    return getattr(grp, field, None)
+
+
+def _today_iso() -> str:
+    return _dt.date.today().isoformat()
+
+
+def _apply_writeback(
+    toml_path: Path,
+    material_key: str,
+    group: str,
+    field: str,
+    value: float,
+    canonical_unit: str,
+    qid: str,
+    pid: str,
+) -> None:
+    """Write a missing value + paired `_sources` row.
+
+    Conservative add-only — caller has already verified that `field`
+    is absent in the TOML.
+    """
+    note = f"{pid} via SPARQL {_today_iso()}"
+    row = build_source_row(
+        citation=f"Wikidata {qid}",
+        kind="qid",
+        ref=qid,
+        license="CC0",
+        note=note,
+    )
+    material_path = material_key.split(".") + [group]
+    writeback(
+        toml_path,
+        material_path,
+        {f"{field}_value": value, f"{field}_unit": canonical_unit},
+        sources={field: row},
+    )
+
+
+def _compare_one(
+    *,
+    category: str,
+    material_key: str,
+    qid: str,
+    wd_entry: dict,
+    mats: dict,
+    toml_path: Path,
+    write: bool,
+    tol: float = 0.05,
+) -> Row:
+    """Compare every property for one material; optionally writeback."""
+    cells: dict[str, str] = {}
+    diffs: list[str] = []
+    missing: list[str] = []
+
+    # Re-parse the TOML each call so writeback() within this loop sees
+    # the latest disk state. Cheap enough — `<category>.toml` is small.
+    doc = _read_doc(toml_path)
+    material_node = _walk(doc, material_key)
+
+    for spec in _PROPERTIES:
+        ours = _ours_value(mats.get(material_key), spec.group, spec.field)
+        theirs = wd_entry.get(spec.wd_key)
+        cell = fmt_delta(ours, theirs, tol=tol)
+        cells[spec.field] = cell
+        if "DIFF" in cell:
+            diffs.append(spec.field)
+        # MISSING: ours absent, wd present, AND the field is writable
+        # (i.e. the schema knows about it). Boiling stays report-only.
+        if ours is None and theirs is not None and spec.writable:
+            missing.append(spec.field)
+
+            if write:
+                # Defensive: writeback only if the TOML truly lacks the
+                # `<field>_value` key. The loaded `mat` could be None
+                # because the property *group* doesn't exist yet.
+                group_node = (
+                    material_node.get(spec.group) if isinstance(material_node, dict) else None
+                )
+                already_set = isinstance(group_node, dict) and (
+                    f"{spec.field}_value" in group_node or spec.field in group_node
+                )
+                if not already_set:
+                    _apply_writeback(
+                        toml_path,
+                        material_key,
+                        spec.group,
+                        spec.field,
+                        float(theirs),
+                        spec.canonical_unit,
+                        qid,
+                        spec.pid,
+                    )
+
+    return Row(
+        category=category,
+        key=material_key,
+        qid=qid,
+        cells=cells,
+        diffs=diffs,
+        missing=missing,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Report rendering                                                            #
+# --------------------------------------------------------------------------- #
+
+
+def _render_report(rows: list[Row], write: bool) -> str:
+    """Render the diff report in a stable, greppable format."""
+    lines: list[str] = []
+    lines.append("# Wikidata enrichment report")
+    lines.append("")
+    lines.append(f"Date: {_today_iso()}")
+    lines.append(f"Mode: {'write (add-only)' if write else 'comparison-only'}")
+    lines.append(f"Materials checked: {len(rows)}")
+    lines.append("")
+
+    header = ["material", "qid"] + [s.field for s in _PROPERTIES]
+    lines.append(" | ".join(header))
+    lines.append(" | ".join("---" for _ in header))
+    for r in rows:
+        cells = [r.key, r.qid]
+        for spec in _PROPERTIES:
+            cell = r.cells.get(spec.field, "—")
+            cells.append(cell.replace("|", "/"))
+        lines.append(" | ".join(cells))
+    lines.append("")
+
+    # Inline DIFF / MISSING summary — easy to grep.
+    diff_rows = [r for r in rows if r.diffs]
+    miss_rows = [r for r in rows if r.missing]
+    lines.append(f"DIFF rows: {len(diff_rows)}")
+    for r in diff_rows:
+        lines.append(f"  DIFF  {r.key} ({r.qid}): {', '.join(r.diffs)}")
+    lines.append(f"MISSING rows: {len(miss_rows)}")
+    for r in miss_rows:
+        action = "WROTE" if write else "would-write"
+        lines.append(f"  MISSING  {r.key} ({r.qid}): {', '.join(r.missing)}  [{action}]")
+    lines.append("")
+    lines.append("Wikidata values are CC0; cited via QIDs in `_sources` rows.")
+    return "\n".join(lines) + "\n"
+
+
+# --------------------------------------------------------------------------- #
+# Driver                                                                      #
+# --------------------------------------------------------------------------- #
+
+
+def _enumerate_targets(key_filter: str | None) -> list[tuple[str, str, str]]:
+    """Return `(category, material_key, qid)` triples for every target.
+
+    Iterates over every `<category>.toml` in `DATA_DIR`, walks each
+    material via `load_material_keys`, and resolves the QID. Materials
+    without a QID are silently skipped.
+    """
+    targets: list[tuple[str, str, str]] = []
+    for cat_path in sorted(DATA_DIR.glob("*.toml")):
+        category = cat_path.stem
+        doc = _read_doc(cat_path)
+        for mkey in load_material_keys(category):
+            if key_filter is not None and mkey != key_filter:
+                continue
+            qid = _resolve_qid(doc, mkey)
+            if qid is None:
+                continue
+            targets.append((category, mkey, qid))
+    return targets
+
+
+def compare(
+    key_filter: str | None = None,
+    *,
+    dry_run: bool = False,
+    write: bool = False,
+    report_path: Path | None = None,
+) -> int:
+    """Run the comparison; print or write the report.
+
+    Return code 0 on success regardless of DIFF count — the report is
+    advisory. Non-zero only on hard errors (missing fixture, network).
+    """
     mats = load_all()
-    targets = {k: q for k, q in WIKIDATA_QIDS.items() if (key_filter is None or k == key_filter)}
+    targets = _enumerate_targets(key_filter)
+
     if not targets:
-        print(f"No material '{key_filter}' in WIKIDATA_QIDS mapping", file=sys.stderr)
+        msg = (
+            f"No targets matched key={key_filter!r}"
+            if key_filter
+            else "No materials with Wikidata QIDs found"
+        )
+        print(msg, file=sys.stderr)
         return 1
 
     if dry_run:
         wd = _parse_sparql_bindings(_load_fixture())
     else:
-        wd = _sparql_query(list(targets.values()))
+        # De-duplicate QIDs: brass and stainless map to distinct Q-IDs,
+        # but a future curator could legitimately point two grades at
+        # the same parent QID, and we shouldn't pay for it twice.
+        unique_qids = sorted({qid for _, _, qid in targets})
+        wd = _sparql_query(unique_qids)
 
-    print(f"{'material':<14} {'density (g/cm³)':<52} {'melt (°C)':<52}")
-    print("-" * 120)
-    diffs = 0
-    for key, qid in targets.items():
-        mat = mats.get(key)
-        if mat is None:
-            continue
-        ours_d = mat.properties.mechanical.density
-        ours_m = mat.properties.thermal.melting_point
-        entry = wd.get(qid, {})
-        wd_d = entry.get("density_g_cm3")
-        wd_m = entry.get("melt_c")
-        d_cell = fmt_delta(ours_d, wd_d, tol=0.05)
-        m_cell = fmt_delta(ours_m, wd_m, tol=0.05)
-        if "DIFF" in d_cell or "DIFF" in m_cell:
-            diffs += 1
-        print(f"{key:<14} {d_cell:<52} {m_cell:<52}")
+    rows: list[Row] = []
+    for category, mkey, qid in targets:
+        toml_path = DATA_DIR / f"{category}.toml"
+        wd_entry = wd.get(qid, {})
+        rows.append(
+            _compare_one(
+                category=category,
+                material_key=mkey,
+                qid=qid,
+                wd_entry=wd_entry,
+                mats=mats,
+                toml_path=toml_path,
+                write=write,
+            )
+        )
 
-    print()
-    print(f"{diffs} material(s) show >5% relative divergence — review these first")
-    print("Wikidata values are CC0; cite as Q-IDs in TOML comments when merging")
+    report = _render_report(rows, write)
+    if report_path is None:
+        print(report)
+    else:
+        report_path.write_text(report, encoding="utf-8")
+        print(f"Report written to {report_path}", file=sys.stderr)
+
     return 0
 
 
@@ -202,8 +619,30 @@ def main():
             "endpoint — for offline reproducibility."
         ),
     )
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help=(
+            "Apply add-only writeback: when a TOML field is missing and "
+            "Wikidata has a value, write the value plus a `_sources` row. "
+            "Existing values are NEVER overwritten."
+        ),
+    )
+    parser.add_argument(
+        "--report",
+        type=Path,
+        default=None,
+        help="Write the diff report to this path (default: stdout).",
+    )
     args = parser.parse_args()
-    sys.exit(compare(args.key, dry_run=args.dry_run))
+    sys.exit(
+        compare(
+            args.key,
+            dry_run=args.dry_run,
+            write=args.write,
+            report_path=args.report,
+        )
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/enrich_from_wikidata.py
+++ b/scripts/enrich_from_wikidata.py
@@ -235,7 +235,7 @@ def _parse_sparql_bindings(payload: dict) -> dict[str, dict]:
     """Parse a SPARQL JSON payload into our `{qid: {...}}` shape.
 
     Each key in the returned dict yields normalized scalar values where
-    possible. Unparseable units are silently dropped — they surface as
+    possible. Unparsable units are silently dropped — they surface as
     `None` and the report logs them as missing rather than wrong.
     """
     out: dict[str, dict] = {}

--- a/tests/test_wikidata_enrichment.py
+++ b/tests/test_wikidata_enrichment.py
@@ -1,0 +1,321 @@
+"""Tests for `scripts/enrich_from_wikidata.py` — issue #158.
+
+Covers the curation-tooling behaviors that the Phase 4 prep PR (#197)
+shipped the foundations for and that #158 actually wires together:
+
+* `--dry-run` mode produces a comparison report without touching the
+  network (substring assertions against the fixture-driven output).
+* `--write` against a `tmp_path` TOML copy adds the value AND the
+  `_sources` row when the field was missing.
+* `--write` does NOT overwrite an existing value, even if Wikidata
+  diverges (the DIFF case must stay advisory).
+* Round-trip preserves comments in the TOML — the same guarantee
+  `_curation.writeback` makes, exercised end-to-end via the enricher.
+
+These tests are gated on `requests` + `tomlkit` because the curation
+deps live in `scripts/requirements-curation.txt`, not in the main
+install — see `tests/test_curation_helpers.py` for the same pattern.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+pytest.importorskip("requests")
+pytest.importorskip("tomlkit")
+
+# scripts/ isn't a package; inject it onto sys.path so we can import
+# the enricher module directly.
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+
+@pytest.fixture
+def enricher():
+    """Import (or re-import) the enricher module fresh per test."""
+    if "enrich_from_wikidata" in sys.modules:
+        del sys.modules["enrich_from_wikidata"]
+    return importlib.import_module("enrich_from_wikidata")
+
+
+# --------------------------------------------------------------------------- #
+# --dry-run                                                                   #
+# --------------------------------------------------------------------------- #
+
+
+def test_dry_run_uses_fixture_and_reports_known_materials(enricher, monkeypatch, capsys):
+    """`--dry-run` must consume the fixture and never hit the network."""
+
+    def boom(*a, **kw):  # pragma: no cover — must not be called
+        raise AssertionError("network must not be hit in --dry-run")
+
+    monkeypatch.setattr(enricher.requests, "post", boom)
+    monkeypatch.setattr(enricher.requests, "get", boom)
+
+    rc = enricher.compare(key_filter=None, dry_run=True)
+    assert rc == 0
+
+    out = capsys.readouterr().out
+    # Header + at least one fixture material (aluminum: Q663, copper: Q753).
+    assert "# Wikidata enrichment report" in out
+    assert "Mode: comparison-only" in out
+    assert "aluminum" in out
+    assert "Q753" in out
+    # Property columns must be present.
+    assert "density" in out
+    assert "melting_point" in out
+    assert "thermal_conductivity" in out
+    assert "specific_heat" in out
+    assert "boiling_point" in out
+
+
+def test_dry_run_with_key_filter_limits_output(enricher, capsys):
+    rc = enricher.compare(key_filter="copper", dry_run=True)
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Materials checked: 1" in out
+    assert "copper" in out
+    # Other fixture entries should NOT appear in a single-key run.
+    assert "tungsten" not in out
+
+
+# --------------------------------------------------------------------------- #
+# --write: end-to-end add-only writeback                                      #
+# --------------------------------------------------------------------------- #
+
+
+_SYNTHETIC_TOML_WITH_GAP = dedent(
+    """\
+    # top-of-file comment — must survive the round-trip
+    [aluminum]
+    name = "Aluminum"
+
+    [aluminum.mechanical]
+    # density was already curated; melting point is the gap.
+    density_value = 2.7
+    density_unit = "g/cm^3"
+
+    [aluminum.thermal]
+    # melting_point intentionally absent — Wikidata fixture should fill it.
+    thermal_conductivity_value = 235
+    thermal_conductivity_unit = "W/(m*K)"
+    """
+)
+
+
+_SYNTHETIC_TOML_DIVERGENT = dedent(
+    """\
+    [aluminum]
+    name = "Aluminum"
+
+    [aluminum.mechanical]
+    # Deliberately wrong — the enricher must NOT silently fix it.
+    density_value = 9.99
+    density_unit = "g/cm^3"
+    """
+)
+
+
+def _patch_data_dir(monkeypatch, enricher, tmp_path: Path) -> None:
+    """Redirect the enricher's DATA_DIR + the helper module's DATA_DIR
+    to `tmp_path` so writebacks land in the test sandbox."""
+    import _curation
+
+    monkeypatch.setattr(_curation, "DATA_DIR", tmp_path)
+    monkeypatch.setattr(enricher, "DATA_DIR", tmp_path)
+
+
+def _stub_load_all(enricher, monkeypatch, mats: dict) -> None:
+    """Stub `pymat.load_all` so the enricher sees a known material map.
+
+    The runtime loader can't easily be pointed at `tmp_path` without
+    monkey-patching the package internals; faking `load_all` is the
+    smallest-surface intervention.
+    """
+    monkeypatch.setattr(enricher, "load_all", lambda: mats)
+
+
+class _StubMaterial:
+    """Minimal stand-in for `pymat.Material` — only the attribute path
+    `mat.properties.<group>.<field>` matters to the enricher."""
+
+    def __init__(self, mechanical: dict | None = None, thermal: dict | None = None):
+        self.properties = type(
+            "P",
+            (),
+            {
+                "mechanical": type("M", (), mechanical or {})(),
+                "thermal": type("T", (), thermal or {})(),
+            },
+        )()
+
+
+def test_write_adds_missing_value_and_sources_row(enricher, monkeypatch, tmp_path):
+    """`--write`: missing field + Wikidata value → write both value and `_sources` row."""
+    toml_path = tmp_path / "metals.toml"
+    toml_path.write_text(_SYNTHETIC_TOML_WITH_GAP)
+
+    _patch_data_dir(monkeypatch, enricher, tmp_path)
+    # mat exists but `melting_point` is None — the writeback gap.
+    _stub_load_all(
+        enricher,
+        monkeypatch,
+        {
+            "aluminum": _StubMaterial(
+                mechanical={"density": 2.7},
+                thermal={"melting_point": None, "thermal_conductivity": 235},
+            )
+        },
+    )
+
+    rc = enricher.compare(key_filter="aluminum", dry_run=True, write=True)
+    assert rc == 0
+
+    out = toml_path.read_text()
+    # New value written under [aluminum.thermal]
+    assert "melting_point_value" in out
+    assert 'melting_point_unit = "degC"' in out
+    # _sources row attached at the material level, keyed by `thermal.melting_point`.
+    assert "[aluminum._sources]" in out
+    assert "thermal.melting_point" in out
+    assert "Q663" in out  # citation references the QID
+    assert "CC0" in out
+    assert "P2101" in out  # note carries the property ID
+    # Top-of-file comment survived the round-trip.
+    assert "# top-of-file comment" in out
+
+
+def test_write_does_not_overwrite_existing_value(enricher, monkeypatch, tmp_path):
+    """`--write`: existing value diverges from Wikidata → DIFF reported, NO write.
+
+    We populate every property on the stub mat so the only candidate
+    field for a writeback is the (already-set) divergent density. That
+    isolates the DIFF behavior from the MISSING-add path tested above.
+    """
+    toml_path = tmp_path / "metals.toml"
+    toml_path.write_text(_SYNTHETIC_TOML_DIVERGENT)
+
+    _patch_data_dir(monkeypatch, enricher, tmp_path)
+    _stub_load_all(
+        enricher,
+        monkeypatch,
+        {
+            "aluminum": _StubMaterial(
+                mechanical={"density": 9.99},
+                # Pre-fill thermal so no MISSING-add fires for those props.
+                thermal={
+                    "melting_point": 660,
+                    "thermal_conductivity": 235,
+                    "specific_heat": 900,
+                },
+            )
+        },
+    )
+
+    rc = enricher.compare(key_filter="aluminum", dry_run=True, write=True)
+    assert rc == 0
+
+    after = toml_path.read_text()
+    # The divergent value must still be exactly what the curator wrote.
+    assert "density_value = 9.99" in after
+    assert "density_value = 2.7" not in after
+    # No `_sources` row attached for density — silent updates are
+    # forbidden, even when paired with provenance.
+    assert "mechanical.density" not in after
+
+
+def test_write_round_trip_preserves_grade_level_comments(enricher, monkeypatch, tmp_path):
+    """Comments at the family + grade level both survive `--write`."""
+    src = dedent(
+        """\
+        # category-level comment
+        [aluminum]
+        name = "Aluminum"
+
+        [aluminum.a6061]
+        # grade-level comment — the survival flag for tomlkit round-trips
+        name = "Aluminum 6061"
+
+        [aluminum.a6061.thermal]
+        thermal_conductivity_value = 167
+        thermal_conductivity_unit = "W/(m*K)"
+        """
+    )
+    toml_path = tmp_path / "metals.toml"
+    toml_path.write_text(src)
+
+    _patch_data_dir(monkeypatch, enricher, tmp_path)
+    # Make `a6061` resolvable via the curator-fallback dict (Q663).
+    monkeypatch.setitem(enricher.WIKIDATA_QIDS, "aluminum.a6061", "Q663")
+    _stub_load_all(
+        enricher,
+        monkeypatch,
+        {
+            "aluminum.a6061": _StubMaterial(
+                mechanical={"density": None},
+                thermal={"melting_point": None, "thermal_conductivity": 167},
+            )
+        },
+    )
+
+    rc = enricher.compare(key_filter="aluminum.a6061", dry_run=True, write=True)
+    assert rc == 0
+
+    out = toml_path.read_text()
+    assert "# category-level comment" in out
+    assert "# grade-level comment" in out
+    # New `_sources` table lives at the grade level, not the family.
+    assert "[aluminum.a6061._sources]" in out
+
+
+# --------------------------------------------------------------------------- #
+# Comparison-only mode never mutates files                                    #
+# --------------------------------------------------------------------------- #
+
+
+def test_comparison_only_never_writes(enricher, monkeypatch, tmp_path):
+    """Default mode (no `--write`) must be a pure read."""
+    toml_path = tmp_path / "metals.toml"
+    toml_path.write_text(_SYNTHETIC_TOML_WITH_GAP)
+    before = toml_path.read_text()
+
+    _patch_data_dir(monkeypatch, enricher, tmp_path)
+    _stub_load_all(
+        enricher,
+        monkeypatch,
+        {
+            "aluminum": _StubMaterial(
+                mechanical={"density": 2.7},
+                thermal={"melting_point": None, "thermal_conductivity": 235},
+            )
+        },
+    )
+
+    rc = enricher.compare(key_filter="aluminum", dry_run=True, write=False)
+    assert rc == 0
+    assert toml_path.read_text() == before
+
+
+# --------------------------------------------------------------------------- #
+# --report writes to a markdown file                                          #
+# --------------------------------------------------------------------------- #
+
+
+def test_report_writes_markdown_file(enricher, tmp_path, capsys):
+    out_path = tmp_path / "wd-report.md"
+    rc = enricher.compare(key_filter="copper", dry_run=True, report_path=out_path)
+    assert rc == 0
+    assert out_path.exists()
+    content = out_path.read_text()
+    assert "# Wikidata enrichment report" in content
+    assert "copper" in content
+    # When --report is set, stdout stays quiet (only the "Report
+    # written to ..." note goes to stderr).
+    captured = capsys.readouterr()
+    assert "# Wikidata enrichment report" not in captured.out


### PR DESCRIPTION
## Summary

- Iterates every material in `src/pymat/data/*.toml` via `_curation.load_material_keys` and resolves the Wikidata QID from `[<material>.sourcing].wikidata` (preferred) or the curator fallback dict; materials without a QID are skipped.
- Adds coverage for boiling point (P2102, report-only since `ThermalProperties` has no `boiling_point` field today), thermal conductivity (P2068, W/(m·K)), and heat capacity (P2056, J/(kg·K) + J/(g·K)). P2153 Young's modulus and P2055 resistivity are deferred — both need per-grade schema resolution that's out of scope; rationale captured in the module docstring.
- New `--write` flag implements conservative add-only writeback: when our value is missing and Wikidata has one, write the value plus a paired `_sources` row built via `_curation.build_source_row` (kind=qid, license=CC0, note="Pxxxx via SPARQL <date>"). Existing values are NEVER overwritten — DIFF cases stay advisory and only surface in the report.
- New `--report <path>` flag redirects the markdown diff report to a file. `--key` and `--dry-run` are preserved.
- No runtime changes, no new materials, no loader/properties.py touches; `requests` + `tomlkit` stay in `scripts/requirements-curation.txt`.

### Heat-capacity unit judgement call

Wikidata mixes J/(kg·K) (Q752197), J/(g·K) (Q21075844 — multiply by 1000), and J/(mol·K) (Q13035094 — molar form). The first two are normalized; molar form is intentionally skipped because converting requires a molar-mass lookup and brings in molecule-vs-formula-unit ambiguity that's out of scope for #158. Unparseable units fall through to `None` and surface as missing in the report.

## Test plan

- [x] `uv run pytest tests/test_curation_helpers.py tests/test_wikidata_enrichment.py -v` — 27 passed locally
- [x] `uv run pytest` (full suite) — 654 passed, 18 skipped (unrelated headless-render skips)
- [x] `uv run ruff check . && uv run ruff format --check .` — clean
- [x] `python scripts/enrich_from_wikidata.py --key copper --dry-run` produces a sensible markdown report against the bundled fixture

Closes #158