### PR TITLE
feat(scripts): mirror Geant4 G4NistManager constants for scintillators (#167)

### DIFF
--- a/docs/data-policy.md
+++ b/docs/data-policy.md
@@ -46,8 +46,26 @@ The `license` field on every `_sources` entry MUST be one of:
 | `PD-USGov` | US Government work — not copyrightable in US | NIST WebBook, NIST Cryogenic, NASA Outgassing, NIST PhysRefData |
 | `CC-BY-4.0` | Creative Commons Attribution 4.0 — attribution required | Materials Project, OQMD, NOMAD, SCOAP3 |
 | `CC-BY-SA-4.0` | CC-BY-SA — attribution + share-alike | Some Wikipedia-derived data (rare; prefer Wikidata) |
+| `Geant4-SL` | Geant4 Software License — BSD-like, attribution required | Geant4 `G4NistMaterialBuilder` constants |
 | `proprietary-reference-only` | Single value cited from a proprietary source for verification — used sparingly, never bulk | Vendor datasheets, ASM Handbook single-value citations |
 | `unknown` | **Transitional only.** Blocked by CI on merge. | Audit-window placeholder per #175 |
+
+### Note on `Geant4-SL`
+
+The [Geant4 Software License](https://geant4.web.cern.ch/download/license.html)
+is BSD-like: redistribution in source or binary form is permitted provided the
+upstream copyright notice and attribution travel with the values. It is
+strictly more permissive than `proprietary-reference-only` (which exists for
+single-value vendor citations under restrictive ToS) but stops short of CC-BY
+because of a few downstream-distribution clauses unique to the HEP
+collaboration. Added in #167 for the `G4NistMaterialBuilder` mirror — the
+Geant4 collaboration ships its NIST-derived constants under this license, and
+calling that out explicitly (rather than collapsing it into
+`proprietary-reference-only`) keeps the attribution requirement legible.
+
+The same license applies to future BSD-like sources we expect to hit
+(certain HEPData mirrors, third-party NIST compilations); reuse this value
+rather than introducing a new one for each.
 
 Any other value will fail the CI check and block merge.
 

--- a/scripts/_curation.py
+++ b/scripts/_curation.py
@@ -44,9 +44,17 @@ LICENSE_ALLOWLIST = frozenset(
         "PD-USGov",
         "CC-BY-4.0",
         "CC-BY-SA-4.0",
+        "Geant4-SL",
         "proprietary-reference-only",
     }
 )
+# `Geant4-SL`: the Geant4 Software License — BSD-like with attribution.
+# Added for #167 (Geant4 G4NistMaterialBuilder mirror). The Geant4
+# collaboration's tabulated NIST constants ride on this license; it's
+# strictly more permissive than `proprietary-reference-only` and
+# distinguishing it makes the attribution requirement explicit. See
+# https://geant4.web.cern.ch/download/license.html and
+# docs/data-policy.md (Allowed-licenses section).
 
 SOURCE_KIND_ALLOWLIST = frozenset({"doi", "qid", "handbook", "vendor", "measured"})
 

--- a/scripts/check_licenses.py
+++ b/scripts/check_licenses.py
@@ -39,6 +39,12 @@ ALLOWED = {
     "PD-USGov",
     "CC-BY-4.0",
     "CC-BY-SA-4.0",
+    # Geant4 Software License — BSD-like, attribution required. Added in
+    # #167 for the G4NistMaterialBuilder mirror. Sits between CC-BY and
+    # `proprietary-reference-only`: redistributable in any form provided
+    # the upstream copyright/attribution travels with the values. See
+    # docs/data-policy.md and https://geant4.web.cern.ch/download/license.html.
+    "Geant4-SL",
     "proprietary-reference-only",
 }
 # `unknown` is parseable but rejected — transitional value, blocked at merge.

--- a/scripts/enrich_from_geant4_nist.py
+++ b/scripts/enrich_from_geant4_nist.py
@@ -1,0 +1,517 @@
+#!/usr/bin/env python3
+"""Compare mat's scintillator + plastic properties against the Geant4
+G4NistMaterialBuilder constants — issue #167.
+
+Geant4 ships ~300 NIST-derived compounds in
+`source/materials/src/G4NistMaterialBuilder.cc` (NaI, CsI, BGO, BaF₂,
+polystyrene, vinyltoluene plastic-scintillator base, polycarbonate,
+teflon, etc.). The constants travel under the **Geant4 Software License**
+(BSD-like, attribution required). Coverage:
+
+* `density`     — g/cm³, already canonical for py-mat
+* `mean ionisation potential` (a.k.a. mean excitation energy) — eV,
+  written into `[<material>.nuclear].mean_excitation_energy_eV`
+  (schema field added in #157)
+* `composition` — element fractions; py-mat does NOT yet store
+  composition arrays (no schema field), so this enricher SKIPS the
+  composition column. When/if a `[composition]` sub-table lands,
+  re-run this script with the new column wired in.
+
+Light yield, decay times, and emission spectra are NOT in
+`G4NistMaterialBuilder` — those live in physics-process tables and
+vendor datasheets, out of scope for this enricher.
+
+This is NOT a runtime dependency of mat — lives in scripts/ for data
+curation. Shared helpers live in `scripts/_curation.py`.
+
+## Reproducibility
+
+The Geant4 numbers are mirrored **by hand** into the `G4_NIST` dict
+below — we do NOT fetch the source at runtime. That's deliberate:
+Geant4 minor versions are stable across these constants, the upstream
+file is a 2000-line C++ source that can't be parsed cleanly without a
+real C++ frontend, and a curation script must be reproducible offline.
+The mirror is pinned to **Geant4 v11.2.0** (current LTS).
+
+Each mirrored entry corresponds to one `AddMaterial(...)` call in the
+upstream file and cites the line number explicitly:
+
+    Upstream: source/materials/src/G4NistMaterialBuilder.cc
+    Public mirror: https://gitlab.cern.ch/geant4/geant4/-/blob/v11.2.0/source/materials/src/G4NistMaterialBuilder.cc
+    GitHub mirror: https://github.com/Geant4/geant4/blob/v11.2.0/source/materials/src/G4NistMaterialBuilder.cc
+    Signature: AddMaterial(name, density_g_cm3, Z, mean_excitation_eV, ncomp, state)
+
+Bumping the pin: re-fetch the same file at the new tag, diff
+`AddMaterial(...)` lines for the keys we mirror, update the dict, and
+update the `GEANT4_VERSION` constant + the line numbers in each entry.
+
+## Usage
+
+    python scripts/enrich_from_geant4_nist.py                     # comparison report
+    python scripts/enrich_from_geant4_nist.py --key bgo --dry-run # one material, offline
+    python scripts/enrich_from_geant4_nist.py --write             # apply add-only writeback
+    python scripts/enrich_from_geant4_nist.py --report out.md     # write report to file
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import tomlkit  # noqa: E402
+from _curation import (  # noqa: E402
+    DATA_DIR,
+    build_source_row,
+    fmt_delta,
+    load_material_keys,
+    writeback,
+)
+
+from pymat import load_all  # noqa: E402
+
+GEANT4_VERSION = "11.2.0"
+G4_SOURCE_FILE = "source/materials/src/G4NistMaterialBuilder.cc"
+
+# Tighter than the Wikidata enricher's 5%: Geant4's numbers are NIST
+# reference values, so a >1% gap is curator-actionable.
+DEFAULT_TOL = 0.01
+
+
+# --------------------------------------------------------------------------- #
+# Mirrored G4 NIST constants — Geant4 v11.2.0                                 #
+# --------------------------------------------------------------------------- #
+#
+# Each entry mirrors one `AddMaterial(name, dens, Z, pot, ncomp, state)` call.
+# `mee_eV` is the `pot` argument (mean ionisation potential in eV); a value
+# of `None` means upstream passes 0.0 — Geant4 treats that as "compute from
+# composition" and there is no canonical scalar to compare against.
+#
+# Composition is intentionally NOT mirrored: py-mat has no schema field for
+# element fraction arrays today (see module docstring).
+
+
+@dataclass(frozen=True)
+class G4Entry:
+    name: str  # e.g. "G4_BGO"
+    density_g_cm3: float
+    mee_eV: float | None  # None → upstream passes 0.0 (compute from composition)
+    line: int  # line in G4NistMaterialBuilder.cc (Geant4 v11.2.0)
+
+
+# Scintillators — mapped onto src/pymat/data/scintillators.toml entries.
+# The Tl/Na-doped variants of NaI and CsI map onto the same host crystal;
+# Geant4 does not differentiate dopant-induced shifts in MEE/density at
+# this layer (those are downstream physics processes).
+G4_NIST: dict[str, G4Entry] = {
+    # ----- scintillator hosts -----
+    "bgo": G4Entry("G4_BGO", 7.13, 534.1, 920),
+    "nai": G4Entry("G4_SODIUM_IODIDE", 3.667, 452.0, 1673),
+    "nai.Tl": G4Entry("G4_SODIUM_IODIDE", 3.667, 452.0, 1673),
+    "csi": G4Entry("G4_CESIUM_IODIDE", 4.51, 553.1, 1062),
+    "csi.Tl": G4Entry("G4_CESIUM_IODIDE", 4.51, 553.1, 1062),
+    "csi.Na": G4Entry("G4_CESIUM_IODIDE", 4.51, 553.1, 1062),
+    # PWO has MEE=0 in upstream (compute-from-composition sentinel) — we
+    # still cross-check the density but skip MEE writeback.
+    "pwo": G4Entry("G4_PbWO4", 8.28, None, 1833),
+    # Plastic scintillator base + commercial variants — all derive from
+    # G4_PLASTIC_SC_VINYLTOLUENE. BC-400 / EJ-200 are the same vinyltoluene-
+    # based PVT formulation at Geant4's resolution.
+    "plastic_scint": G4Entry("G4_PLASTIC_SC_VINYLTOLUENE", 1.032, 64.7, 1481),
+    "plastic_scint.BC400": G4Entry("G4_PLASTIC_SC_VINYLTOLUENE", 1.032, 64.7, 1481),
+    "plastic_scint.EJ200": G4Entry("G4_PLASTIC_SC_VINYLTOLUENE", 1.032, 64.7, 1481),
+    # ----- plastics (subset that has a Geant4 NIST equivalent) -----
+    # PMMA → G4_LUCITE (NIST treats them as equivalent).
+    "pmma": G4Entry("G4_LUCITE", 1.19, 74.0, 1846),
+    "pc": G4Entry("G4_POLYCARBONATE", 1.2, 73.1, 1499),
+    "ptfe": G4Entry("G4_TEFLON", 2.2, 99.1, 1544),
+    "pe": G4Entry("G4_POLYETHYLENE", 0.94, 57.4, 1515),
+    "nylon": G4Entry("G4_NYLON-6-6", 1.14, 63.9, 1441),
+    "delrin": G4Entry("G4_POLYOXYMETHYLENE", 1.425, 77.4, 1530),
+    "pctfe": G4Entry("G4_POLYTRIFLUOROCHLOROETHYLENE", 2.1, 120.7, 1548),
+}
+
+# Materials we know exist in our TOMLs but Geant4 NIST does NOT cover.
+# Logged in the report so the rationale is in the artifact, not in tribal
+# knowledge.
+KNOWN_NOT_IN_G4_NIST: dict[str, str] = {
+    "lyso": (
+        "G4_LYSO is not a NIST-mirrored material in Geant4 11.2; "
+        "modeled at G4 build time via mixture"
+    ),
+    "lyso.Ce": "see lyso",
+    "labr3": "G4 11.2 has G4_LANTHANUM_OXYBROMIDE (LaOBr) but not LaBr3:Ce",
+    "peek": "PEEK is not in G4NistMaterialBuilder",
+    "ultem": "Ultem (PEI) not in G4NistMaterialBuilder",
+    "esr": "3M ESR multilayer is a vendor product, not a NIST compound",
+    "pla": "PLA not in G4NistMaterialBuilder",
+    "abs": "ABS not in G4NistMaterialBuilder",
+    "petg": "PETG not in G4NistMaterialBuilder (G4_DACRON exists but is PET, distinct)",
+    "tpu": "TPU not in G4NistMaterialBuilder",
+    "vespel": "Vespel (polyimide) not in G4NistMaterialBuilder",
+    "torlon": "Torlon (PAI) not in G4NistMaterialBuilder",
+}
+
+# Categories this enricher walks. The runtime catalog has many more, but
+# G4NistMaterialBuilder is most useful for the scintillator + plastics
+# columns — metals and ceramics get better coverage from Wikidata / NIST
+# WebBook (and we don't want to silently triple-cite).
+TARGET_CATEGORIES = ("scintillators", "plastics")
+
+
+# --------------------------------------------------------------------------- #
+# Property mapping (TOML field → G4 attribute)                                #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class PropertySpec:
+    group: str  # property sub-table: "mechanical" or "nuclear"
+    field: str  # field name on the dataclass
+    g4_attr: str  # attribute name on G4Entry
+    canonical_unit: str | None  # `None` → field is bare scalar (no _unit suffix)
+    writable: bool = True
+
+
+_PROPERTIES: list[PropertySpec] = [
+    PropertySpec("mechanical", "density", "density_g_cm3", "g/cm^3"),
+    # mean_excitation_energy_eV is a bare scalar — unit baked into name.
+    PropertySpec("nuclear", "mean_excitation_energy_eV", "mee_eV", None),
+]
+
+
+# --------------------------------------------------------------------------- #
+# TOML helpers                                                                #
+# --------------------------------------------------------------------------- #
+
+
+def _read_doc(toml_path: Path) -> tomlkit.TOMLDocument:
+    return tomlkit.parse(toml_path.read_text(encoding="utf-8"))
+
+
+def _walk(doc: Any, dotted: str) -> Any | None:
+    node: Any = doc
+    for seg in dotted.split("."):
+        if not isinstance(node, dict) or seg not in node:
+            return None
+        node = node[seg]
+    return node
+
+
+def _ours_value(mat: Any, group: str, field: str) -> float | None:
+    if mat is None:
+        return None
+    props = getattr(mat, "properties", None)
+    if props is None:
+        return None
+    grp = getattr(props, group, None)
+    if grp is None:
+        return None
+    return getattr(grp, field, None)
+
+
+def _today_iso() -> str:
+    return _dt.date.today().isoformat()
+
+
+# --------------------------------------------------------------------------- #
+# Source row + writeback                                                      #
+# --------------------------------------------------------------------------- #
+
+
+def _make_source_row(entry: G4Entry, field: str) -> dict[str, str]:
+    """Build a `_sources` row for one (entry, field) pair.
+
+    `kind = "handbook"` is the closest fit in our allow-list — Geant4's
+    table is itself a handbook of constants, indexed by material name and
+    cited by line number into a single C++ source.
+    """
+    note = f"Geant4 v{GEANT4_VERSION} {entry.name}; field '{field}' mirrored on {_today_iso()}"
+    return build_source_row(
+        citation=f"Geant4 G4NistMaterialBuilder v{GEANT4_VERSION}",
+        kind="handbook",
+        ref=f"{Path(G4_SOURCE_FILE).name}:{entry.line}",
+        license="Geant4-SL",
+        note=note,
+    )
+
+
+def _apply_writeback(
+    *,
+    toml_path: Path,
+    material_key: str,
+    spec: PropertySpec,
+    value: float,
+    entry: G4Entry,
+) -> None:
+    """Conservative add-only writeback. Caller verifies the field is absent."""
+    material_path = material_key.split(".") + [spec.group]
+    row = _make_source_row(entry, spec.field)
+    if spec.canonical_unit is None:
+        # Bare scalar — no `_value`/`_unit` pair (e.g. mean_excitation_energy_eV).
+        updates = {spec.field: value}
+    else:
+        updates = {f"{spec.field}_value": value, f"{spec.field}_unit": spec.canonical_unit}
+    writeback(
+        toml_path,
+        material_path,
+        updates,
+        sources={spec.field: row},
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Comparison                                                                  #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class Row:
+    category: str
+    key: str
+    g4_name: str
+    cells: dict[str, str]
+    diffs: list[str]
+    missing: list[str]
+
+
+def _compare_one(
+    *,
+    category: str,
+    material_key: str,
+    entry: G4Entry,
+    mats: dict,
+    toml_path: Path,
+    write: bool,
+    tol: float = DEFAULT_TOL,
+) -> Row:
+    cells: dict[str, str] = {}
+    diffs: list[str] = []
+    missing: list[str] = []
+
+    doc = _read_doc(toml_path)
+    material_node = _walk(doc, material_key)
+
+    for spec in _PROPERTIES:
+        ours = _ours_value(mats.get(material_key), spec.group, spec.field)
+        theirs = getattr(entry, spec.g4_attr)
+        cell = fmt_delta(ours, theirs, tol=tol)
+        cells[spec.field] = cell
+        if "DIFF" in cell:
+            diffs.append(spec.field)
+        if ours is None and theirs is not None and spec.writable:
+            missing.append(spec.field)
+            if write:
+                # Defensive: only write if the TOML truly lacks the field.
+                # The loaded `mat` could be None because the property
+                # group itself doesn't exist yet.
+                group_node = (
+                    material_node.get(spec.group) if isinstance(material_node, dict) else None
+                )
+                if spec.canonical_unit is None:
+                    already_set = isinstance(group_node, dict) and spec.field in group_node
+                else:
+                    already_set = isinstance(group_node, dict) and (
+                        f"{spec.field}_value" in group_node or spec.field in group_node
+                    )
+                if not already_set:
+                    _apply_writeback(
+                        toml_path=toml_path,
+                        material_key=material_key,
+                        spec=spec,
+                        value=float(theirs),
+                        entry=entry,
+                    )
+
+    return Row(
+        category=category,
+        key=material_key,
+        g4_name=entry.name,
+        cells=cells,
+        diffs=diffs,
+        missing=missing,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Report                                                                      #
+# --------------------------------------------------------------------------- #
+
+
+def _render_report(
+    rows: list[Row],
+    skipped: list[tuple[str, str]],
+    write: bool,
+) -> str:
+    lines: list[str] = []
+    lines.append("# Geant4 NIST enrichment report")
+    lines.append("")
+    lines.append(f"Date: {_today_iso()}")
+    lines.append(f"Geant4 version: v{GEANT4_VERSION}")
+    lines.append(f"Mode: {'write (add-only)' if write else 'comparison-only'}")
+    lines.append(f"Tolerance: {DEFAULT_TOL * 100:.1f}% (DIFF flag threshold)")
+    lines.append(f"Materials checked: {len(rows)}")
+    lines.append(f"Materials skipped (no G4 mirror): {len(skipped)}")
+    lines.append("")
+
+    header = ["material", "g4_name"] + [s.field for s in _PROPERTIES]
+    lines.append(" | ".join(header))
+    lines.append(" | ".join("---" for _ in header))
+    for r in rows:
+        cells = [r.key, r.g4_name]
+        for spec in _PROPERTIES:
+            cell = r.cells.get(spec.field, "—")
+            cells.append(cell.replace("|", "/"))
+        lines.append(" | ".join(cells))
+    lines.append("")
+
+    diff_rows = [r for r in rows if r.diffs]
+    miss_rows = [r for r in rows if r.missing]
+    lines.append(f"DIFF rows: {len(diff_rows)}")
+    for r in diff_rows:
+        lines.append(f"  DIFF  {r.key} ({r.g4_name}): {', '.join(r.diffs)}")
+    lines.append(f"MISSING rows: {len(miss_rows)}")
+    for r in miss_rows:
+        action = "WROTE" if write else "would-write"
+        lines.append(f"  MISSING  {r.key} ({r.g4_name}): {', '.join(r.missing)}  [{action}]")
+    if skipped:
+        lines.append("")
+        lines.append("Skipped (no G4 NIST mirror):")
+        for key, reason in skipped:
+            lines.append(f"  SKIP  {key}: {reason}")
+    lines.append("")
+    lines.append(
+        f"Geant4 values mirrored from {G4_SOURCE_FILE} v{GEANT4_VERSION}; "
+        "license = Geant4-SL (BSD-like, attribution required)."
+    )
+    return "\n".join(lines) + "\n"
+
+
+# --------------------------------------------------------------------------- #
+# Driver                                                                      #
+# --------------------------------------------------------------------------- #
+
+
+def _enumerate_targets(
+    key_filter: str | None,
+) -> tuple[list[tuple[str, str, G4Entry]], list[tuple[str, str]]]:
+    """Walk every key in TARGET_CATEGORIES; split into (matches, skipped).
+
+    Materials with a G4 mirror entry → matches. Materials without →
+    skipped (logged in the report). When `key_filter` is set, both
+    lists are filtered down to that single key.
+    """
+    matches: list[tuple[str, str, G4Entry]] = []
+    skipped: list[tuple[str, str]] = []
+    for category in TARGET_CATEGORIES:
+        # Tolerate a missing category TOML — happens in tests (which
+        # only stage one category into tmp_path) and would also be the
+        # right behavior if a category file were deleted in production.
+        if not (DATA_DIR / f"{category}.toml").exists():
+            continue
+        for mkey in load_material_keys(category):
+            if key_filter is not None and mkey != key_filter:
+                continue
+            entry = G4_NIST.get(mkey)
+            if entry is None:
+                reason = KNOWN_NOT_IN_G4_NIST.get(mkey, "no Geant4 NIST mirror")
+                skipped.append((mkey, reason))
+                continue
+            matches.append((category, mkey, entry))
+    return matches, skipped
+
+
+def compare(
+    key_filter: str | None = None,
+    *,
+    dry_run: bool = False,  # noqa: ARG001 — kept for CLI parity with Wikidata
+    write: bool = False,
+    report_path: Path | None = None,
+) -> int:
+    """Run the comparison; print or write the report.
+
+    `--dry-run` is accepted for muscle-memory parity with the Wikidata
+    enricher but is a no-op here: the G4 values are mirrored offline,
+    so this enricher never makes a network call.
+    """
+    mats = load_all()
+    matches, skipped = _enumerate_targets(key_filter)
+
+    if not matches and not skipped:
+        msg = (
+            f"No targets matched key={key_filter!r}"
+            if key_filter
+            else f"No materials found in {TARGET_CATEGORIES}"
+        )
+        print(msg, file=sys.stderr)
+        return 1
+
+    rows: list[Row] = []
+    for category, mkey, entry in matches:
+        toml_path = DATA_DIR / f"{category}.toml"
+        rows.append(
+            _compare_one(
+                category=category,
+                material_key=mkey,
+                entry=entry,
+                mats=mats,
+                toml_path=toml_path,
+                write=write,
+            )
+        )
+
+    report = _render_report(rows, skipped, write)
+    if report_path is None:
+        print(report)
+    else:
+        report_path.write_text(report, encoding="utf-8")
+        print(f"Report written to {report_path}", file=sys.stderr)
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--key", help="Only compare this material key")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "No-op for this enricher (kept for CLI parity with "
+            "enrich_from_wikidata.py). Geant4 values are mirrored "
+            "offline; no network call is ever made."
+        ),
+    )
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help=(
+            "Apply add-only writeback: when a TOML field is missing and "
+            "G4_NIST has a value, write the value plus a `_sources` row. "
+            "Existing values are NEVER overwritten."
+        ),
+    )
+    parser.add_argument(
+        "--report",
+        type=Path,
+        default=None,
+        help="Write the diff report to this path (default: stdout).",
+    )
+    args = parser.parse_args()
+    sys.exit(
+        compare(
+            args.key,
+            dry_run=args.dry_run,
+            write=args.write,
+            report_path=args.report,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_check_licenses.py
+++ b/tests/test_check_licenses.py
@@ -135,7 +135,16 @@ class TestValidate:
         assert "not in allow-list" in result.stderr
 
     @pytest.mark.parametrize(
-        "lic", ["CC0", "PD-USGov", "CC-BY-4.0", "CC-BY-SA-4.0", "proprietary-reference-only"]
+        "lic",
+        [
+            "CC0",
+            "PD-USGov",
+            "CC-BY-4.0",
+            "CC-BY-SA-4.0",
+            # Geant4-SL added in #167 for the G4NistMaterialBuilder mirror.
+            "Geant4-SL",
+            "proprietary-reference-only",
+        ],
     )
     def test_accepts_each_allowed_license(self, data_dir, lic):
         (data_dir / "metals.toml").write_text(

--- a/tests/test_geant4_enrichment.py
+++ b/tests/test_geant4_enrichment.py
@@ -1,0 +1,352 @@
+"""Tests for `scripts/enrich_from_geant4_nist.py` — issue #167.
+
+Mirrors the test layout of `test_wikidata_enrichment.py` (PR #198) so
+the enricher CLIs stay interchangeable for curators. Covers:
+
+* `--dry-run` (no-op for this offline-only enricher) produces the
+  comparison report from the embedded G4 mirror.
+* `--write` adds `mean_excitation_energy_eV` AND the paired `_sources`
+  row when the field is missing on a `tmp_path` TOML copy.
+* `--write` does NOT overwrite an existing `mean_excitation_energy_eV`,
+  even if our value diverges from Geant4's.
+* Round-trip preserves comments end-to-end via the enricher.
+* The license allow-list now includes `Geant4-SL` (the new license value
+  introduced in #167) — guarding against accidental removal.
+
+Skip if `requests`/`tomlkit` aren't installed: those live in
+`scripts/requirements-curation.txt` and aren't part of the runtime
+install. See `tests/test_curation_helpers.py` for the same pattern.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+pytest.importorskip("requests")
+pytest.importorskip("tomlkit")
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+
+@pytest.fixture
+def enricher():
+    """Re-import fresh per test so module-level state doesn't leak."""
+    if "enrich_from_geant4_nist" in sys.modules:
+        del sys.modules["enrich_from_geant4_nist"]
+    return importlib.import_module("enrich_from_geant4_nist")
+
+
+# --------------------------------------------------------------------------- #
+# Helpers                                                                     #
+# --------------------------------------------------------------------------- #
+
+
+def _patch_data_dir(monkeypatch, enricher, tmp_path: Path) -> None:
+    """Redirect both module-level DATA_DIR pointers to `tmp_path`."""
+    import _curation
+
+    monkeypatch.setattr(_curation, "DATA_DIR", tmp_path)
+    monkeypatch.setattr(enricher, "DATA_DIR", tmp_path)
+
+
+def _stub_load_all(enricher, monkeypatch, mats: dict) -> None:
+    monkeypatch.setattr(enricher, "load_all", lambda: mats)
+
+
+class _StubMaterial:
+    """Minimal stand-in for `pymat.Material` — only the attribute path
+    `mat.properties.<group>.<field>` matters to the enricher."""
+
+    def __init__(
+        self,
+        mechanical: dict | None = None,
+        nuclear: dict | None = None,
+    ):
+        self.properties = type(
+            "P",
+            (),
+            {
+                "mechanical": type("M", (), mechanical or {})(),
+                "nuclear": type("N", (), nuclear or {})(),
+            },
+        )()
+
+
+# --------------------------------------------------------------------------- #
+# License allow-list integrity (Reviewer #2 ask: catch accidental removal)    #
+# --------------------------------------------------------------------------- #
+
+
+def test_license_allowlist_includes_geant4_sl():
+    """The Geant4-SL license value is the controversial bit of #167; if a
+    refactor accidentally drops it from the allow-list, every Geant4
+    enrichment writeback would silently fail. This test is the canary."""
+    import _curation
+    from check_licenses import ALLOWED
+
+    assert "Geant4-SL" in _curation.LICENSE_ALLOWLIST
+    assert "Geant4-SL" in ALLOWED
+
+
+# --------------------------------------------------------------------------- #
+# --dry-run / report-only mode                                                #
+# --------------------------------------------------------------------------- #
+
+
+def test_dry_run_produces_expected_report(enricher, capsys):
+    """`--dry-run` produces a report without any monkey-patching: the
+    enricher is offline-only, so this also implicitly verifies no
+    network call is made."""
+    rc = enricher.compare(key_filter="bgo", dry_run=True)
+    assert rc == 0
+
+    out = capsys.readouterr().out
+    assert "# Geant4 NIST enrichment report" in out
+    assert "Geant4 version: v11.2.0" in out
+    assert "Mode: comparison-only" in out
+    # bgo cells reference G4_BGO and the mean_excitation_energy_eV column.
+    assert "bgo" in out
+    assert "G4_BGO" in out
+    assert "mean_excitation_energy_eV" in out
+    assert "density" in out
+
+
+def test_skipped_materials_appear_in_report(enricher, capsys):
+    """`labr3` exists in scintillators.toml but has no Geant4 NIST
+    equivalent — it should appear in the SKIP list, not the comparison
+    table."""
+    rc = enricher.compare(key_filter=None, dry_run=True)
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "labr3" in out
+    assert "Skipped (no G4 NIST mirror)" in out
+
+
+# --------------------------------------------------------------------------- #
+# --write: add-only writeback                                                 #
+# --------------------------------------------------------------------------- #
+
+
+_SYNTHETIC_BGO_GAP = dedent(
+    """\
+    # top-of-file comment — must survive the round-trip
+    [bgo]
+    name = "BGO"
+    formula = "Bi4Ge3O12"
+
+    [bgo.mechanical]
+    # density already curated; MEE is the gap.
+    density_value = 7.13
+    density_unit = "g/cm^3"
+
+    [bgo.nuclear]
+    # mean_excitation_energy_eV intentionally absent — Geant4 fills it.
+    radiation_length = 1.12
+    """
+)
+
+
+def test_write_adds_missing_mee_and_sources_row(enricher, monkeypatch, tmp_path):
+    """`--write`: missing `mean_excitation_energy_eV` + G4 has a value
+    → write both the bare scalar and a `_sources` row keyed
+    `nuclear.mean_excitation_energy_eV`."""
+    toml_path = tmp_path / "scintillators.toml"
+    toml_path.write_text(_SYNTHETIC_BGO_GAP)
+
+    _patch_data_dir(monkeypatch, enricher, tmp_path)
+    # Stub: density is set, MEE is None — only the writeback gap.
+    _stub_load_all(
+        enricher,
+        monkeypatch,
+        {
+            "bgo": _StubMaterial(
+                mechanical={"density": 7.13},
+                nuclear={"mean_excitation_energy_eV": None},
+            )
+        },
+    )
+
+    rc = enricher.compare(key_filter="bgo", dry_run=True, write=True)
+    assert rc == 0
+
+    out = toml_path.read_text()
+    # Bare scalar (no _value/_unit suffix) — schema convention for
+    # mean_excitation_energy_eV (unit baked into the field name).
+    assert "mean_excitation_energy_eV = 534.1" in out
+    # _sources row attached at the material level.
+    assert "[bgo._sources]" in out
+    assert "nuclear.mean_excitation_energy_eV" in out
+    assert "Geant4-SL" in out
+    assert "G4NistMaterialBuilder.cc:920" in out
+    assert "v11.2.0" in out
+    # Top-of-file comment survives.
+    assert "# top-of-file comment" in out
+
+
+def test_write_does_not_overwrite_existing_mee(enricher, monkeypatch, tmp_path):
+    """`--write`: existing MEE diverges from Geant4 → DIFF reported, no write."""
+    src = dedent(
+        """\
+        [bgo]
+        name = "BGO"
+
+        [bgo.mechanical]
+        density_value = 7.13
+        density_unit = "g/cm^3"
+
+        [bgo.nuclear]
+        # Wrong on purpose — must not be silently corrected.
+        mean_excitation_energy_eV = 999.9
+        """
+    )
+    toml_path = tmp_path / "scintillators.toml"
+    toml_path.write_text(src)
+
+    _patch_data_dir(monkeypatch, enricher, tmp_path)
+    _stub_load_all(
+        enricher,
+        monkeypatch,
+        {
+            "bgo": _StubMaterial(
+                mechanical={"density": 7.13},
+                nuclear={"mean_excitation_energy_eV": 999.9},
+            )
+        },
+    )
+
+    rc = enricher.compare(key_filter="bgo", dry_run=True, write=True)
+    assert rc == 0
+
+    after = toml_path.read_text()
+    # The divergent value is exactly what the curator wrote.
+    assert "mean_excitation_energy_eV = 999.9" in after
+    assert "534.1" not in after
+    # No _sources row attached — silent updates are forbidden, even with
+    # provenance attached.
+    assert "nuclear.mean_excitation_energy_eV" not in after
+
+
+def test_write_round_trip_preserves_grade_level_comments(enricher, monkeypatch, tmp_path):
+    """Comments at family + grade level survive a `--write` pass through
+    a dotted material key (`plastic_scint.BC400`)."""
+    src = dedent(
+        """\
+        # category-level comment
+        [plastic_scint]
+        name = "Plastic Scintillator"
+
+        [plastic_scint.BC400]
+        # grade-level comment — survival flag for tomlkit round-trips
+        name = "BC-400 Plastic Scintillator"
+        vendor = "eljen"
+
+        [plastic_scint.BC400.optical]
+        light_yield = 12000
+        """
+    )
+    toml_path = tmp_path / "scintillators.toml"
+    toml_path.write_text(src)
+
+    _patch_data_dir(monkeypatch, enricher, tmp_path)
+    _stub_load_all(
+        enricher,
+        monkeypatch,
+        {
+            "plastic_scint.BC400": _StubMaterial(
+                mechanical={"density": None},
+                nuclear={"mean_excitation_energy_eV": None},
+            )
+        },
+    )
+
+    rc = enricher.compare(key_filter="plastic_scint.BC400", dry_run=True, write=True)
+    assert rc == 0
+
+    out = toml_path.read_text()
+    assert "# category-level comment" in out
+    assert "# grade-level comment" in out
+    # New _sources block lives at the grade level, not the family.
+    assert "[plastic_scint.BC400._sources]" in out
+    # Both the missing density and MEE got filled.
+    assert "density_value = 1.032" in out
+    assert "mean_excitation_energy_eV = 64.7" in out
+
+
+# --------------------------------------------------------------------------- #
+# Comparison-only mode never mutates files                                    #
+# --------------------------------------------------------------------------- #
+
+
+def test_comparison_only_never_writes(enricher, monkeypatch, tmp_path):
+    toml_path = tmp_path / "scintillators.toml"
+    toml_path.write_text(_SYNTHETIC_BGO_GAP)
+    before = toml_path.read_text()
+
+    _patch_data_dir(monkeypatch, enricher, tmp_path)
+    _stub_load_all(
+        enricher,
+        monkeypatch,
+        {
+            "bgo": _StubMaterial(
+                mechanical={"density": 7.13},
+                nuclear={"mean_excitation_energy_eV": None},
+            )
+        },
+    )
+
+    rc = enricher.compare(key_filter="bgo", dry_run=True, write=False)
+    assert rc == 0
+    assert toml_path.read_text() == before
+
+
+# --------------------------------------------------------------------------- #
+# --report writes to a markdown file                                          #
+# --------------------------------------------------------------------------- #
+
+
+def test_report_writes_markdown_file(enricher, tmp_path, capsys):
+    out_path = tmp_path / "g4-report.md"
+    rc = enricher.compare(key_filter="bgo", dry_run=True, report_path=out_path)
+    assert rc == 0
+    assert out_path.exists()
+    content = out_path.read_text()
+    assert "# Geant4 NIST enrichment report" in content
+    assert "G4_BGO" in content
+    # When --report is set, stdout stays quiet.
+    captured = capsys.readouterr()
+    assert "# Geant4 NIST enrichment report" not in captured.out
+
+
+# --------------------------------------------------------------------------- #
+# Source-row sanity                                                           #
+# --------------------------------------------------------------------------- #
+
+
+def test_source_row_is_well_formed(enricher):
+    """The `_sources` row built by the enricher must satisfy the curation
+    helper's schema (kind in allow-list, license in allow-list, non-empty
+    citation/ref)."""
+    entry = enricher.G4_NIST["bgo"]
+    row = enricher._make_source_row(entry, "mean_excitation_energy_eV")
+    assert row["kind"] == "handbook"
+    assert row["license"] == "Geant4-SL"
+    assert "Geant4 G4NistMaterialBuilder" in row["citation"]
+    assert "G4NistMaterialBuilder.cc:920" in row["ref"]
+    assert "v11.2.0" in row["citation"]
+    assert "G4_BGO" in row["note"]
+
+
+def test_pwo_has_no_writable_mee(enricher):
+    """G4_PbWO4 carries `pot=0.0` upstream (compute-from-composition
+    sentinel). The mirror represents that as `mee_eV=None`, so the
+    enricher must not attempt to write a MEE for `pwo` even if the
+    field is missing in our TOML."""
+    entry = enricher.G4_NIST["pwo"]
+    assert entry.mee_eV is None


### PR DESCRIPTION
## Summary

- Adds `scripts/enrich_from_geant4_nist.py` — sibling to `enrich_from_wikidata.py` (#198), built on the shared curation helpers from #197. Cross-checks scintillator + plastic entries against Geant4 v11.2.0's `G4NistMaterialBuilder.cc` constants (density, mean excitation energy). Composition is intentionally skipped — py-mat has no schema field for element fractions yet.
- Mirrors the Geant4 NIST table **by hand** into a pinned `G4_NIST` dict (v11.2.0, line-number citations into `G4NistMaterialBuilder.cc`). No runtime fetch: curation must be reproducible offline; minor versions are stable across these constants.
- **CONTROVERSIAL** — extends the license allow-list with `Geant4-SL` (Geant4 Software License, BSD-like with attribution). Touches `scripts/check_licenses.py`, `scripts/_curation.py`, `docs/data-policy.md`, `tests/test_check_licenses.py`. The Geant4 SL is materially more permissive than `proprietary-reference-only` implies, and distinguishing it sets the right precedent for the BSD-like sources we'll hit next (HEPData mirrors, third-party NIST compilations). If a reviewer prefers collapsing into `proprietary-reference-only` (Option B in the issue brief), the revert is small.

## What it covers

| Category | Matched | Skipped |
|---|---|---|
| scintillators | bgo, nai, nai.Tl, csi, csi.Tl, csi.Na, plastic_scint(+BC400, EJ200), pwo (density only) | lyso, lyso.Ce, labr3 |
| plastics | pmma (→ G4_LUCITE), pc, ptfe, pe, nylon, delrin, pctfe | peek, ultem, esr, pla, abs, petg, tpu, vespel, torlon |

`pwo` matches `G4_PbWO4` for density but Geant4 carries `pot=0.0` (compute-from-composition sentinel) — the enricher recognizes that as `mee_eV=None` and skips the MEE writeback for it.

## Behavior

- Tighter tolerance than the Wikidata enricher: `1.0%` (NIST reference values should be exact).
- NEVER overwrites; NEVER adds new materials. Add-only writeback gated by `--write`.
- `--dry-run` is a no-op accepted for CLI parity (this enricher is offline-only).

## Test plan

- [x] `uv run pytest tests/test_geant4_enrichment.py tests/test_curation_helpers.py -v` — 30 passed
- [x] `uv run pytest` — 665 passed, 18 skipped
- [x] `uv run ruff check . && uv run ruff format --check .`
- [x] `uv run python scripts/enrich_from_geant4_nist.py --key bgo --dry-run` — clean comparison output
- [x] `uv run python scripts/enrich_from_geant4_nist.py --dry-run` — full report; 16 MISSING + 3 DIFF + 25 SKIP rows; no crashes

Closes #167