### PR TITLE
feat(scripts): NIST WebBook (SRD 69) enricher for gases & liquids (#159)

### DIFF
--- a/scripts/enrich_from_nist_webbook.py
+++ b/scripts/enrich_from_nist_webbook.py
@@ -1,0 +1,664 @@
+#!/usr/bin/env python3
+"""Enrich gases & liquids with NIST Chemistry WebBook (SRD 69) values — #159.
+
+NIST SRD 69 (Lemmon-REFPROP equation of state) covers the thermophysical
+properties of ~74 fluids (Cp, viscosity, thermal conductivity, density
+vs T, P). It is **PD-USGov** — US-government work, public domain in the
+US per 17 U.S.C. §105 — so attribution is not legally required, but the
+NIST AS-IS notice still applies (see the per-row `note` and the report
+footer).
+
+This enricher targets a small, audited subset that already exists in
+`src/pymat/data/{gases,liquids}.toml`:
+
+* `water` — liquid at T=293.15 K, P=1.01325 bar
+* `nitrogen` — gas at T=298.15 K, P=1.01325 bar (STP, ish)
+* `argon` — gas at T=298.15 K, P=1.01325 bar
+* `helium` — gas at T=298.15 K, P=1.01325 bar
+* `co2` — gas at T=298.15 K, P=1.01325 bar
+
+Phase 5 will widen the set; this PR sticks to overlap with the current
+catalog. New fluids are explicitly out of scope (see issue #159 design
+review).
+
+Properties enriched (only those already in the schema):
+
+* `mechanical.density` — converted to g/cm³ for the comparison + writeback
+* `thermal.specific_heat` — converted to J/(kg·K) (NIST ships J/(g·K))
+* `thermal.thermal_conductivity` — W/(m·K), already canonical
+
+Viscosity is in the NIST response but the runtime schema has no
+viscosity field today; we skip that column rather than invent one.
+Temperature-dependent curves are also out of scope here — that's a
+separate Phase-4 follow-up.
+
+This is NOT a runtime dependency of mat — lives in scripts/ for data
+curation. Shared helpers live in `scripts/_curation.py`.
+
+## Source endpoint
+
+NIST WebBook has no JSON API. The `Action=Data&Type=IsoBar` flavour of
+`https://webbook.nist.gov/cgi/fluid.cgi` returns a clean tab-separated
+table whose first line is the column header. We request a 2-row range
+spanning the target temperature so the WebBook accepts the query (a
+zero-width range triggers a "Range Error" page); we then pick the row
+whose temperature matches the target.
+
+The Lemmon REFPROP equation of state is what NIST runs to produce these
+values; we cite it explicitly in the `note` field so curators know the
+provenance is a numerical model, not a primary measurement.
+
+## Behaviour
+
+* Default: comparison-only. Prints a side-by-side report of our value
+  vs. NIST's with a relative-tolerance flag (DIFF if >2%).
+* `--write`: ADD-ONLY. If a property is already populated on a target
+  material, log DIFF and SKIP — we never overwrite curator data.
+* `--dry-run`: skip writeback. Network fetches still hit
+  `cached_get_text` (30-day TTL); use a pre-warmed cache or the test
+  fixture for true offline mode.
+* Cache: backs `cached_get_text` under `scripts/.cache/nist_webbook/`.
+
+## Usage
+
+    python scripts/enrich_from_nist_webbook.py                    # full report
+    python scripts/enrich_from_nist_webbook.py --key water --dry-run
+    python scripts/enrich_from_nist_webbook.py --write
+    python scripts/enrich_from_nist_webbook.py --report out.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import tomlkit  # noqa: E402
+from _curation import (  # noqa: E402
+    DATA_DIR,
+    build_source_row,
+    cached_get_text,
+    fmt_delta,
+    writeback,
+)
+
+from pymat import load_all  # noqa: E402
+
+# --------------------------------------------------------------------------- #
+# Source endpoint                                                             #
+# --------------------------------------------------------------------------- #
+
+_BASE_URL = "https://webbook.nist.gov/cgi/fluid.cgi"
+SOURCE_NAME = "nist_webbook"
+
+# Tighter than Wikidata's 5%: NIST WebBook is a reference-grade source
+# (Lemmon REFPROP equation of state), so >2% gap is curator-actionable.
+DEFAULT_TOL = 0.02
+
+# Standard pressure for both gases and liquids in this enricher.
+_P_BAR = 1.01325
+
+
+# --------------------------------------------------------------------------- #
+# Per-fluid mapping                                                           #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class FluidEntry:
+    """One target fluid: NIST CAS-derived ID, the (T, P) point, the species
+    name (for the citation), and which TOML category houses it."""
+
+    cas_id: str  # NIST WebBook ID, e.g. "C7732185"
+    species: str  # human-readable species name for the citation
+    category: str  # category TOML file ("gases" / "liquids")
+    t_kelvin: float  # target temperature in K
+    p_bar: float = _P_BAR  # target pressure in bar (default = 1 atm)
+
+
+# CAS IDs verified live against webbook.nist.gov on 2026-05-07.
+# Each fluid's category matches its `[<key>]` location in
+# src/pymat/data/{gases,liquids}.toml; see _CATEGORY_BASES at runtime.
+ENTRY_MAP: dict[str, FluidEntry] = {
+    # `water` lives in liquids.toml; the WebBook gives the liquid phase
+    # at this (T, P) point.
+    "water": FluidEntry(cas_id="C7732185", species="Water", category="liquids", t_kelvin=293.15),
+    "nitrogen": FluidEntry(
+        cas_id="C7727379", species="Nitrogen", category="gases", t_kelvin=298.15
+    ),
+    "argon": FluidEntry(cas_id="C7440371", species="Argon", category="gases", t_kelvin=298.15),
+    "helium": FluidEntry(cas_id="C7440597", species="Helium", category="gases", t_kelvin=298.15),
+    "co2": FluidEntry(
+        cas_id="C124389",
+        species="Carbon Dioxide",
+        category="gases",
+        t_kelvin=298.15,
+    ),
+}
+
+
+# --------------------------------------------------------------------------- #
+# Property mapping                                                            #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class PropertySpec:
+    """One enrichable property.
+
+    `group` is the TOML sub-table (`mechanical` / `thermal`), `field` is
+    the schema field name (matching the dataclass attribute), `column` is
+    the NIST TSV column header substring we match on, `canonical_unit` is
+    the unit we write into TOML, and `scale` is the multiplier from
+    NIST's units to ours.
+    """
+
+    group: str
+    field: str
+    column: str
+    canonical_unit: str
+    scale: float
+
+
+# NIST WebBook units (after the canonical IsoBar request):
+#   Density       — kg/m³        → multiply by 1e-3  → g/cm³
+#   Cp            — J/(g·K)      → multiply by 1e3   → J/(kg·K)
+#   Therm. Cond.  — W/(m·K)      → identity
+_PROPERTIES: list[PropertySpec] = [
+    PropertySpec("mechanical", "density", "Density", "g/cm^3", 1e-3),
+    PropertySpec("thermal", "specific_heat", "Cp", "J/(kg*K)", 1e3),
+    PropertySpec(
+        "thermal",
+        "thermal_conductivity",
+        "Therm. Cond.",
+        "W/(m*K)",
+        1.0,
+    ),
+]
+
+
+# --------------------------------------------------------------------------- #
+# TSV parsing                                                                 #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class FluidRow:
+    """One row of the NIST WebBook IsoBar TSV, keyed by header name.
+
+    `header_to_value` carries the raw float values; the column-name
+    keys preserve the WebBook's spelling (e.g. `'Therm. Cond. (W/m*K)'`)
+    so we can match against `PropertySpec.column` substrings.
+    """
+
+    t_kelvin: float
+    p_bar: float
+    phase: str
+    header_to_value: dict[str, float]
+
+
+def parse_isobar_tsv(text: str) -> list[FluidRow]:
+    """Parse the WebBook IsoBar TSV into a list of `FluidRow`.
+
+    Rejects responses that don't start with a `Temperature` header (which
+    is the WebBook's tell-tale for an HTML error page leaking through —
+    e.g. 'Range Error').
+    """
+    lines = [ln for ln in text.splitlines() if ln.strip()]
+    if not lines:
+        raise ValueError("empty TSV")
+    header_line = lines[0]
+    if not header_line.startswith("Temperature"):
+        raise ValueError(
+            f"Response does not look like a WebBook IsoBar TSV (first line: {header_line[:80]!r})"
+        )
+    headers = header_line.split("\t")
+    # The Phase column is a string; everything else is numeric.
+    try:
+        phase_idx = headers.index("Phase")
+    except ValueError:
+        phase_idx = -1
+
+    rows: list[FluidRow] = []
+    for raw in lines[1:]:
+        cols = raw.split("\t")
+        if len(cols) < len(headers):
+            continue
+        try:
+            t = float(cols[0])
+            p = float(cols[1])
+        except ValueError:
+            continue
+        phase = cols[phase_idx] if phase_idx >= 0 else ""
+        h2v: dict[str, float] = {}
+        for i, name in enumerate(headers):
+            if i == phase_idx:
+                continue
+            try:
+                h2v[name] = float(cols[i])
+            except ValueError:
+                # Skip non-numeric cells (e.g. "infinite", "undefined").
+                continue
+        rows.append(FluidRow(t_kelvin=t, p_bar=p, phase=phase, header_to_value=h2v))
+    return rows
+
+
+def _select_row(rows: list[FluidRow], t_target: float) -> FluidRow:
+    """Pick the row whose temperature matches `t_target` (within 1e-3 K)."""
+    if not rows:
+        raise ValueError("no parseable rows in TSV")
+    for row in rows:
+        if abs(row.t_kelvin - t_target) <= 1e-3:
+            return row
+    # No exact match — surface what we got rather than guess.
+    seen = ", ".join(f"{r.t_kelvin:.3f}" for r in rows)
+    raise ValueError(f"no row at T={t_target} K (got: {seen})")
+
+
+def _column_value(row: FluidRow, column_substr: str) -> float | None:
+    """Find the first column whose header contains `column_substr`."""
+    for header, value in row.header_to_value.items():
+        if column_substr in header:
+            return value
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# Fetch                                                                       #
+# --------------------------------------------------------------------------- #
+
+
+def _build_params(entry: FluidEntry) -> dict[str, str]:
+    """Build the WebBook query for an IsoBar 2-row range straddling the
+    target temperature.
+
+    The WebBook rejects zero-width ranges with a "Range Error" page, so
+    we ask for `[t, t+5 K]` at the target pressure. We then pick the
+    row that matches `t` exactly.
+    """
+    t_lo = entry.t_kelvin
+    t_hi = entry.t_kelvin + 5.0
+    return {
+        "ID": entry.cas_id,
+        "Action": "Data",
+        "Type": "IsoBar",
+        "P": f"{entry.p_bar:g}",
+        "TLow": f"{t_lo:g}",
+        "THigh": f"{t_hi:g}",
+        "TInc": "5",
+        "Digits": "5",
+        "RefState": "DEF",
+        "TUnit": "K",
+        "PUnit": "bar",
+        "DUnit": "kg/m3",
+        "HUnit": "kJ/kg",
+        "WUnit": "m/s",
+        "VisUnit": "Pa*s",
+        "STUnit": "N/m",
+    }
+
+
+def fetch_fluid(entry: FluidEntry) -> FluidRow:
+    """Fetch and parse one fluid's IsoBar TSV; return the row at `entry.t_kelvin`.
+
+    On HTTP error or parse failure, the caller logs the row and continues —
+    never aborts the whole batch.
+    """
+    text = cached_get_text(
+        _BASE_URL,
+        _build_params(entry),
+        source=SOURCE_NAME,
+        suffix=".tsv",
+        ttl_days=30,
+    )
+    rows = parse_isobar_tsv(text)
+    return _select_row(rows, entry.t_kelvin)
+
+
+# --------------------------------------------------------------------------- #
+# TOML helpers                                                                #
+# --------------------------------------------------------------------------- #
+
+
+def _read_doc(toml_path: Path) -> tomlkit.TOMLDocument:
+    return tomlkit.parse(toml_path.read_text(encoding="utf-8"))
+
+
+def _walk(doc: Any, dotted: str) -> Any | None:
+    node: Any = doc
+    for seg in dotted.split("."):
+        if not isinstance(node, dict) or seg not in node:
+            return None
+        node = node[seg]
+    return node
+
+
+def _ours_value(mat: Any, group: str, field: str) -> float | None:
+    if mat is None:
+        return None
+    props = getattr(mat, "properties", None)
+    if props is None:
+        return None
+    grp = getattr(props, group, None)
+    if grp is None:
+        return None
+    return getattr(grp, field, None)
+
+
+def _today_iso() -> str:
+    return _dt.date.today().isoformat()
+
+
+# --------------------------------------------------------------------------- #
+# Source row + writeback                                                      #
+# --------------------------------------------------------------------------- #
+
+
+def _make_source_row(entry: FluidEntry, field: str, row: FluidRow) -> dict[str, str]:
+    """Build a `_sources` row for one (entry, field) pair.
+
+    The note pins the (T, P) point and names the equation of state so a
+    curator reading the TOML two years from now knows exactly what
+    NIST gave us. The AS-IS notice is implicit in the `license =
+    PD-USGov` tag plus the report footer — repeating it in every row
+    note would just bloat the TOML.
+    """
+    note = (
+        f"T={row.t_kelvin:g} K, P={row.p_bar:g} bar "
+        f"(Lemmon REFPROP equation of state); fetched {_today_iso()}"
+    )
+    return build_source_row(
+        citation=f"NIST Chemistry WebBook SRD 69 ({entry.species})",
+        kind="handbook",
+        ref=f"webbook.nist.gov:fluid.cgi?ID={entry.cas_id}",
+        license="PD-USGov",
+        note=note,
+    )
+
+
+def _apply_writeback(
+    *,
+    toml_path: Path,
+    material_key: str,
+    spec: PropertySpec,
+    value: float,
+    entry: FluidEntry,
+    row: FluidRow,
+) -> None:
+    """Conservative add-only writeback. Caller verifies the field is absent."""
+    material_path = material_key.split(".") + [spec.group]
+    src = _make_source_row(entry, spec.field, row)
+    updates = {f"{spec.field}_value": value, f"{spec.field}_unit": spec.canonical_unit}
+    writeback(
+        toml_path,
+        material_path,
+        updates,
+        sources={spec.field: src},
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Comparison                                                                  #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class Row:
+    key: str
+    cas_id: str
+    species: str
+    t_k: float
+    p_bar: float
+    phase: str
+    cells: dict[str, str]
+    diffs: list[str]
+    missing: list[str]
+    status: str = "OK"
+    note: str = ""
+
+
+def _compare_one(
+    *,
+    material_key: str,
+    entry: FluidEntry,
+    mats: dict,
+    toml_path: Path,
+    write: bool,
+    tol: float = DEFAULT_TOL,
+) -> Row:
+    cells: dict[str, str] = {}
+    diffs: list[str] = []
+    missing: list[str] = []
+
+    try:
+        fluid_row = fetch_fluid(entry)
+    except Exception as exc:  # network/parse errors → ERROR row, continue.
+        return Row(
+            key=material_key,
+            cas_id=entry.cas_id,
+            species=entry.species,
+            t_k=entry.t_kelvin,
+            p_bar=entry.p_bar,
+            phase="-",
+            cells={spec.field: "—" for spec in _PROPERTIES},
+            diffs=[],
+            missing=[],
+            status="ERROR",
+            note=f"fetch/parse failed: {exc}",
+        )
+
+    doc = _read_doc(toml_path)
+    material_node = _walk(doc, material_key)
+
+    for spec in _PROPERTIES:
+        ours = _ours_value(mats.get(material_key), spec.group, spec.field)
+        raw = _column_value(fluid_row, spec.column)
+        if raw is None:
+            cells[spec.field] = "(no NIST col)"
+            continue
+        theirs = raw * spec.scale
+        cell = fmt_delta(ours, theirs, tol=tol)
+        cells[spec.field] = cell
+        if "DIFF" in cell:
+            diffs.append(spec.field)
+        if ours is None and theirs is not None:
+            missing.append(spec.field)
+            if write:
+                # Defensive double-check on disk — don't overwrite a
+                # value that's present in TOML but was None on the
+                # loaded dataclass for some reason.
+                group_node = (
+                    material_node.get(spec.group) if isinstance(material_node, dict) else None
+                )
+                already_set = isinstance(group_node, dict) and (
+                    f"{spec.field}_value" in group_node or spec.field in group_node
+                )
+                if not already_set:
+                    _apply_writeback(
+                        toml_path=toml_path,
+                        material_key=material_key,
+                        spec=spec,
+                        value=float(theirs),
+                        entry=entry,
+                        row=fluid_row,
+                    )
+
+    return Row(
+        key=material_key,
+        cas_id=entry.cas_id,
+        species=entry.species,
+        t_k=fluid_row.t_kelvin,
+        p_bar=fluid_row.p_bar,
+        phase=fluid_row.phase,
+        cells=cells,
+        diffs=diffs,
+        missing=missing,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Report                                                                      #
+# --------------------------------------------------------------------------- #
+
+
+def _render_report(rows: list[Row], *, write: bool) -> str:
+    lines: list[str] = []
+    lines.append("# NIST Chemistry WebBook (SRD 69) enrichment report")
+    lines.append("")
+    lines.append(f"Date: {_today_iso()}")
+    lines.append(f"Mode: {'write (add-only)' if write else 'comparison-only'}")
+    lines.append(f"Tolerance: {DEFAULT_TOL * 100:.1f}% (DIFF flag threshold)")
+    lines.append(f"Materials checked: {len(rows)}")
+    diffs = sum(1 for r in rows if r.diffs)
+    miss = sum(1 for r in rows if r.missing)
+    err = sum(1 for r in rows if r.status == "ERROR")
+    lines.append(f"DIFF: {diffs}  MISSING: {miss}  ERROR: {err}")
+    lines.append("")
+
+    header = ["material", "cas_id", "T[K]", "P[bar]", "phase"] + [s.field for s in _PROPERTIES]
+    lines.append(" | ".join(header))
+    lines.append(" | ".join("---" for _ in header))
+    for r in rows:
+        cells = [r.key, r.cas_id, f"{r.t_k:g}", f"{r.p_bar:g}", r.phase]
+        for spec in _PROPERTIES:
+            cell = r.cells.get(spec.field, "—")
+            cells.append(cell.replace("|", "/"))
+        lines.append(" | ".join(cells))
+    lines.append("")
+
+    diff_rows = [r for r in rows if r.diffs]
+    miss_rows = [r for r in rows if r.missing]
+    err_rows = [r for r in rows if r.status == "ERROR"]
+    lines.append(f"DIFF rows: {len(diff_rows)}")
+    for r in diff_rows:
+        lines.append(f"  DIFF  {r.key} ({r.species}): {', '.join(r.diffs)}")
+    lines.append(f"MISSING rows: {len(miss_rows)}")
+    for r in miss_rows:
+        action = "WROTE" if write else "would-write"
+        lines.append(f"  MISSING  {r.key} ({r.species}): {', '.join(r.missing)}  [{action}]")
+    if err_rows:
+        lines.append(f"ERROR rows: {len(err_rows)}")
+        for r in err_rows:
+            lines.append(f"  ERROR  {r.key}: {r.note}")
+    lines.append("")
+    lines.append(
+        "NIST Chemistry WebBook (SRD 69) data is PD-USGov "
+        "(US-government work, public domain in the US per 17 U.S.C. §105). "
+        "Per NIST: data is provided AS IS, with no warranty of any kind. "
+        "Underlying values come from the Lemmon REFPROP equation of state."
+    )
+    return "\n".join(lines) + "\n"
+
+
+# --------------------------------------------------------------------------- #
+# Driver                                                                      #
+# --------------------------------------------------------------------------- #
+
+
+def compare(
+    key_filter: str | None = None,
+    *,
+    dry_run: bool = False,  # noqa: ARG001 — accepted for CLI parity
+    write: bool = False,
+    report_path: Path | None = None,
+) -> int:
+    """Run the comparison; print or write the report.
+
+    `--dry-run` is accepted for CLI parity with the other enrichers; in
+    this script it suppresses writeback (same semantics as omitting
+    `--write`). Network fetches are still cached on disk via
+    `cached_get_text`.
+    """
+    mats = load_all()
+
+    targets = list(ENTRY_MAP.items())
+    if key_filter is not None:
+        targets = [(k, v) for k, v in targets if k == key_filter]
+    if not targets:
+        print(f"No targets matched key={key_filter!r}", file=sys.stderr)
+        return 1
+
+    rows: list[Row] = []
+    for material_key, entry in targets:
+        toml_path = DATA_DIR / f"{entry.category}.toml"
+        if not toml_path.exists():
+            rows.append(
+                Row(
+                    key=material_key,
+                    cas_id=entry.cas_id,
+                    species=entry.species,
+                    t_k=entry.t_kelvin,
+                    p_bar=entry.p_bar,
+                    phase="-",
+                    cells={spec.field: "—" for spec in _PROPERTIES},
+                    diffs=[],
+                    missing=[],
+                    status="ERROR",
+                    note=f"missing {toml_path}",
+                )
+            )
+            continue
+        rows.append(
+            _compare_one(
+                material_key=material_key,
+                entry=entry,
+                mats=mats,
+                toml_path=toml_path,
+                write=write,
+            )
+        )
+
+    report = _render_report(rows, write=write)
+    if report_path is None:
+        print(report)
+    else:
+        report_path.write_text(report, encoding="utf-8")
+        print(f"Report written to {report_path}", file=sys.stderr)
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--key", help="Only compare this material key")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "Skip writeback. Network fetches are still cached; pass "
+            "--key with a previously-cached entry to run fully offline."
+        ),
+    )
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help=(
+            "Apply add-only writeback: when a TOML field is missing and "
+            "NIST has a value, write the value plus a `_sources` row. "
+            "Existing values are NEVER overwritten."
+        ),
+    )
+    parser.add_argument(
+        "--report",
+        type=Path,
+        default=None,
+        help="Write the diff report to this path (default: stdout).",
+    )
+    args = parser.parse_args()
+    sys.exit(
+        compare(
+            args.key,
+            dry_run=args.dry_run,
+            write=args.write,
+            report_path=args.report,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fixtures/nist_webbook_water.txt
+++ b/tests/fixtures/nist_webbook_water.txt
@@ -1,0 +1,3 @@
+Temperature (K)	Pressure (bar)	Density (kg/m3)	Volume (m3/kg)	Internal Energy (kJ/kg)	Enthalpy (kJ/kg)	Entropy (J/g*K)	Cv (J/g*K)	Cp (J/g*K)	Sound Spd. (m/s)	Joule-Thomson (K/bar)	Viscosity (Pa*s)	Therm. Cond. (W/m*K)	Phase
+293.15	1.0132	998.21	0.0010018	83.906	84.007	0.29646	4.1567	4.1841	1482.3	-0.022492	0.0010016	0.59801	liquid
+298.15	1.0132	997.05	0.0010030	104.82	104.92	0.36720	4.1376	4.1813	1496.7	-0.022147	0.00089002	0.60652	liquid

--- a/tests/test_nist_webbook_enrichment.py
+++ b/tests/test_nist_webbook_enrichment.py
@@ -1,0 +1,403 @@
+"""Tests for `scripts/enrich_from_nist_webbook.py` — issue #159.
+
+Mirrors the test layout of `test_geant4_enrichment.py` (PR #200) and
+`test_refractiveindex_enrichment.py` (PR #201) so the enricher CLIs
+stay interchangeable for curators. Covers:
+
+* TSV parsing on a small captured fixture (`tests/fixtures/nist_webbook_water.txt`)
+* `--dry-run` produces the comparison report without mutating files
+  and without hitting the network (the `cached_get_text` shim is
+  monkey-patched to return the fixture).
+* `--write` adds missing fields + the paired `_sources` row.
+* `--write` does NOT overwrite an existing value, even if NIST diverges.
+* Round-trip preserves comments end-to-end.
+* The license allow-list still includes `PD-USGov` — guarding against
+  accidental removal that would silently break this enricher.
+
+Skip if `requests`/`tomlkit` aren't installed: those live in
+`scripts/requirements-curation.txt` and aren't part of the runtime
+install. See `tests/test_curation_helpers.py` for the same pattern.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+pytest.importorskip("requests")
+pytest.importorskip("tomlkit")
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+FIXTURE_DIR = Path(__file__).resolve().parent / "fixtures"
+WATER_FIXTURE = FIXTURE_DIR / "nist_webbook_water.txt"
+
+
+@pytest.fixture
+def enricher():
+    """Re-import fresh per test so module-level state doesn't leak."""
+    if "enrich_from_nist_webbook" in sys.modules:
+        del sys.modules["enrich_from_nist_webbook"]
+    return importlib.import_module("enrich_from_nist_webbook")
+
+
+# --------------------------------------------------------------------------- #
+# Helpers                                                                     #
+# --------------------------------------------------------------------------- #
+
+
+def _patch_data_dir(monkeypatch, enricher, tmp_path: Path) -> None:
+    """Redirect both module-level DATA_DIR pointers to `tmp_path`."""
+    import _curation
+
+    monkeypatch.setattr(_curation, "DATA_DIR", tmp_path)
+    monkeypatch.setattr(enricher, "DATA_DIR", tmp_path)
+
+
+def _stub_load_all(enricher, monkeypatch, mats: dict) -> None:
+    monkeypatch.setattr(enricher, "load_all", lambda: mats)
+
+
+def _stub_fetch_with_fixture(enricher, monkeypatch) -> None:
+    """Replace `cached_get_text` so every call returns the water fixture.
+
+    The fixture spans 293.15 K and 298.15 K at 1.0132 bar — enough to
+    answer queries for `water` (293.15 K) without a network round-trip.
+    Tests that target other fluids set up their own stub.
+    """
+    fixture_text = WATER_FIXTURE.read_text(encoding="utf-8")
+
+    def fake(url, params=None, **kwargs):  # noqa: ARG001
+        return fixture_text
+
+    monkeypatch.setattr(enricher, "cached_get_text", fake)
+
+
+class _StubMaterial:
+    """Minimal stand-in for `pymat.Material` — only the attribute path
+    `mat.properties.<group>.<field>` matters to the enricher."""
+
+    def __init__(
+        self,
+        mechanical: dict | None = None,
+        thermal: dict | None = None,
+    ):
+        self.properties = type(
+            "P",
+            (),
+            {
+                "mechanical": type("M", (), mechanical or {})(),
+                "thermal": type("T", (), thermal or {})(),
+            },
+        )()
+
+
+# --------------------------------------------------------------------------- #
+# License allow-list integrity                                                #
+# --------------------------------------------------------------------------- #
+
+
+def test_license_allowlist_includes_pd_usgov():
+    """`PD-USGov` is the license tag for every NIST WebBook source row;
+    if a refactor accidentally drops it from the allow-list, every
+    writeback would silently fail. This test is the canary."""
+    import _curation
+    from check_licenses import ALLOWED
+
+    assert "PD-USGov" in _curation.LICENSE_ALLOWLIST
+    assert "PD-USGov" in ALLOWED
+
+
+# --------------------------------------------------------------------------- #
+# TSV parsing                                                                 #
+# --------------------------------------------------------------------------- #
+
+
+def test_parse_isobar_tsv_extracts_two_rows(enricher):
+    rows = enricher.parse_isobar_tsv(WATER_FIXTURE.read_text(encoding="utf-8"))
+    assert len(rows) == 2
+    assert rows[0].t_kelvin == pytest.approx(293.15)
+    assert rows[1].t_kelvin == pytest.approx(298.15)
+    # Density in kg/m³, Cp in J/(g·K), Therm. Cond. in W/(m·K).
+    assert rows[0].header_to_value["Density (kg/m3)"] == pytest.approx(998.21)
+    assert rows[0].header_to_value["Cp (J/g*K)"] == pytest.approx(4.1841)
+    assert rows[0].header_to_value["Therm. Cond. (W/m*K)"] == pytest.approx(0.59801)
+    assert rows[0].phase == "liquid"
+
+
+def test_parse_rejects_non_tsv(enricher):
+    with pytest.raises(ValueError, match="not look like a WebBook"):
+        enricher.parse_isobar_tsv("<html>Range Error</html>")
+
+
+def test_select_row_picks_target_temperature(enricher):
+    rows = enricher.parse_isobar_tsv(WATER_FIXTURE.read_text(encoding="utf-8"))
+    selected = enricher._select_row(rows, 293.15)
+    assert selected.t_kelvin == pytest.approx(293.15)
+
+
+def test_select_row_raises_when_target_missing(enricher):
+    rows = enricher.parse_isobar_tsv(WATER_FIXTURE.read_text(encoding="utf-8"))
+    with pytest.raises(ValueError, match="no row at T=350"):
+        enricher._select_row(rows, 350.0)
+
+
+# --------------------------------------------------------------------------- #
+# --dry-run / report-only mode                                                #
+# --------------------------------------------------------------------------- #
+
+
+def test_dry_run_produces_report_offline(enricher, monkeypatch, capsys, tmp_path):
+    """`--dry-run` against the fixture: no network, report rendered."""
+    _stub_fetch_with_fixture(enricher, monkeypatch)
+    # We need a `liquids.toml` to walk; copy a minimal one into tmp_path.
+    toml_path = tmp_path / "liquids.toml"
+    toml_path.write_text(
+        dedent(
+            """\
+            [water]
+            name = "Water"
+            formula = "H2O"
+
+            [water.mechanical]
+            density_value = 0.998
+            density_unit = "g/cm^3"
+
+            [water.thermal]
+            thermal_conductivity_value = 0.598
+            thermal_conductivity_unit = "W/(m*K)"
+            specific_heat_value = 4182
+            specific_heat_unit = "J/(kg*K)"
+            """
+        )
+    )
+    _patch_data_dir(monkeypatch, enricher, tmp_path)
+    _stub_load_all(
+        enricher,
+        monkeypatch,
+        {
+            "water": _StubMaterial(
+                mechanical={"density": 0.998},
+                thermal={
+                    "thermal_conductivity": 0.598,
+                    "specific_heat": 4182,
+                },
+            )
+        },
+    )
+
+    rc = enricher.compare(key_filter="water", dry_run=True)
+    assert rc == 0
+
+    out = capsys.readouterr().out
+    assert "# NIST Chemistry WebBook (SRD 69) enrichment report" in out
+    assert "Mode: comparison-only" in out
+    assert "water" in out
+    assert "C7732185" in out
+    assert "density" in out and "specific_heat" in out and "thermal_conductivity" in out
+    # AS-IS notice in the report footer.
+    assert "AS IS" in out
+    assert "PD-USGov" in out
+
+    # The TOML was not mutated.
+    assert "_sources" not in toml_path.read_text()
+
+
+# --------------------------------------------------------------------------- #
+# --write: add-only writeback                                                 #
+# --------------------------------------------------------------------------- #
+
+
+_SYNTHETIC_WATER_GAP = dedent(
+    """\
+    # top-of-file comment — must survive the round-trip
+    [water]
+    name = "Water"
+    formula = "H2O"
+
+    [water.mechanical]
+    # density already curated; thermal block is the gap.
+    density_value = 0.998
+    density_unit = "g/cm^3"
+
+    [water.thermal]
+    # thermal_conductivity + specific_heat intentionally absent.
+    """
+)
+
+
+def test_write_adds_missing_fields_and_sources_row(enricher, monkeypatch, tmp_path):
+    """`--write`: missing thermal fields + NIST has values → write both
+    the `_value`/`_unit` pair and a `_sources` row keyed
+    `thermal.<field>`."""
+    _stub_fetch_with_fixture(enricher, monkeypatch)
+    toml_path = tmp_path / "liquids.toml"
+    toml_path.write_text(_SYNTHETIC_WATER_GAP)
+
+    _patch_data_dir(monkeypatch, enricher, tmp_path)
+    # Stub: density set, thermal fields None — only the writeback gap.
+    _stub_load_all(
+        enricher,
+        monkeypatch,
+        {
+            "water": _StubMaterial(
+                mechanical={"density": 0.998},
+                thermal={"thermal_conductivity": None, "specific_heat": None},
+            )
+        },
+    )
+
+    rc = enricher.compare(key_filter="water", dry_run=True, write=True)
+    assert rc == 0
+
+    out = toml_path.read_text()
+    # NIST water at 293.15 K, 1.0132 bar:
+    #   Cp = 4.1841 J/(g·K) → 4184.1 J/(kg·K)
+    #   Therm. Cond. = 0.59801 W/(m·K)
+    assert "specific_heat_value = 4184.1" in out
+    assert 'specific_heat_unit = "J/(kg*K)"' in out
+    assert "thermal_conductivity_value = 0.59801" in out
+    assert 'thermal_conductivity_unit = "W/(m*K)"' in out
+    # _sources rows attached at the material level, keyed by group.field.
+    assert "[water._sources]" in out
+    assert "thermal.specific_heat" in out
+    assert "thermal.thermal_conductivity" in out
+    assert "PD-USGov" in out
+    assert "C7732185" in out
+    assert "Lemmon REFPROP" in out
+    # Top-of-file comment survives.
+    assert "# top-of-file comment" in out
+
+
+def test_write_does_not_overwrite_existing_value(enricher, monkeypatch, tmp_path):
+    """`--write`: existing density diverges from NIST → DIFF reported, no write."""
+    _stub_fetch_with_fixture(enricher, monkeypatch)
+    src = dedent(
+        """\
+        [water]
+        name = "Water"
+
+        [water.mechanical]
+        # Wrong on purpose — must not be silently corrected.
+        density_value = 1.234
+        density_unit = "g/cm^3"
+
+        [water.thermal]
+        thermal_conductivity_value = 0.598
+        thermal_conductivity_unit = "W/(m*K)"
+        specific_heat_value = 4182
+        specific_heat_unit = "J/(kg*K)"
+        """
+    )
+    toml_path = tmp_path / "liquids.toml"
+    toml_path.write_text(src)
+
+    _patch_data_dir(monkeypatch, enricher, tmp_path)
+    _stub_load_all(
+        enricher,
+        monkeypatch,
+        {
+            "water": _StubMaterial(
+                mechanical={"density": 1.234},
+                thermal={
+                    "thermal_conductivity": 0.598,
+                    "specific_heat": 4182,
+                },
+            )
+        },
+    )
+
+    rc = enricher.compare(key_filter="water", dry_run=True, write=True)
+    assert rc == 0
+
+    after = toml_path.read_text()
+    # The divergent value is exactly what the curator wrote.
+    assert "density_value = 1.234" in after
+    # The NIST value (0.99821 g/cm³) is NOT in the file.
+    assert "0.99821" not in after
+    # No _sources row attached for density — silent updates are forbidden.
+    assert "mechanical.density" not in after
+
+
+def test_comparison_only_never_writes(enricher, monkeypatch, tmp_path):
+    _stub_fetch_with_fixture(enricher, monkeypatch)
+    toml_path = tmp_path / "liquids.toml"
+    toml_path.write_text(_SYNTHETIC_WATER_GAP)
+    before = toml_path.read_text()
+
+    _patch_data_dir(monkeypatch, enricher, tmp_path)
+    _stub_load_all(
+        enricher,
+        monkeypatch,
+        {
+            "water": _StubMaterial(
+                mechanical={"density": 0.998},
+                thermal={"thermal_conductivity": None, "specific_heat": None},
+            )
+        },
+    )
+
+    rc = enricher.compare(key_filter="water", dry_run=True, write=False)
+    assert rc == 0
+    assert toml_path.read_text() == before
+
+
+# --------------------------------------------------------------------------- #
+# --report writes to a markdown file                                          #
+# --------------------------------------------------------------------------- #
+
+
+def test_report_writes_markdown_file(enricher, monkeypatch, tmp_path, capsys):
+    _stub_fetch_with_fixture(enricher, monkeypatch)
+    toml_path = tmp_path / "liquids.toml"
+    toml_path.write_text(_SYNTHETIC_WATER_GAP)
+    _patch_data_dir(monkeypatch, enricher, tmp_path)
+    _stub_load_all(
+        enricher,
+        monkeypatch,
+        {
+            "water": _StubMaterial(
+                mechanical={"density": 0.998},
+                thermal={"thermal_conductivity": None, "specific_heat": None},
+            )
+        },
+    )
+
+    out_path = tmp_path / "nist-report.md"
+    rc = enricher.compare(key_filter="water", dry_run=True, report_path=out_path)
+    assert rc == 0
+    assert out_path.exists()
+    content = out_path.read_text()
+    assert "# NIST Chemistry WebBook (SRD 69) enrichment report" in content
+    assert "C7732185" in content
+    # When --report is set, stdout stays quiet.
+    captured = capsys.readouterr()
+    assert "# NIST Chemistry WebBook" not in captured.out
+
+
+# --------------------------------------------------------------------------- #
+# Source-row sanity                                                           #
+# --------------------------------------------------------------------------- #
+
+
+def test_source_row_is_well_formed(enricher):
+    """The `_sources` row built by the enricher must satisfy the curation
+    helper's schema (kind in allow-list, license in allow-list, non-empty
+    citation/ref)."""
+    entry = enricher.ENTRY_MAP["water"]
+    row = enricher.parse_isobar_tsv(WATER_FIXTURE.read_text(encoding="utf-8"))[0]
+    src = enricher._make_source_row(entry, "specific_heat", row)
+    assert src["kind"] == "handbook"
+    assert src["license"] == "PD-USGov"
+    assert "NIST Chemistry WebBook SRD 69" in src["citation"]
+    assert "Water" in src["citation"]
+    assert "C7732185" in src["ref"]
+    assert "T=293.15 K" in src["note"]
+    assert "P=1.0132 bar" in src["note"]
+    assert "Lemmon REFPROP" in src["note"]


### PR DESCRIPTION
## Summary

- Adds `scripts/enrich_from_nist_webbook.py`: a comparison + add-only enricher for the five fluids overlapping between `src/pymat/data/{gases,liquids}.toml` and NIST Chemistry WebBook (SRD 69) — `water`, `nitrogen`, `argon`, `helium`, `co2`. New fluids and temperature curves are explicitly out of scope (Phase 5 / a follow-up).
- Source endpoint: `webbook.nist.gov/cgi/fluid.cgi?Action=Data&Type=IsoBar` returns a clean TSV; we straddle the target temperature with a 5 K range to dodge the WebBook's "Range Error" page, then select the matching row. `(T, P)` = (293.15 K, 1.01325 bar) for water (liquid phase) and (298.15 K, 1.01325 bar) for the gases — pinned in every `_sources.note` along with `Lemmon REFPROP equation of state`.
- Properties enriched: `mechanical.density`, `thermal.specific_heat`, `thermal.thermal_conductivity`. Viscosity is dropped (no schema field). Behaviour mirrors PRs #197/#198/#200/#201: `cached_get_text` for fetches, `build_source_row` + `writeback` for the comment-preserving TOML edit, ADD-ONLY semantics, identical CLI shape (`--key` / `--write` / `--dry-run` / `--report`).
- `_sources` rows: `license = "PD-USGov"`, `kind = "handbook"`, ref `webbook.nist.gov:fluid.cgi?ID=<CAS>`. Report footer carries the NIST AS-IS notice. `LICENSES-DATA.md` only enumerates CC-BY/CC-BY-SA sources, so no edit there (issue's "skip if PD-USGov isn't listed" branch).

Live comparison run (5 fluids): 0 MISSING, 1 DIFF (helium thermal_conductivity at 2.1%, just over the 2% threshold). The remaining 14 cells are within 2% of NIST; existing curator values are preserved.

Closes #159

## Test plan

- [x] `pytest tests/test_nist_webbook_enrichment.py tests/test_curation_helpers.py` — 31 passing (11 new + 20 helpers).
- [x] Full suite: `pytest --ignore=tests/test_visual_compare.py` — 648 passed, 35 skipped (visual_compare ignored: needs PIL, unrelated).
- [x] `ruff check .` and `ruff format --check .` — clean.
- [x] Live run: `python scripts/enrich_from_nist_webbook.py` — 5 fluids fetched, comparison report rendered, no TOML mutation in default mode.
- [x] `scripts/check_licenses.py` — passes.