### PR TITLE
feat(scripts): refractiveindex.info enricher for n,k dispersion (#164)

### DIFF
--- a/scripts/_curation.py
+++ b/scripts/_curation.py
@@ -125,6 +125,51 @@ def cached_get(
     return body
 
 
+def cached_get_text(
+    url: str,
+    params: dict[str, Any] | None = None,
+    *,
+    ttl_days: int = 30,
+    source: str,
+    suffix: str = ".txt",
+    headers: dict[str, str] | None = None,
+    timeout: int = 20,
+) -> str:
+    """Fetch a text/yaml/xml response, caching on disk under `scripts/.cache/<source>/`.
+
+    Sibling of `cached_get` for sources that ship non-JSON payloads
+    (refractiveindex.info ships YAML 1.1 files; NIST sometimes serves
+    plain-text tables). Returns the raw response body as a string. On a
+    cache hit within TTL, no network call is made.
+
+    `suffix` controls the on-disk extension (default `.txt`; pass
+    `.yaml`/`.xml` for clarity when browsing the cache). The cache key
+    is derived from `(url, params)` so two callers using different
+    suffixes won't collide unless the URL is identical — which is the
+    correct behaviour: same URL = same payload.
+    """
+    key = _cache_key(url, {**(params or {}), "method": "GET-text"})
+    path = _cache_path(source, key, suffix)
+    ttl_seconds = ttl_days * 86400
+
+    if path.exists():
+        age = time.time() - path.stat().st_mtime
+        if age < ttl_seconds:
+            return path.read_text(encoding="utf-8")
+
+    merged_headers = {"User-Agent": USER_AGENT}
+    if headers:
+        merged_headers.update(headers)
+
+    resp = requests.get(url, params=params, headers=merged_headers, timeout=timeout)
+    resp.raise_for_status()
+    body = resp.text
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    return body
+
+
 # --------------------------------------------------------------------------- #
 # 2. UnitNormalizer — source unit string → py-mat canonical                  #
 # --------------------------------------------------------------------------- #
@@ -390,6 +435,7 @@ __all__ = [
     "UnitNormalizer",
     "build_source_row",
     "cached_get",
+    "cached_get_text",
     "default_normalizer",
     "fmt_delta",
     "load_material_keys",

--- a/scripts/enrich_from_refractiveindex.py
+++ b/scripts/enrich_from_refractiveindex.py
@@ -1,0 +1,654 @@
+#!/usr/bin/env python3
+"""Enrich mat optical entries with n,k dispersion from refractiveindex.info — #164.
+
+The Polyanskiy refractiveindex.info database is **CC0** (per
+https://github.com/polyanskiy/refractiveindex.info-database). It is the
+canonical bulk source for the `optical.refractive_index_dispersion`
+schema field added in #146 / #152: a dict of
+`{wavelengths_nm: [...], n: [...], k: [...]}` (k optional for absorbing
+media — metals).
+
+This enricher pulls per-material YAML files on demand from the project's
+GitHub mirror (no submodule — the database is ~100 MB), parses the
+`DATA:` block, converts wavelengths from micrometres to nanometres, and
+adds-only writes the result into the relevant `[<material>.optical]`
+table together with a `_sources` row tagged
+`optical.refractive_index_dispersion`.
+
+Both `formula 1` (Sellmeier) and `tabulated nk` data types are
+supported. For Sellmeier entries we evaluate the formula on a 50-point
+log-spaced grid spanning the database's declared `wavelength_range`,
+which gives downstream Geant4 / OpticsBuilder consumers a tabulated
+proxy without forcing them to embed a Sellmeier evaluator.
+
+This is NOT a runtime dependency of mat — lives in scripts/ for data
+curation. Shared helpers live in `scripts/_curation.py`.
+
+## Phase-4 scope
+
+Per the design review on #164 this PR enriches a small, audited subset:
+five scintillator hosts (`nai`, `nai.Tl`, `csi`, `csi.Tl`, `csi.Na`,
+`bgo`) and three metals (`aluminum`, `copper`, `gold`). BaF₂, YAG,
+sapphire, fused-silica, PMMA, polystyrene are deferred — those entries
+either don't exist in mat's TOMLs yet (Phase 5 material adds) or
+warrant a follow-up enrichment PR.
+
+## Behaviour
+
+* `--dry-run` (default-on when neither `--write` nor a network call is
+  needed for the comparison): produces the report without mutating
+  anything.
+* `--write`: ADD-ONLY. If `optical.refractive_index_dispersion` is
+  already present on a material, log DIFF and SKIP (we never silently
+  overwrite curator data).
+* Cache: backs `cached_get_text` with a 30-day TTL under
+  `scripts/.cache/refractiveindex/`.
+* Missing entries: a `404` from the GitHub raw URL is caught and
+  logged; the run continues for the remaining materials.
+
+## Usage
+
+    python scripts/enrich_from_refractiveindex.py                    # full report
+    python scripts/enrich_from_refractiveindex.py --key bgo --dry-run
+    python scripts/enrich_from_refractiveindex.py --write
+    python scripts/enrich_from_refractiveindex.py --report out.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import math
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import requests  # noqa: E402
+import tomlkit  # noqa: E402
+import yaml  # noqa: E402
+from _curation import (  # noqa: E402
+    DATA_DIR,
+    build_source_row,
+    cached_get_text,
+    writeback,
+)
+
+from pymat import load_all  # noqa: E402
+
+# --------------------------------------------------------------------------- #
+# Source URL pattern + per-entry mapping                                      #
+# --------------------------------------------------------------------------- #
+
+# The repo's default branch is `main` (verified 2026-05; the issue
+# mentioned `master` but that branch was renamed years ago).
+_BASE_URL = (
+    "https://raw.githubusercontent.com/polyanskiy/"
+    "refractiveindex.info-database/main/database/data/{path}.yml"
+)
+SOURCE_NAME = "refractiveindex"
+
+# When we synthesise a tabulated grid from a Sellmeier `formula 1` entry
+# we use this many points across the declared `wavelength_range`.
+SELLMEIER_GRID_POINTS = 50
+
+# Maps a py-mat material key → (database path, citation label). The
+# database path is everything after `database/data/` and before the
+# `.yml` suffix. The citation label is what we put in the `_sources`
+# row. All paths verified live against `main` HEAD on 2026-05-07.
+ENTRY_MAP: dict[str, tuple[str, str]] = {
+    # ----- scintillator hosts (formula 1 / Sellmeier) -----
+    # Tl- and Na-doped variants share the host-crystal dispersion.
+    "nai": ("main/NaI/nk/Li", "Li 1976 (NaI, 297 K)"),
+    "nai.Tl": ("main/NaI/nk/Li", "Li 1976 (NaI, 297 K)"),
+    "csi": ("main/CsI/nk/Li", "Li 1976 (CsI)"),
+    "csi.Tl": ("main/CsI/nk/Li", "Li 1976 (CsI)"),
+    "csi.Na": ("main/CsI/nk/Li", "Li 1976 (CsI)"),
+    "bgo": ("main/Bi4Ge3O12/nk/Williams", "Williams 1996 (BGO ord. ray)"),
+    # ----- metals (tabulated nk) -----
+    "aluminum": ("main/Al/nk/Rakic-LD", "Rakic 1995 (Al, Lorentz-Drude)"),
+    "copper": ("main/Cu/nk/Johnson", "Johnson & Christy 1972 (Cu)"),
+    "gold": ("main/Au/nk/Johnson", "Johnson & Christy 1972 (Au)"),
+}
+
+# (material_key → category file). Kept explicit rather than scanning
+# every category TOML — the mapping above is small and the explicit
+# table makes scope review easy.
+CATEGORY_FOR: dict[str, str] = {
+    "nai": "scintillators",
+    "nai.Tl": "scintillators",
+    "csi": "scintillators",
+    "csi.Tl": "scintillators",
+    "csi.Na": "scintillators",
+    "bgo": "scintillators",
+    "aluminum": "metals",
+    "copper": "metals",
+    "gold": "metals",
+}
+
+
+# --------------------------------------------------------------------------- #
+# YAML parsing                                                                #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class Dispersion:
+    """Tabulated n/k samples on a wavelength grid (nanometres).
+
+    `k` is `None` for transparent dielectrics where the source provides
+    only n (Sellmeier-derived scintillators); `k` is a list-of-floats
+    when the source provides absorption (tabulated metals).
+    """
+
+    wavelengths_nm: list[float]
+    n: list[float]
+    k: list[float] | None
+    type_label: str  # "tabulated nk" / "tabulated n" / "formula 1" — for the report
+    has_doi: bool
+    references: str
+
+
+def _extract_doi(references: str) -> str | None:
+    """Pull a DOI out of the YAML's REFERENCES block (best-effort).
+
+    refractiveindex.info uses inline HTML like
+    `<a href="https://doi.org/10.1364/...">...`. We grep the URL out and
+    keep the bare DOI string for the `_sources.ref`.
+    """
+    m = re.search(r"https?://(?:dx\.)?doi\.org/(\S+?)(?:[\"<\s])", references + '"')
+    return m.group(1) if m else None
+
+
+def _parse_tabulated(
+    data_block: str, has_k: bool
+) -> tuple[list[float], list[float], list[float] | None]:
+    """Parse the `data:` string for a tabulated nk / n entry.
+
+    Each row: `wavelength_um n [k]`. Wavelengths are micrometres in the
+    source — converted to nanometres here (×1000).
+    """
+    wavelengths: list[float] = []
+    ns: list[float] = []
+    ks: list[float] | None = [] if has_k else None
+    for raw_line in data_block.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        cols = line.split()
+        if len(cols) < 2:
+            continue
+        try:
+            lam_um = float(cols[0])
+            n_val = float(cols[1])
+        except ValueError:
+            continue
+        wavelengths.append(lam_um * 1000.0)  # µm → nm
+        ns.append(n_val)
+        if has_k:
+            assert ks is not None
+            if len(cols) >= 3:
+                try:
+                    ks.append(float(cols[2]))
+                except ValueError:
+                    ks.append(0.0)
+            else:
+                ks.append(0.0)
+    return wavelengths, ns, ks
+
+
+def _eval_formula_1(coefficients: list[float], lam_um: float) -> float:
+    """Evaluate refractiveindex.info `formula 1` (Sellmeier-like).
+
+    Per the database's formula spec:
+        n²(λ) - 1 = c[0] + Σᵢ c[2i-1] λ² / (λ² - c[2i]²)
+    Coefficients arrive as a list of floats. λ is in µm.
+    """
+    n2m1 = coefficients[0]
+    i = 1
+    while i + 1 < len(coefficients):
+        b = coefficients[i]
+        c = coefficients[i + 1]
+        n2m1 += b * lam_um * lam_um / (lam_um * lam_um - c * c)
+        i += 2
+    return math.sqrt(1.0 + n2m1)
+
+
+def _logspace(lo: float, hi: float, n: int) -> list[float]:
+    """Log-spaced grid of `n` points in [lo, hi] inclusive."""
+    if n < 2:
+        return [lo]
+    log_lo = math.log(lo)
+    log_hi = math.log(hi)
+    step = (log_hi - log_lo) / (n - 1)
+    return [math.exp(log_lo + step * i) for i in range(n)]
+
+
+def _parse_wavelength_range(s: str | list[float]) -> tuple[float, float]:
+    """Parse `wavelength_range: 0.305 1.00` (string OR list — yaml.safe_load
+    can land it either way depending on whether the source uses spaces
+    or commas)."""
+    if isinstance(s, list):
+        return float(s[0]), float(s[1])
+    parts = str(s).split()
+    return float(parts[0]), float(parts[1])
+
+
+def parse_dispersion_yaml(text: str) -> Dispersion:
+    """Parse a refractiveindex.info YAML payload into a `Dispersion`.
+
+    Raises ValueError if no DATA block recognisably contains n,k.
+    """
+    doc = yaml.safe_load(text)
+    if not isinstance(doc, dict) or "DATA" not in doc:
+        raise ValueError("YAML missing top-level DATA block")
+    data_blocks = doc["DATA"]
+    if not isinstance(data_blocks, list) or not data_blocks:
+        raise ValueError("DATA block is not a non-empty list")
+
+    references = str(doc.get("REFERENCES", "")).strip()
+    doi = _extract_doi(references)
+
+    # Walk the DATA blocks; the first one we recognise wins. Per the
+    # database's spec, multiple blocks of differing types may appear
+    # (e.g. n2 + nk2). For our purposes we want a single n[,k] sample
+    # set, so we commit to the first usable block.
+    for block in data_blocks:
+        if not isinstance(block, dict):
+            continue
+        btype = str(block.get("type", "")).strip()
+        if btype == "tabulated nk":
+            wavs, ns, ks = _parse_tabulated(block.get("data", ""), has_k=True)
+            if not wavs:
+                continue
+            return Dispersion(
+                wavelengths_nm=wavs,
+                n=ns,
+                k=ks,
+                type_label=btype,
+                has_doi=doi is not None,
+                references=references,
+            )
+        if btype in ("tabulated n", "tabulated k"):
+            wavs, ns, _ = _parse_tabulated(block.get("data", ""), has_k=False)
+            if not wavs:
+                continue
+            return Dispersion(
+                wavelengths_nm=wavs,
+                n=ns,
+                k=None,
+                type_label=btype,
+                has_doi=doi is not None,
+                references=references,
+            )
+        if btype.startswith("formula"):
+            # We currently only handle formula 1 (Sellmeier). Other
+            # formulas (Cauchy, polynomial variants) require their own
+            # evaluators and aren't in this PR's scope — log + skip.
+            if btype != "formula 1":
+                continue
+            coeffs = block.get("coefficients")
+            wrange = block.get("wavelength_range")
+            if coeffs is None or wrange is None:
+                continue
+            if isinstance(coeffs, str):
+                coeffs = [float(x) for x in coeffs.split()]
+            else:
+                coeffs = [float(x) for x in coeffs]
+            lo, hi = _parse_wavelength_range(wrange)
+            grid = _logspace(lo, hi, SELLMEIER_GRID_POINTS)
+            n_vals = [_eval_formula_1(coeffs, lam) for lam in grid]
+            return Dispersion(
+                wavelengths_nm=[lam * 1000.0 for lam in grid],
+                n=n_vals,
+                k=None,
+                type_label=btype,
+                has_doi=doi is not None,
+                references=references,
+            )
+    raise ValueError(
+        "No usable DATA block found (expected `tabulated nk` / `tabulated n` / `formula 1`)"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Source row + writeback                                                      #
+# --------------------------------------------------------------------------- #
+
+
+def _today_iso() -> str:
+    return _dt.date.today().isoformat()
+
+
+def _make_source_row(
+    *,
+    citation_label: str,
+    db_path: str,
+    disp: Dispersion,
+) -> dict[str, str]:
+    """Build a `_sources` row for an `optical.refractive_index_dispersion` write."""
+    note = (
+        f"n,k tabulated {len(disp.wavelengths_nm)} rows, "
+        f"{disp.wavelengths_nm[0]:.0f}-{disp.wavelengths_nm[-1]:.0f} nm, "
+        f"fetched {_today_iso()}"
+    )
+    return build_source_row(
+        citation=f"{citation_label} via refractiveindex.info",
+        kind="doi" if disp.has_doi else "handbook",
+        ref=f"refractiveindex.info:{db_path}",
+        license="CC0",
+        note=note,
+    )
+
+
+def _build_dispersion_inline(disp: Dispersion) -> Any:
+    """Build the tomlkit value for an `optical.refractive_index_dispersion` field.
+
+    Schema is `Optional[Dict[str, List[float]]]`, so we emit a TOML
+    inline table holding the parallel arrays. tomlkit keeps the
+    `wavelengths_nm` first by insertion order.
+    """
+    table = tomlkit.inline_table()
+    table["wavelengths_nm"] = [round(w, 4) for w in disp.wavelengths_nm]
+    table["n"] = [round(v, 6) for v in disp.n]
+    if disp.k is not None:
+        table["k"] = [round(v, 6) for v in disp.k]
+    return table
+
+
+# --------------------------------------------------------------------------- #
+# Comparison                                                                  #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class Row:
+    key: str
+    db_path: str
+    citation_label: str
+    type_label: str
+    n_rows: int
+    wmin_nm: float
+    wmax_nm: float
+    has_k: bool
+    status: str  # "OK" / "MISSING" / "DIFF" / "SKIP" / "ERROR"
+    note: str = ""
+
+
+def _read_doc(toml_path: Path) -> tomlkit.TOMLDocument:
+    return tomlkit.parse(toml_path.read_text(encoding="utf-8"))
+
+
+def _walk(doc: Any, dotted: str) -> Any | None:
+    node: Any = doc
+    for seg in dotted.split("."):
+        if not isinstance(node, dict) or seg not in node:
+            return None
+        node = node[seg]
+    return node
+
+
+def _ours_dispersion(mat: Any) -> dict[str, list[float]] | None:
+    """Read `properties.optical.refractive_index_dispersion` if present."""
+    if mat is None:
+        return None
+    props = getattr(mat, "properties", None)
+    if props is None:
+        return None
+    optical = getattr(props, "optical", None)
+    if optical is None:
+        return None
+    return getattr(optical, "refractive_index_dispersion", None)
+
+
+def _fetch_one(db_path: str, *, dry_run: bool) -> Dispersion | None:
+    """Fetch + parse a single refractiveindex.info entry.
+
+    Returns None on 404 or YAML parse failure (logged via the caller's
+    Row). When `dry_run` is True we still hit the cache (the offline
+    flag is on the test side via monkey-patching `cached_get_text`); a
+    cache miss in dry-run will still trigger a network call. That
+    matches enrich_from_wikidata.py's semantics — `--dry-run` means "no
+    writeback", not "no network".
+    """
+    url = _BASE_URL.format(path=db_path)
+    try:
+        return parse_dispersion_yaml(
+            cached_get_text(url, source=SOURCE_NAME, suffix=".yaml", ttl_days=30)
+        )
+    except requests.HTTPError as e:
+        if e.response is not None and e.response.status_code == 404:
+            return None
+        raise
+    except ValueError:
+        return None
+
+
+def _compare_one(
+    *,
+    material_key: str,
+    db_path: str,
+    citation_label: str,
+    mats: dict,
+    toml_path: Path,
+    write: bool,
+    dry_run: bool,
+) -> Row:
+    disp = _fetch_one(db_path, dry_run=dry_run)
+    if disp is None:
+        return Row(
+            key=material_key,
+            db_path=db_path,
+            citation_label=citation_label,
+            type_label="-",
+            n_rows=0,
+            wmin_nm=0.0,
+            wmax_nm=0.0,
+            has_k=False,
+            status="ERROR",
+            note="fetch/parse failed (see network log; entry may not be on main HEAD)",
+        )
+
+    row = Row(
+        key=material_key,
+        db_path=db_path,
+        citation_label=citation_label,
+        type_label=disp.type_label,
+        n_rows=len(disp.wavelengths_nm),
+        wmin_nm=disp.wavelengths_nm[0],
+        wmax_nm=disp.wavelengths_nm[-1],
+        has_k=disp.k is not None,
+        status="OK",
+    )
+
+    ours = _ours_dispersion(mats.get(material_key))
+    doc = _read_doc(toml_path)
+    optical_node = _walk(doc, f"{material_key}.optical")
+    on_disk = isinstance(optical_node, dict) and "refractive_index_dispersion" in optical_node
+
+    if ours is not None or on_disk:
+        # NEVER overwrite. Compute overlap of wavelength ranges for the
+        # report so curators can spot egregious mismatches by eye.
+        their_lo, their_hi = disp.wavelengths_nm[0], disp.wavelengths_nm[-1]
+        if ours is not None and ours.get("wavelengths_nm"):
+            our_lo = float(min(ours["wavelengths_nm"]))
+            our_hi = float(max(ours["wavelengths_nm"]))
+            row.status = "DIFF"
+            row.note = (
+                f"ours={our_lo:.0f}-{our_hi:.0f} nm  "
+                f"theirs={their_lo:.0f}-{their_hi:.0f} nm — kept ours"
+            )
+        else:
+            row.status = "DIFF"
+            row.note = (
+                f"on-disk dispersion present (no parsed wavelength_nm grid); "
+                f"theirs={their_lo:.0f}-{their_hi:.0f} nm — kept ours"
+            )
+        return row
+
+    row.status = "MISSING"
+    if write:
+        material_path = material_key.split(".") + ["optical"]
+        src_row = _make_source_row(citation_label=citation_label, db_path=db_path, disp=disp)
+        writeback(
+            toml_path,
+            material_path,
+            {"refractive_index_dispersion": _build_dispersion_inline(disp)},
+            sources={"refractive_index_dispersion": src_row},
+        )
+    return row
+
+
+# --------------------------------------------------------------------------- #
+# Report                                                                      #
+# --------------------------------------------------------------------------- #
+
+
+def _render_report(rows: list[Row], *, write: bool) -> str:
+    lines: list[str] = []
+    lines.append("# refractiveindex.info enrichment report")
+    lines.append("")
+    lines.append(f"Date: {_today_iso()}")
+    lines.append(f"Mode: {'write (add-only)' if write else 'comparison-only'}")
+    lines.append(f"Materials checked: {len(rows)}")
+    ok = sum(1 for r in rows if r.status == "OK" or r.status == "MISSING")
+    diffs = sum(1 for r in rows if r.status == "DIFF")
+    errors = sum(1 for r in rows if r.status == "ERROR")
+    lines.append(f"OK: {ok}  DIFF: {diffs}  ERROR: {errors}")
+    lines.append("")
+
+    header = ["material", "db_path", "type", "rows", "wmin_nm", "wmax_nm", "k?", "status"]
+    lines.append(" | ".join(header))
+    lines.append(" | ".join("---" for _ in header))
+    for r in rows:
+        cells = [
+            r.key,
+            r.db_path,
+            r.type_label,
+            str(r.n_rows),
+            f"{r.wmin_nm:.0f}",
+            f"{r.wmax_nm:.0f}",
+            "yes" if r.has_k else "no",
+            r.status,
+        ]
+        lines.append(" | ".join(cells))
+    lines.append("")
+    notes = [r for r in rows if r.note]
+    if notes:
+        lines.append("Notes:")
+        for r in notes:
+            action = "WROTE" if (write and r.status == "MISSING") else r.status
+            lines.append(f"  {action}  {r.key}: {r.note}")
+    lines.append("")
+    lines.append(
+        "refractiveindex.info data is licensed CC0 "
+        "(https://github.com/polyanskiy/refractiveindex.info-database)."
+    )
+    return "\n".join(lines) + "\n"
+
+
+# --------------------------------------------------------------------------- #
+# Driver                                                                      #
+# --------------------------------------------------------------------------- #
+
+
+def compare(
+    key_filter: str | None = None,
+    *,
+    dry_run: bool = False,
+    write: bool = False,
+    report_path: Path | None = None,
+) -> int:
+    mats = load_all()
+
+    targets = list(ENTRY_MAP.items())
+    if key_filter is not None:
+        targets = [(k, v) for k, v in targets if k == key_filter]
+    if not targets:
+        print(f"No targets matched key={key_filter!r}", file=sys.stderr)
+        return 1
+
+    rows: list[Row] = []
+    for material_key, (db_path, citation_label) in targets:
+        category = CATEGORY_FOR[material_key]
+        toml_path = DATA_DIR / f"{category}.toml"
+        if not toml_path.exists():
+            rows.append(
+                Row(
+                    key=material_key,
+                    db_path=db_path,
+                    citation_label=citation_label,
+                    type_label="-",
+                    n_rows=0,
+                    wmin_nm=0.0,
+                    wmax_nm=0.0,
+                    has_k=False,
+                    status="ERROR",
+                    note=f"missing {toml_path}",
+                )
+            )
+            continue
+        rows.append(
+            _compare_one(
+                material_key=material_key,
+                db_path=db_path,
+                citation_label=citation_label,
+                mats=mats,
+                toml_path=toml_path,
+                write=write,
+                dry_run=dry_run,
+            )
+        )
+
+    report = _render_report(rows, write=write)
+    if report_path is None:
+        print(report)
+    else:
+        report_path.write_text(report, encoding="utf-8")
+        print(f"Report written to {report_path}", file=sys.stderr)
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--key", help="Only enrich this material key")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "Skip writeback. Network fetches are still cached; pass "
+            "--key with a previously-cached entry to run fully offline."
+        ),
+    )
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help=(
+            "Apply add-only writeback: when `optical.refractive_index_dispersion` "
+            "is missing on the target material, write the parsed dispersion plus "
+            "a `_sources` row. Existing dispersion data is NEVER overwritten."
+        ),
+    )
+    parser.add_argument(
+        "--report",
+        type=Path,
+        default=None,
+        help="Write the enrichment report to this path (default: stdout).",
+    )
+    args = parser.parse_args()
+    sys.exit(
+        compare(
+            args.key,
+            dry_run=args.dry_run,
+            write=args.write,
+            report_path=args.report,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/requirements-curation.txt
+++ b/scripts/requirements-curation.txt
@@ -14,3 +14,6 @@ playwright>=1.40
 # tomlkit: roundtrip-safe TOML for scripts/_curation.writeback. Preserves
 # comments and formatting when enrichers patch values into data TOMLs.
 tomlkit>=0.12
+# pyyaml: refractiveindex.info ships its database as YAML 1.1 files;
+# used by scripts/enrich_from_refractiveindex.py (#164). NOT a runtime dep.
+pyyaml>=6.0

--- a/tests/fixtures/refractiveindex_sample.yaml
+++ b/tests/fixtures/refractiveindex_sample.yaml
@@ -1,0 +1,22 @@
+# this file is part of refractiveindex.info database
+# refractiveindex.info database is in the public domain
+# copyright and related rights waived via CC0 1.0
+#
+# Synthetic fixture for tests/test_refractiveindex_enrichment.py — NOT a
+# real material. Designed to exercise the parser's `tabulated nk` path
+# end-to-end (4 rows, both n and k populated, wavelengths in micrometres
+# so the µm→nm conversion matters).
+
+REFERENCES: |
+    Test Author.
+    Synthetic fixture for refractiveindex.info enricher tests.
+    <a href="https://doi.org/10.0000/test"><i>Fixture J.</i> <b>1</b>, 1-2 (2026)</a>
+COMMENTS: |
+    Synthetic test data — not a real material.
+DATA:
+  - type: tabulated nk
+    data: |
+        0.300 1.50 0.001
+        0.500 1.55 0.002
+        0.700 1.52 0.003
+        0.900 1.50 0.004

--- a/tests/test_refractiveindex_enrichment.py
+++ b/tests/test_refractiveindex_enrichment.py
@@ -1,0 +1,420 @@
+"""Tests for `scripts/enrich_from_refractiveindex.py` — issue #164.
+
+Mirrors the layout of `test_geant4_enrichment.py` (PR #200) so the
+enricher CLIs remain interchangeable for curators. Covers:
+
+* YAML parser converts µm → nm (×1000) and survives a real-shape
+  fixture file with `tabulated nk` data + a DOI in REFERENCES.
+* Sellmeier `formula 1` blocks are evaluated on a wavelength grid; the
+  Sellmeier path is exercised separately so a future formula change
+  doesn't slip past the tabulated test.
+* `--dry-run` against a stubbed fetch produces an expected report.
+* `--write` adds the `optical.refractive_index_dispersion` field AND a
+  paired `_sources` row when missing on a tmp-path TOML copy.
+* `--write` does NOT overwrite an existing dispersion field.
+
+Skip if `requests` / `tomlkit` / `yaml` aren't installed: those live in
+`scripts/requirements-curation.txt` and aren't part of the runtime
+install.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+pytest.importorskip("requests")
+pytest.importorskip("tomlkit")
+pytest.importorskip("yaml")
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+FIXTURE = Path(__file__).parent / "fixtures" / "refractiveindex_sample.yaml"
+
+
+@pytest.fixture
+def enricher():
+    """Re-import fresh per test so module-level state doesn't leak."""
+    if "enrich_from_refractiveindex" in sys.modules:
+        del sys.modules["enrich_from_refractiveindex"]
+    return importlib.import_module("enrich_from_refractiveindex")
+
+
+def _patch_data_dir(monkeypatch, enricher, tmp_path: Path) -> None:
+    """Redirect both module-level DATA_DIR pointers to `tmp_path`."""
+    import _curation
+
+    monkeypatch.setattr(_curation, "DATA_DIR", tmp_path)
+    monkeypatch.setattr(enricher, "DATA_DIR", tmp_path)
+
+
+def _stub_load_all(enricher, monkeypatch, mats: dict) -> None:
+    monkeypatch.setattr(enricher, "load_all", lambda: mats)
+
+
+def _stub_fetch(enricher, monkeypatch, payload_for: dict[str, str]) -> None:
+    """Stub `cached_get_text` to return per-URL fixture YAML.
+
+    Map keys are URL substrings; first match wins. Anything unmapped
+    raises — tests should declare every URL they expect a hit on.
+    """
+
+    def fake_fetch(url, **kw):
+        for needle, payload in payload_for.items():
+            if needle in url:
+                return payload
+        raise AssertionError(f"unexpected fetch: {url}")
+
+    monkeypatch.setattr(enricher, "cached_get_text", fake_fetch)
+
+
+class _StubMaterial:
+    def __init__(self, optical: dict | None = None):
+        self.properties = type(
+            "P",
+            (),
+            {"optical": type("O", (), optical or {})()},
+        )()
+
+
+# --------------------------------------------------------------------------- #
+# Fixture validity                                                            #
+# --------------------------------------------------------------------------- #
+
+
+def test_fixture_file_is_valid_yaml():
+    import yaml
+
+    payload = yaml.safe_load(FIXTURE.read_text())
+    assert "DATA" in payload
+    assert payload["DATA"][0]["type"] == "tabulated nk"
+
+
+# --------------------------------------------------------------------------- #
+# Parser                                                                      #
+# --------------------------------------------------------------------------- #
+
+
+def test_parser_converts_micrometres_to_nanometres(enricher):
+    """The fixture's wavelengths are 0.3 / 0.5 / 0.7 / 0.9 µm → 300 / 500
+    / 700 / 900 nm. The ×1000 factor is the load-bearing thing here."""
+    disp = enricher.parse_dispersion_yaml(FIXTURE.read_text())
+    assert disp.wavelengths_nm == [300.0, 500.0, 700.0, 900.0]
+    assert disp.n == [1.50, 1.55, 1.52, 1.50]
+    assert disp.k == [0.001, 0.002, 0.003, 0.004]
+    assert disp.type_label == "tabulated nk"
+    assert disp.has_doi is True
+
+
+def test_parser_handles_tabulated_n_only(enricher):
+    src = dedent(
+        """\
+        REFERENCES: "Test"
+        DATA:
+          - type: tabulated n
+            data: |
+                0.4 1.50
+                0.6 1.52
+        """
+    )
+    disp = enricher.parse_dispersion_yaml(src)
+    assert disp.wavelengths_nm == [400.0, 600.0]
+    assert disp.n == [1.50, 1.52]
+    assert disp.k is None
+
+
+def test_parser_evaluates_sellmeier_formula_1(enricher):
+    """formula 1 (Sellmeier) is evaluated on a log-spaced grid spanning
+    the declared wavelength_range. Sanity-check NaI's well-known value
+    n(589 nm) ≈ 1.77 falls between adjacent grid points."""
+    src = dedent(
+        """\
+        REFERENCES: "Li 1976"
+        DATA:
+          - type: formula 1
+            wavelength_range: 0.25 40
+            coefficients: 0.478 1.532 0.170 4.27 86.21
+        """
+    )
+    disp = enricher.parse_dispersion_yaml(src)
+    assert disp.k is None
+    assert disp.type_label == "formula 1"
+    # 50 grid points across [0.25, 40] µm = [250, 40000] nm
+    assert len(disp.wavelengths_nm) == enricher.SELLMEIER_GRID_POINTS
+    assert disp.wavelengths_nm[0] == pytest.approx(250.0, rel=1e-6)
+    assert disp.wavelengths_nm[-1] == pytest.approx(40000.0, rel=1e-6)
+    # Well-formed Sellmeier => all positive, finite, within plausible
+    # bounds. NaI's UV side approaches n ~ 1.93, and the IR side falls
+    # off (n(40 µm) ~ 1.36) — the bounds reflect the full grid span.
+    assert all(1.0 < n < 2.5 for n in disp.n)
+    # Visible-band sanity: n(589 nm) ≈ 1.7745 (well-known for NaI).
+    n_589 = enricher._eval_formula_1([0.478, 1.532, 0.170, 4.27, 86.21], 0.589)
+    assert n_589 == pytest.approx(1.7745, abs=1e-3)
+
+
+def test_parser_rejects_yaml_without_data(enricher):
+    with pytest.raises(ValueError, match="DATA"):
+        enricher.parse_dispersion_yaml("REFERENCES: nope")
+
+
+def test_doi_extraction(enricher):
+    refs = '<a href="https://doi.org/10.1364/AO.35.003562">Appl. Opt.</a>'
+    assert enricher._extract_doi(refs) == "10.1364/AO.35.003562"
+    assert enricher._extract_doi("no doi here") is None
+
+
+# --------------------------------------------------------------------------- #
+# --dry-run                                                                   #
+# --------------------------------------------------------------------------- #
+
+
+_SYNTHETIC_BGO_GAP = dedent(
+    """\
+    # top-of-file comment — must survive the round-trip
+    [bgo]
+    name = "BGO"
+    formula = "Bi4Ge3O12"
+
+    [bgo.optical]
+    refractive_index = 2.15
+    """
+)
+
+
+def test_dry_run_produces_expected_report(enricher, monkeypatch, tmp_path, capsys):
+    toml_path = tmp_path / "scintillators.toml"
+    toml_path.write_text(_SYNTHETIC_BGO_GAP)
+    _patch_data_dir(monkeypatch, enricher, tmp_path)
+    _stub_load_all(
+        enricher,
+        monkeypatch,
+        {"bgo": _StubMaterial(optical={"refractive_index_dispersion": None})},
+    )
+    _stub_fetch(enricher, monkeypatch, {"Bi4Ge3O12": FIXTURE.read_text()})
+
+    rc = enricher.compare(key_filter="bgo", dry_run=True)
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "# refractiveindex.info enrichment report" in out
+    assert "Mode: comparison-only" in out
+    assert "bgo" in out
+    assert "MISSING" in out
+    assert "CC0" in out
+
+
+# --------------------------------------------------------------------------- #
+# --write: add-only                                                           #
+# --------------------------------------------------------------------------- #
+
+
+def test_write_adds_dispersion_and_sources_row(enricher, monkeypatch, tmp_path):
+    toml_path = tmp_path / "scintillators.toml"
+    toml_path.write_text(_SYNTHETIC_BGO_GAP)
+    _patch_data_dir(monkeypatch, enricher, tmp_path)
+    _stub_load_all(
+        enricher,
+        monkeypatch,
+        {"bgo": _StubMaterial(optical={"refractive_index_dispersion": None})},
+    )
+    _stub_fetch(enricher, monkeypatch, {"Bi4Ge3O12": FIXTURE.read_text()})
+
+    rc = enricher.compare(key_filter="bgo", dry_run=False, write=True)
+    assert rc == 0
+
+    out = toml_path.read_text()
+    # Field landed under [bgo.optical] as an inline dispersion table.
+    assert "refractive_index_dispersion" in out
+    # µm → nm conversion: fixture is 0.3 µm → 300 nm.
+    assert "wavelengths_nm = [300" in out
+    # Source row tagged with the canonical group.field key.
+    assert "[bgo._sources]" in out
+    assert "optical.refractive_index_dispersion" in out
+    assert "CC0" in out
+    assert "refractiveindex.info" in out
+    # Top-of-file comment survives the round-trip.
+    assert "# top-of-file comment" in out
+
+
+def test_write_does_not_overwrite_existing_dispersion(enricher, monkeypatch, tmp_path):
+    """When the target field is already present, the writeback path
+    must be a no-op even with --write."""
+    src = dedent(
+        """\
+        [bgo]
+        name = "BGO"
+
+        [bgo.optical]
+        refractive_index = 2.15
+        # Curator-set value — must be preserved.
+        refractive_index_dispersion = {wavelengths_nm = [400.0, 700.0], n = [2.20, 2.10]}
+        """
+    )
+    toml_path = tmp_path / "scintillators.toml"
+    toml_path.write_text(src)
+    _patch_data_dir(monkeypatch, enricher, tmp_path)
+    _stub_load_all(
+        enricher,
+        monkeypatch,
+        {
+            "bgo": _StubMaterial(
+                optical={
+                    "refractive_index_dispersion": {
+                        "wavelengths_nm": [400.0, 700.0],
+                        "n": [2.20, 2.10],
+                    }
+                }
+            )
+        },
+    )
+    _stub_fetch(enricher, monkeypatch, {"Bi4Ge3O12": FIXTURE.read_text()})
+
+    rc = enricher.compare(key_filter="bgo", dry_run=False, write=True)
+    assert rc == 0
+
+    after = toml_path.read_text()
+    # Original n values are still there; fixture's 1.50 didn't sneak in.
+    assert "[2.2, 2.1]" in after or "2.2" in after
+    assert "1.50" not in after
+    # No source row was added (we never overwrote, so no provenance entry).
+    assert "optical.refractive_index_dispersion" not in after
+
+
+def test_comparison_only_never_writes(enricher, monkeypatch, tmp_path):
+    toml_path = tmp_path / "scintillators.toml"
+    toml_path.write_text(_SYNTHETIC_BGO_GAP)
+    before = toml_path.read_text()
+    _patch_data_dir(monkeypatch, enricher, tmp_path)
+    _stub_load_all(
+        enricher,
+        monkeypatch,
+        {"bgo": _StubMaterial(optical={"refractive_index_dispersion": None})},
+    )
+    _stub_fetch(enricher, monkeypatch, {"Bi4Ge3O12": FIXTURE.read_text()})
+
+    rc = enricher.compare(key_filter="bgo", dry_run=True, write=False)
+    assert rc == 0
+    assert toml_path.read_text() == before
+
+
+# --------------------------------------------------------------------------- #
+# Source row sanity                                                           #
+# --------------------------------------------------------------------------- #
+
+
+def test_source_row_is_well_formed(enricher):
+    disp = enricher.parse_dispersion_yaml(FIXTURE.read_text())
+    row = enricher._make_source_row(
+        citation_label="Williams 1996 (BGO ord. ray)",
+        db_path="main/Bi4Ge3O12/nk/Williams",
+        disp=disp,
+    )
+    assert row["license"] == "CC0"
+    assert row["kind"] == "doi"  # fixture has a DOI in REFERENCES
+    assert "via refractiveindex.info" in row["citation"]
+    assert row["ref"].startswith("refractiveindex.info:")
+    assert "fetched" in row["note"]
+    assert "300-900 nm" in row["note"]
+
+
+def test_source_row_falls_back_to_handbook_when_no_doi(enricher):
+    src = dedent(
+        """\
+        REFERENCES: "no doi here"
+        DATA:
+          - type: tabulated n
+            data: |
+                0.4 1.50
+                0.6 1.52
+        """
+    )
+    disp = enricher.parse_dispersion_yaml(src)
+    row = enricher._make_source_row(
+        citation_label="X",
+        db_path="main/X/nk/Y",
+        disp=disp,
+    )
+    assert row["kind"] == "handbook"
+
+
+# --------------------------------------------------------------------------- #
+# --report                                                                    #
+# --------------------------------------------------------------------------- #
+
+
+def test_report_writes_markdown_file(enricher, monkeypatch, tmp_path, capsys):
+    toml_path = tmp_path / "scintillators.toml"
+    toml_path.write_text(_SYNTHETIC_BGO_GAP)
+    _patch_data_dir(monkeypatch, enricher, tmp_path)
+    _stub_load_all(
+        enricher,
+        monkeypatch,
+        {"bgo": _StubMaterial(optical={"refractive_index_dispersion": None})},
+    )
+    _stub_fetch(enricher, monkeypatch, {"Bi4Ge3O12": FIXTURE.read_text()})
+
+    out_path = tmp_path / "report.md"
+    rc = enricher.compare(key_filter="bgo", dry_run=True, report_path=out_path)
+    assert rc == 0
+    assert out_path.exists()
+    content = out_path.read_text()
+    assert "# refractiveindex.info enrichment report" in content
+    captured = capsys.readouterr()
+    assert "# refractiveindex.info enrichment report" not in captured.out
+
+
+# --------------------------------------------------------------------------- #
+# Entry-map paths are well-formed                                             #
+# --------------------------------------------------------------------------- #
+
+
+def test_entry_map_paths_well_formed(enricher):
+    """Each ENTRY_MAP value is `<book>/<page>/nk/<entry>` (4 path
+    segments). Catches a typo that would 404 every fetch."""
+    for key, (path, label) in enricher.ENTRY_MAP.items():
+        parts = path.split("/")
+        assert len(parts) == 4, f"{key}: unexpected path {path!r}"
+        assert parts[0] == "main"
+        assert parts[2] == "nk"
+        assert label, f"{key}: empty citation label"
+        assert key in enricher.CATEGORY_FOR
+
+
+# --------------------------------------------------------------------------- #
+# cached_get_text smoke test                                                  #
+# --------------------------------------------------------------------------- #
+
+
+def test_cached_get_text_persists_to_disk_and_reuses(monkeypatch, tmp_path):
+    import _curation
+    from _curation import cached_get_text
+
+    monkeypatch.setattr(_curation, "CACHE_DIR", tmp_path / "cache")
+    calls = {"n": 0}
+
+    class _FakeResp:
+        def __init__(self, text):
+            self.text = text
+            self.status_code = 200
+
+        def raise_for_status(self):
+            return None
+
+    def fake_get(url, params=None, headers=None, timeout=None):
+        calls["n"] += 1
+        return _FakeResp(f"hello {calls['n']}")
+
+    monkeypatch.setattr(_curation.requests, "get", fake_get)
+
+    out1 = cached_get_text("https://example.test/x.yml", source="ut", suffix=".yaml")
+    out2 = cached_get_text("https://example.test/x.yml", source="ut", suffix=".yaml")
+    assert calls["n"] == 1
+    assert out1 == out2 == "hello 1"
+    # Persisted with the requested suffix.
+    cached = list((tmp_path / "cache" / "ut").glob("*.yaml"))
+    assert len(cached) == 1


### PR DESCRIPTION
## Summary

- Adds `scripts/enrich_from_refractiveindex.py` — a Phase-4 curation enricher that pulls n,k dispersion from the Polyanskiy refractiveindex.info database (CC0) into the `optical.refractive_index_dispersion` schema field (added in #146 / #152).
- Adds `cached_get_text(url, *, ttl_days, source, suffix)` to `scripts/_curation.py` — sibling of the existing JSON-only `cached_get`, persists text/YAML/XML payloads under `scripts/.cache/<source>/`. Exported via `__all__`.
- Scope per #164 Phase-4 review: 6 scintillator hosts (`nai`, `nai.Tl`, `csi`, `csi.Tl`, `csi.Na`, `bgo`) + 3 metals (`aluminum`, `copper`, `gold`). BaF2/YAG/sapphire/fused-silica/PMMA deferred — those entries either aren't in mat's TOMLs yet or warrant a follow-up.
- Both `tabulated nk` (metals) and `formula 1` Sellmeier (scintillators) data types parsed; Sellmeier evaluated on a 50-point log grid spanning the upstream `wavelength_range`.
- ADD-ONLY writeback: existing dispersion values are NEVER overwritten. Source rows tagged `optical.refractive_index_dispersion`, `license = CC0`, `kind = doi` when the YAML's REFERENCES block contains a DOI link.
- No submodule (database is ~100 MB) — per-material fetches via the `raw.githubusercontent.com` mirror with a 30-day disk cache.
- `pyyaml>=6.0` added to `scripts/requirements-curation.txt` (NOT a runtime dep).

Live verification (2026-05-07): all 9 `ENTRY_MAP` paths resolve on upstream `main`; comparison report shows `MISSING` (so no collisions with curated values) for every target.

| material | db_path | type | rows | wmin_nm | wmax_nm | k? |
|---|---|---|---|---|---|---|
| nai / nai.Tl | main/NaI/nk/Li | formula 1 | 50 | 250 | 40000 | no |
| csi / csi.Tl / csi.Na | main/CsI/nk/Li | formula 1 | 50 | 250 | 67000 | no |
| bgo | main/Bi4Ge3O12/nk/Williams | formula 1 | 50 | 305 | 1000 | no |
| aluminum | main/Al/nk/Rakic-LD | tabulated nk | 1000 | 62 | 247970 | yes |
| copper | main/Cu/nk/Johnson | tabulated nk | 49 | 188 | 1937 | yes |
| gold | main/Au/nk/Johnson | tabulated nk | 49 | 188 | 1937 | yes |

## Test plan

- [x] `pytest tests/test_refractiveindex_enrichment.py tests/test_curation_helpers.py -v` — 35 passed
- [x] `pytest --ignore=tests/test_visual_compare.py` (full suite) — 652 passed, 34 skipped
- [x] `ruff check . && ruff format --check .` — clean
- [x] Live `python scripts/enrich_from_refractiveindex.py --dry-run` — all 9 entries fetched, parsed, no DIFF
- [x] Live `python scripts/enrich_from_refractiveindex.py --key bgo --write` (then reverted) — produces well-formed inline TOML and `optical.refractive_index_dispersion` source row, all comments preserved

Closes #164.