### PR TITLE
docs(data): primary-paper citations for scintillator entries (#170)

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -37,6 +37,11 @@ Stinless = "Stinless"
 stinless = "stinless"
 Stainles = "Stainles"
 stainles = "stainles"
+# Scintillator material acronyms — LSO is "lutetium oxyorthosilicate"
+# (Lu2SiO5), the historical parent of LYSO. Typos otherwise rewrites
+# every instance of "LSO" to "ALSO" (#170).
+LSO = "LSO"
+lso = "lso"
 
 [files]
 extend-exclude = [

--- a/src/pymat/data/scintillators.toml
+++ b/src/pymat/data/scintillators.toml
@@ -297,24 +297,74 @@ light_yield = 12000
 decay_time = 2.1
 
 # ============================================================================
-# Provenance (#175 audit)
+# Provenance (#170 — primary-paper citations)
 # ----------------------------------------------------------------------------
-# Default _sources entries attached during the one-time #175 audit. These
-# placeholder citations point at py-mat's aggregate curation history; future
-# per-source PRs (#158-#173) overwrite individual entries with proper
-# citations (Wikidata QIDs, NIST datasets, vendor URLs, etc.).
+# Primary measurement papers attached to scintillator entries. The LBNL
+# Scintillator Library (https://scintillator.lbl.gov/) was used as a
+# *discovery index* to locate these papers — see issue #170 — but is never
+# itself cited in `_sources.ref` (license unclear; treat as discovery only).
+# The LBNL group's own database overview (Shook, Laplace, Boswell, Bourret,
+# Derenzo, Goldblum 2025, NIM A) is included as `optical._review` for the
+# modern scintillators it covers.
+#
+# Vendor- and handbook-specific values (Saint-Gobain, Hamamatsu, Eljen,
+# SICCAS, Epic, Crystals catalogue) retain the `_default` placeholder from
+# the #175 audit — primary papers don't constrain vendor variants.
 # ============================================================================
 
-[lyso._sources._default]
-citation = "py-mat-curation-3.x"
-kind = "handbook"
-ref = "py-mat curation history; values from handbook/vendor/Wikidata aggregate (pre-#175 audit)"
+# --- LSO/LYSO (lyso parent: nominally LSO Lu2SiO5; values match Melcher 1992) -
+
+[lyso._sources."optical.light_yield"]
+citation = "melcher_schweitzer_1992"
+kind = "doi"
+ref = "10.1109/23.159655"
+license = "proprietary-reference-only"
+note = "LSO:Ce discovery paper — Melcher & Schweitzer 1992, IEEE Trans. Nucl. Sci. 39(4), 502."
+
+[lyso._sources."optical.decay_time"]
+citation = "melcher_schweitzer_1992"
+kind = "doi"
+ref = "10.1109/23.159655"
 license = "proprietary-reference-only"
 
-[lyso.Ce._sources._default]
-citation = "py-mat-curation-3.x"
-kind = "handbook"
-ref = "py-mat curation history; values from handbook/vendor/Wikidata aggregate (pre-#175 audit)"
+[lyso._sources."optical.emission_peak"]
+citation = "melcher_schweitzer_1992"
+kind = "doi"
+ref = "10.1109/23.159655"
+license = "proprietary-reference-only"
+
+[lyso._sources."mechanical.density"]
+citation = "melcher_schweitzer_1992"
+kind = "doi"
+ref = "10.1109/23.159655"
+license = "proprietary-reference-only"
+
+[lyso._sources."optical._review"]
+citation = "shook_laplace_2025"
+kind = "doi"
+ref = "10.1016/j.nima.2025.170389"
+license = "proprietary-reference-only"
+note = "LBNL Scintillator Library overview — Shook, Laplace, Boswell, Bourret, Derenzo, Goldblum 2025, NIM A 1075, 170389. Cited as a review; values are not extracted from this paper."
+
+# --- LYSO:Ce (lyso.Ce) -------------------------------------------------------
+
+[lyso.Ce._sources."optical.light_yield"]
+citation = "cooke_2000"
+kind = "doi"
+ref = "10.1063/1.1328775"
+license = "proprietary-reference-only"
+note = "LYSO:Ce (Lu1.8Y0.2SiO5:Ce) Czochralski growth + scintillation — Cooke et al. 2000, J. Appl. Phys. 88, 7360."
+
+[lyso.Ce._sources."optical.decay_time"]
+citation = "cooke_2000"
+kind = "doi"
+ref = "10.1063/1.1328775"
+license = "proprietary-reference-only"
+
+[lyso.Ce._sources."optical._review"]
+citation = "shook_laplace_2025"
+kind = "doi"
+ref = "10.1016/j.nima.2025.170389"
 license = "proprietary-reference-only"
 
 [lyso.Ce.saint_gobain._sources._default]
@@ -341,22 +391,58 @@ kind = "handbook"
 ref = "py-mat curation history; values from handbook/vendor/Wikidata aggregate (pre-#175 audit)"
 license = "proprietary-reference-only"
 
-[bgo._sources._default]
-citation = "py-mat-curation-3.x"
-kind = "handbook"
-ref = "py-mat curation history; values from handbook/vendor/Wikidata aggregate (pre-#175 audit)"
+# --- BGO ---------------------------------------------------------------------
+
+[bgo._sources."optical.light_yield"]
+citation = "weber_monchamp_1973"
+kind = "doi"
+ref = "10.1063/1.1662183"
+license = "proprietary-reference-only"
+note = "BGO (Bi4Ge3O12) luminescence — Weber & Monchamp 1973, J. Appl. Phys. 44, 5495. Discovery of BGO scintillation."
+
+[bgo._sources."optical.decay_time"]
+citation = "weber_monchamp_1973"
+kind = "doi"
+ref = "10.1063/1.1662183"
 license = "proprietary-reference-only"
 
-[nai._sources._default]
-citation = "py-mat-curation-3.x"
-kind = "handbook"
-ref = "py-mat curation history; values from handbook/vendor/Wikidata aggregate (pre-#175 audit)"
+[bgo._sources."optical.emission_peak"]
+citation = "weber_monchamp_1973"
+kind = "doi"
+ref = "10.1063/1.1662183"
 license = "proprietary-reference-only"
 
-[nai.Tl._sources._default]
-citation = "py-mat-curation-3.x"
-kind = "handbook"
-ref = "py-mat curation history; values from handbook/vendor/Wikidata aggregate (pre-#175 audit)"
+# --- NaI / NaI:Tl ------------------------------------------------------------
+
+[nai._sources."optical.light_yield"]
+citation = "hofstadter_1948"
+kind = "doi"
+ref = "10.1103/PhysRev.74.100"
+license = "proprietary-reference-only"
+note = "NaI:Tl as a scintillation counter — Hofstadter 1948, Phys. Rev. 74, 100. Discovery of NaI(Tl) scintillation."
+
+[nai._sources."optical.decay_time"]
+citation = "hofstadter_1948"
+kind = "doi"
+ref = "10.1103/PhysRev.74.100"
+license = "proprietary-reference-only"
+
+[nai._sources."optical.emission_peak"]
+citation = "hofstadter_1948"
+kind = "doi"
+ref = "10.1103/PhysRev.74.100"
+license = "proprietary-reference-only"
+
+[nai.Tl._sources."optical.light_yield"]
+citation = "hofstadter_1948"
+kind = "doi"
+ref = "10.1103/PhysRev.74.100"
+license = "proprietary-reference-only"
+
+[nai.Tl._sources."optical.decay_time"]
+citation = "hofstadter_1948"
+kind = "doi"
+ref = "10.1103/PhysRev.74.100"
 license = "proprietary-reference-only"
 
 [nai.Tl.saint_gobain._sources._default]
@@ -371,35 +457,93 @@ kind = "handbook"
 ref = "py-mat curation history; values from handbook/vendor/Wikidata aggregate (pre-#175 audit)"
 license = "proprietary-reference-only"
 
-[csi._sources._default]
-citation = "py-mat-curation-3.x"
-kind = "handbook"
-ref = "py-mat curation history; values from handbook/vendor/Wikidata aggregate (pre-#175 audit)"
+# --- CsI / CsI:Tl / CsI:Na ---------------------------------------------------
+
+[csi._sources."optical.light_yield"]
+citation = "holl_lorenz_mageras_1988"
+kind = "doi"
+ref = "10.1109/23.12684"
+license = "proprietary-reference-only"
+note = "Light yield of common inorganic scintillators (NaI, CsI, BGO) — Holl, Lorenz, Mageras 1988, IEEE Trans. Nucl. Sci. 35, 105."
+
+[csi._sources."optical.emission_peak"]
+citation = "holl_lorenz_mageras_1988"
+kind = "doi"
+ref = "10.1109/23.12684"
 license = "proprietary-reference-only"
 
-[csi.Tl._sources._default]
-citation = "py-mat-curation-3.x"
-kind = "handbook"
-ref = "py-mat curation history; values from handbook/vendor/Wikidata aggregate (pre-#175 audit)"
+[csi.Tl._sources."optical.light_yield"]
+citation = "holl_lorenz_mageras_1988"
+kind = "doi"
+ref = "10.1109/23.12684"
 license = "proprietary-reference-only"
 
+[csi.Tl._sources."optical.decay_time"]
+citation = "holl_lorenz_mageras_1988"
+kind = "doi"
+ref = "10.1109/23.12684"
+license = "proprietary-reference-only"
+
+# CsI:Na — Holl 1988 covered CsI(Tl), not CsI(Na). No verified primary cite at
+# this time; keep the audit placeholder. TODO(#170): locate primary CsI:Na
+# scintillation paper (Hofstadter et al. 1950s era? Brinckmann?) and replace.
 [csi.Na._sources._default]
 citation = "py-mat-curation-3.x"
 kind = "handbook"
 ref = "py-mat curation history; values from handbook/vendor/Wikidata aggregate (pre-#175 audit)"
 license = "proprietary-reference-only"
 
-[labr3._sources._default]
-citation = "py-mat-curation-3.x"
-kind = "handbook"
-ref = "py-mat curation history; values from handbook/vendor/Wikidata aggregate (pre-#175 audit)"
+# --- LaBr3:Ce ----------------------------------------------------------------
+
+[labr3._sources."optical.light_yield"]
+citation = "van_loef_2001"
+kind = "doi"
+ref = "10.1063/1.1385342"
+license = "proprietary-reference-only"
+note = "LaBr3:Ce high-energy-resolution scintillator discovery — van Loef, Dorenbos, van Eijk, Krämer, Güdel 2001, Appl. Phys. Lett. 79, 1573."
+
+[labr3._sources."optical.decay_time"]
+citation = "van_loef_2001"
+kind = "doi"
+ref = "10.1063/1.1385342"
 license = "proprietary-reference-only"
 
-[pwo._sources._default]
-citation = "py-mat-curation-3.x"
-kind = "handbook"
-ref = "py-mat curation history; values from handbook/vendor/Wikidata aggregate (pre-#175 audit)"
+[labr3._sources."optical.emission_peak"]
+citation = "van_loef_2001"
+kind = "doi"
+ref = "10.1063/1.1385342"
 license = "proprietary-reference-only"
+
+[labr3._sources."optical._review"]
+citation = "shook_laplace_2025"
+kind = "doi"
+ref = "10.1016/j.nima.2025.170389"
+license = "proprietary-reference-only"
+
+# --- PWO (PbWO4) -------------------------------------------------------------
+
+[pwo._sources."optical.light_yield"]
+citation = "kobayashi_1993"
+kind = "doi"
+ref = "10.1016/0168-9002(93)91187-R"
+license = "proprietary-reference-only"
+note = "PbWO4 single-crystal scintillation at room temperature — Kobayashi, Ishii, Usuki, Yahagi 1993, NIM A 333, 429."
+
+[pwo._sources."optical.decay_time"]
+citation = "kobayashi_1993"
+kind = "doi"
+ref = "10.1016/0168-9002(93)91187-R"
+license = "proprietary-reference-only"
+
+[pwo._sources."optical.emission_peak"]
+citation = "kobayashi_1993"
+kind = "doi"
+ref = "10.1016/0168-9002(93)91187-R"
+license = "proprietary-reference-only"
+
+# --- Plastic scintillators ---------------------------------------------------
+# Generic plastic + Eljen vendor variants — no single primary paper; values
+# are vendor datasheet aggregates. Keep the audit placeholder.
 
 [plastic_scint._sources._default]
 citation = "py-mat-curation-3.x"


### PR DESCRIPTION
## Summary

Cite-only attachment of primary measurement papers to scintillator `_sources` blocks, per #170. The LBNL Scintillator Library (https://scintillator.lbl.gov/) was used as a discovery index — papers it cites were verified via Crossref and attached as `_sources.ref` DOIs. The LBNL site itself is never cited as a source. The LBNL group's own database overview (Shook, Laplace, Boswell, Bourret, Derenzo, Goldblum 2025, NIM A) is attached as `optical._review` for the modern materials it covers.

No property values, schema, or runtime code were touched. Vendor- and grade-specific entries retain the `_default` placeholder where primary papers don't constrain vendor variants.

### Per-material citations attached (DOIs verified via Crossref)

| Material | Primary paper | DOI |
|---|---|---|
| `lyso` (LSO) | Melcher & Schweitzer 1992, IEEE Trans. Nucl. Sci. 39(4), 502 | `10.1109/23.159655` |
| `lyso.Ce` (LYSO:Ce) | Cooke et al. 2000, J. Appl. Phys. 88, 7360 | `10.1063/1.1328775` |
| `bgo` | Weber & Monchamp 1973, J. Appl. Phys. 44, 5495 | `10.1063/1.1662183` |
| `nai`, `nai.Tl` | Hofstadter 1948, Phys. Rev. 74, 100 | `10.1103/PhysRev.74.100` |
| `csi`, `csi.Tl` | Holl, Lorenz, Mageras 1988, IEEE Trans. Nucl. Sci. 35, 105 | `10.1109/23.12684` |
| `labr3` | van Loef et al. 2001, Appl. Phys. Lett. 79, 1573 | `10.1063/1.1385342` |
| `pwo` | Kobayashi et al. 1993, NIM A 333, 429 | `10.1016/0168-9002(93)91187-R` |
| LBNL review (lyso, lyso.Ce, labr3) | Shook, Laplace, Boswell, Bourret, Derenzo, Goldblum 2025, NIM A 1075, 170389 | `10.1016/j.nima.2025.170389` |

### Notes on the issue's DOI hint

- The issue suggested DOI `10.1016/j.nima.2024.169742` for "Laplace et al. 2024, NIM A". That DOI resolves (via Crossref) to a different paper — Zhang et al. 2024, "Conceptual design of a gamma-to-electron energy-selective imaging system" (NIM A 1068). The actual LBNL Scintillator Library overview paper from this group is **Shook, Laplace et al. 2025, NIM A 1075, 170389** (DOI `10.1016/j.nima.2025.170389`); Laplace is second author. Cited under the verified DOI accordingly. Per spec ("never invent a DOI"), the unverified hint was discarded.
- The eScholarship preprint URL `https://escholarship.org/uc/item/4rx6b1k3` is bot-blocked behind CloudFront WAF, so verification fell back to Crossref metadata for the published version, which is canonical.

### Materials NOT attached (placeholder retained)

| Material | Reason |
|---|---|
| `csi.Na` | Holl 1988 only covers CsI(Tl); no verified CsI(Na) primary paper located. TODO comment left inline. |
| `lyso.Ce.saint_gobain` (+ prelude420), `lyso.Ce.epic`, `lyso.Ce.siccas` | Vendor-specific values — not in primary papers. |
| `nai.Tl.saint_gobain`, `nai.Tl.hamamatsu` | Vendor-specific values. |
| `plastic_scint`, `plastic_scint.BC400`, `plastic_scint.EJ200` | Eljen-vendor catalogue values; no single primary paper. |

The 6 modern scintillators in the issue list that are not in this TOML (GAGG, CeBr3, SrI2, LSO-as-distinct-from-LYSO) were out of scope per the "do NOT add new materials" rule. The verified primary-paper DOIs for those (Kamada 2011 GAGG `10.1021/cg200694a`; Shah 2005 CeBr3 IEEE TNS 52(6) 3157; Cherepy 2008 SrI2:Eu APL `10.1063/1.2885728`) are documented here for future reference when those materials land.

## Test plan

- [x] `python -c "import tomllib; tomllib.loads(open('src/pymat/data/scintillators.toml').read())"` — TOML parses
- [x] `python scripts/check_licenses.py` — license gate passes (7 TOML files scanned)
- [x] `uv run python -m pytest tests/test_toml_integrity.py tests/test_sources.py -v` — 43 passed
- [x] `uv run python -m pytest` — 628 passed, 22 skipped
- [x] `uv run ruff check . && uv run ruff format --check .` — clean

Closes #170.