### PR TITLE
feat(data): add Inconel 625 and 718 nickel-base superalloys (#125, #126)

### DIFF
--- a/src/pymat/__init__.py
+++ b/src/pymat/__init__.py
@@ -88,7 +88,17 @@ _LOADED_CATEGORIES: set[str] = set()
 
 # Category to base materials mapping
 _CATEGORY_BASES: Dict[str, list[str]] = {
-    "metals": ["stainless", "aluminum", "copper", "tungsten", "lead", "titanium", "brass"],
+    "metals": [
+        "stainless",
+        "aluminum",
+        "copper",
+        "tungsten",
+        "lead",
+        "titanium",
+        "brass",
+        "inconel625",
+        "inconel718",
+    ],
     "scintillators": [
         "lyso",
         "bgo",

--- a/src/pymat/data/metals.toml
+++ b/src/pymat/data/metals.toml
@@ -799,6 +799,77 @@ metallic = 1.0
 roughness = 0.3
 transmission = 0.0
 
+# Inconel 625 — Ni-Cr-Mo-Nb solid-solution superalloy (#125)
+# MIL-HDBK-5J §6.3.3, p.6-34 to 6-44. Sheet/plate values from Table 6.3.3.0(b),
+# AMS 5599, annealed, A-basis, longitudinal, room temperature.
+[nickel.inconel625]
+name = "Inconel 625"
+grade = "alloy 625"
+# Nominal composition (Special Metals technical bulletin SMC-063, mass fractions).
+composition = {Ni = 0.62, Cr = 0.215, Mo = 0.09, Nb = 0.038, Fe = 0.025, Co = 0.005, Mn = 0.003, Si = 0.003, Al = 0.002, Ti = 0.002}
+
+[nickel.inconel625.mechanical]
+density_value = 8.44
+density_unit = "g/cm^3"
+youngs_modulus_value = 205
+youngs_modulus_unit = "GPa"
+poissons_ratio = 0.28
+yield_strength_value = 379
+yield_strength_unit = "MPa"
+tensile_strength_value = 820
+tensile_strength_unit = "MPa"
+elongation = 30
+
+[nickel.inconel625.thermal]
+melting_point_value = 1350
+melting_point_unit = "degC"
+thermal_conductivity_value = 9.8
+thermal_conductivity_unit = "W/(m*K)"
+specific_heat_value = 410
+specific_heat_unit = "J/(kg*K)"
+thermal_expansion_value = 12.8e-6
+thermal_expansion_unit = "1/K"
+
+[nickel.inconel625.electrical]
+resistivity_value = 1.29e-6
+resistivity_unit = "ohm*m"
+
+# Inconel 718 — Ni-Cr-Fe precipitation-hardenable superalloy (#126)
+# MIL-HDBK-5J §6.3.5, p.6-51 to 6-76. Sheet/plate STA values from Table
+# 6.3.5.0(b), AMS 5596, solution-treated and aged per spec, A-basis, long
+# transverse (LT), room temperature.
+[nickel.inconel718]
+name = "Inconel 718"
+grade = "alloy 718"
+# Nominal composition (Special Metals technical bulletin SMC-045, mass fractions).
+composition = {Ni = 0.525, Fe = 0.182, Cr = 0.19, Nb = 0.05, Mo = 0.03, Ti = 0.009, Al = 0.005, Co = 0.005, Mn = 0.002, Si = 0.002}
+
+[nickel.inconel718.mechanical]
+density_value = 8.22
+density_unit = "g/cm^3"
+youngs_modulus_value = 203
+youngs_modulus_unit = "GPa"
+poissons_ratio = 0.29
+yield_strength_value = 1014
+yield_strength_unit = "MPa"
+tensile_strength_value = 1241
+tensile_strength_unit = "MPa"
+elongation = 12
+
+[nickel.inconel718.thermal]
+melting_point_value = 1336
+melting_point_unit = "degC"
+thermal_conductivity_value = 11.1
+thermal_conductivity_unit = "W/(m*K)"
+specific_heat_value = 435
+specific_heat_unit = "J/(kg*K)"
+thermal_expansion_value = 13.0e-6
+thermal_expansion_unit = "1/K"
+
+[nickel.inconel718.electrical]
+resistivity_value = 1.25e-6
+resistivity_unit = "ohm*m"
+
 
 # ============================================================================
 # IRON
@@ -1190,6 +1261,188 @@ citation = "py-mat-curation-3.x"
 kind = "handbook"
 ref = "py-mat curation history; values from handbook/vendor/Wikidata aggregate (pre-#175 audit)"
 license = "proprietary-reference-only"
+
+# Inconel 625 (#125). Mechanical values from MIL-HDBK-5J Table 6.3.3.0(b), p.6-35,
+# AMS 5599 sheet/plate, annealed, A-basis design allowable, longitudinal,
+# room temperature. Density also published in Table 6.3.3.0(b) and (c) as
+# typical physical property. Thermal/electrical values come from the Special
+# Metals INCONEL alloy 625 technical bulletin (SMC-063) — RT entries from
+# Table 2 (Physical Constants) and Table 3 (Thermal & Electrical Properties).
+# Verified 2026-05-07 from everyspec.com PDF and specialmetals.com bulletin.
+[nickel.inconel625._sources._default]
+citation = "MIL-HDBK-5J p.6-35 + Special Metals SMC-063"
+kind = "handbook"
+ref = "mil-hdbk-5j:p6-35"
+license = "PD-USGov"
+note = "Inconel 625 AMS 5599 sheet/plate, annealed; mechanical values from MIL-HDBK-5J Table 6.3.3.0(b), A-basis, room temperature; thermal/electrical values from Special Metals Inc. SMC-063 bulletin (proprietary-reference-only); see per-property entries for precise sourcing; verified 2026-05-07."
+
+[nickel.inconel625._sources."mechanical.density"]
+citation = "MIL-HDBK-5J p.6-35"
+kind = "handbook"
+ref = "mil-hdbk-5j:p6-35"
+license = "PD-USGov"
+note = "Inconel 625 AMS 5599 sheet/plate, annealed; physical property (typical) from Table 6.3.3.0(b); 0.305 lb/in^3 = 8.44 g/cm^3; room temperature; verified 2026-05-07."
+
+[nickel.inconel625._sources."mechanical.tensile_strength"]
+citation = "MIL-HDBK-5J p.6-35"
+kind = "handbook"
+ref = "mil-hdbk-5j:p6-35"
+license = "PD-USGov"
+note = "Inconel 625 AMS 5599 sheet/plate, annealed, A-basis design allowable, longitudinal, thickness 0.063-0.109 in, room temperature; Table 6.3.3.0(b) Ftu(L) = 119 ksi = 820.4 MPa (TOML rounds to 820); verified 2026-05-07."
+
+[nickel.inconel625._sources."mechanical.yield_strength"]
+citation = "MIL-HDBK-5J p.6-35"
+kind = "handbook"
+ref = "mil-hdbk-5j:p6-35"
+license = "PD-USGov"
+note = "Inconel 625 AMS 5599 sheet/plate, annealed, A-basis design allowable, longitudinal, 0.2% offset, thickness 0.063-0.109 in, room temperature; Table 6.3.3.0(b) Fty(L) = 55 ksi = 379.2 MPa (TOML rounds to 379); verified 2026-05-07."
+
+[nickel.inconel625._sources."mechanical.youngs_modulus"]
+citation = "MIL-HDBK-5J p.6-35"
+kind = "handbook"
+ref = "mil-hdbk-5j:p6-35"
+license = "PD-USGov"
+note = "Inconel 625 AMS 5599 sheet/plate, annealed; tensile modulus E from Table 6.3.3.0(b); 29.8e3 ksi = 205.4 GPa (TOML rounds to 205); room temperature; verified 2026-05-07."
+
+[nickel.inconel625._sources."mechanical.poissons_ratio"]
+citation = "MIL-HDBK-5J p.6-35"
+kind = "handbook"
+ref = "mil-hdbk-5j:p6-35"
+license = "PD-USGov"
+note = "Inconel 625 AMS 5599 sheet/plate, annealed; Poisson's ratio from Table 6.3.3.0(b); mu = 0.28; room temperature; verified 2026-05-07."
+
+[nickel.inconel625._sources."mechanical.elongation"]
+citation = "MIL-HDBK-5J p.6-35"
+kind = "handbook"
+ref = "mil-hdbk-5j:p6-35"
+license = "PD-USGov"
+note = "Inconel 625 AMS 5599 sheet/plate, annealed; elongation (S-basis), long-transverse direction, from Table 6.3.3.0(b); 30%; room temperature; verified 2026-05-07."
+
+[nickel.inconel625._sources."thermal.melting_point"]
+citation = "Special Metals Inc. INCONEL alloy 625 Technical Bulletin"
+kind = "vendor"
+ref = "specialmetals.com:inconel-alloy-625"
+license = "proprietary-reference-only"
+note = "Inconel 625 melting range 1290-1350 degC from Table 2 (Physical Constants), SMC-063; TOML stores liquidus 1350 degC; pub. SMC-063 (2013); verified 2026-05-07."
+
+[nickel.inconel625._sources."thermal.thermal_conductivity"]
+citation = "Special Metals Inc. INCONEL alloy 625 Technical Bulletin"
+kind = "vendor"
+ref = "specialmetals.com:inconel-alloy-625"
+license = "proprietary-reference-only"
+note = "Inconel 625 annealed 2100F/1hr; Table 3 (Thermal & Electrical Properties), SMC-063; k at 21 degC = 9.8 W/(m*K) (interpolated cell at 21 degC); pub. SMC-063 (2013); verified 2026-05-07."
+
+[nickel.inconel625._sources."thermal.specific_heat"]
+citation = "Special Metals Inc. INCONEL alloy 625 Technical Bulletin"
+kind = "vendor"
+ref = "specialmetals.com:inconel-alloy-625"
+license = "proprietary-reference-only"
+note = "Inconel 625 specific heat from Table 2 (Physical Constants), SMC-063; calculated value 410 J/(kg*K) at 21 degC (70 degF); pub. SMC-063 (2013); verified 2026-05-07."
+
+[nickel.inconel625._sources."thermal.thermal_expansion"]
+citation = "Special Metals Inc. INCONEL alloy 625 Technical Bulletin"
+kind = "vendor"
+ref = "specialmetals.com:inconel-alloy-625"
+license = "proprietary-reference-only"
+note = "Inconel 625 mean linear expansion 70 degF to 200 degF (21-93 degC) from Table 3, SMC-063; 7.1e-6 in/in/degF = 12.8e-6 1/K; pub. SMC-063 (2013); verified 2026-05-07."
+
+[nickel.inconel625._sources."electrical.resistivity"]
+citation = "Special Metals Inc. INCONEL alloy 625 Technical Bulletin"
+kind = "vendor"
+ref = "specialmetals.com:inconel-alloy-625"
+license = "proprietary-reference-only"
+note = "Inconel 625 annealed 2100F/1hr electrical resistivity at 70 degF (21 degC) from Table 3, SMC-063; 776 ohm-circ-mil/ft = 129 microohm-cm = 1.29e-6 ohm*m; pub. SMC-063 (2013); verified 2026-05-07."
+
+# Inconel 718 (#126). Mechanical values from MIL-HDBK-5J Table 6.3.5.0(b),
+# p.6-52, AMS 5596 sheet/plate, solution-treated and aged (per spec),
+# A-basis design allowable, long-transverse, room temperature. Density is
+# the typical physical property listed in the same table. Thermal/electrical
+# values come from the Special Metals INCONEL alloy 718 technical bulletin
+# (SMC-045) — RT entries from Table 2 (Physical Constants) and Table 5
+# (Thermal Properties). Verified 2026-05-07.
+[nickel.inconel718._sources._default]
+citation = "MIL-HDBK-5J p.6-52 + Special Metals SMC-045"
+kind = "handbook"
+ref = "mil-hdbk-5j:p6-52"
+license = "PD-USGov"
+note = "Inconel 718 AMS 5596 sheet/plate, solution-treated and aged per spec; mechanical values from MIL-HDBK-5J Table 6.3.5.0(b), A-basis, long-transverse, room temperature; thermal/electrical values from Special Metals Inc. SMC-045 bulletin (proprietary-reference-only); see per-property entries for precise sourcing; verified 2026-05-07."
+
+[nickel.inconel718._sources."mechanical.density"]
+citation = "MIL-HDBK-5J p.6-52"
+kind = "handbook"
+ref = "mil-hdbk-5j:p6-52"
+license = "PD-USGov"
+note = "Inconel 718 AMS 5596 sheet/plate, STA; physical property (typical) from Table 6.3.5.0(b); 0.297 lb/in^3 = 8.22 g/cm^3; room temperature; verified 2026-05-07."
+
+[nickel.inconel718._sources."mechanical.tensile_strength"]
+citation = "MIL-HDBK-5J p.6-52"
+kind = "handbook"
+ref = "mil-hdbk-5j:p6-52"
+license = "PD-USGov"
+note = "Inconel 718 AMS 5596 sheet/plate, STA, A-basis design allowable, long-transverse, thickness 0.010-0.187 in, room temperature; Table 6.3.5.0(b) Ftu(LT) = 180 ksi = 1241.1 MPa (TOML rounds to 1241); verified 2026-05-07."
+
+[nickel.inconel718._sources."mechanical.yield_strength"]
+citation = "MIL-HDBK-5J p.6-52"
+kind = "handbook"
+ref = "mil-hdbk-5j:p6-52"
+license = "PD-USGov"
+note = "Inconel 718 AMS 5596 sheet/plate, STA, A-basis design allowable, long-transverse, 0.2% offset, thickness 0.010-0.187 in, room temperature; Table 6.3.5.0(b) Fty(LT) = 147 ksi = 1013.5 MPa (TOML rounds to 1014); verified 2026-05-07."
+
+[nickel.inconel718._sources."mechanical.youngs_modulus"]
+citation = "MIL-HDBK-5J p.6-52"
+kind = "handbook"
+ref = "mil-hdbk-5j:p6-52"
+license = "PD-USGov"
+note = "Inconel 718 AMS 5596 sheet/plate, STA; tensile modulus E from Table 6.3.5.0(b); 29.4e3 ksi = 202.7 GPa (TOML rounds to 203); room temperature; verified 2026-05-07."
+
+[nickel.inconel718._sources."mechanical.poissons_ratio"]
+citation = "MIL-HDBK-5J p.6-52"
+kind = "handbook"
+ref = "mil-hdbk-5j:p6-52"
+license = "PD-USGov"
+note = "Inconel 718 AMS 5596 sheet/plate, STA; Poisson's ratio from Table 6.3.5.0(b); mu = 0.29; room temperature; verified 2026-05-07."
+
+[nickel.inconel718._sources."mechanical.elongation"]
+citation = "MIL-HDBK-5J p.6-52"
+kind = "handbook"
+ref = "mil-hdbk-5j:p6-52"
+license = "PD-USGov"
+note = "Inconel 718 AMS 5596 sheet/plate, STA; elongation (S-basis), long-transverse direction, from Table 6.3.5.0(b); 12%; room temperature; verified 2026-05-07."
+
+[nickel.inconel718._sources."thermal.melting_point"]
+citation = "Special Metals Inc. INCONEL alloy 718 Technical Bulletin"
+kind = "vendor"
+ref = "specialmetals.com:inconel-alloy-718"
+license = "proprietary-reference-only"
+note = "Inconel 718 melting range 1260-1336 degC from Table 2 (Physical Constants), SMC-045; TOML stores liquidus 1336 degC; pub. SMC-045 (2007); verified 2026-05-07."
+
+[nickel.inconel718._sources."thermal.thermal_conductivity"]
+citation = "Special Metals Inc. INCONEL alloy 718 Technical Bulletin"
+kind = "vendor"
+ref = "specialmetals.com:inconel-alloy-718"
+license = "proprietary-reference-only"
+note = "Inconel 718 annealed 1800F/1hr; Table 5 (Thermal Properties), SMC-045; k at 70 degF (21 degC) = 77 BTU*in/(ft^2*h*degF) = 11.1 W/(m*K); pub. SMC-045 (2007); verified 2026-05-07."
+
+[nickel.inconel718._sources."thermal.specific_heat"]
+citation = "Special Metals Inc. INCONEL alloy 718 Technical Bulletin"
+kind = "vendor"
+ref = "specialmetals.com:inconel-alloy-718"
+license = "proprietary-reference-only"
+note = "Inconel 718 specific heat from Table 2 (Physical Constants), SMC-045; 0.104 BTU/(lb*degF) at 70 degF (21 degC) = 435 J/(kg*K); pub. SMC-045 (2007); verified 2026-05-07."
+
+[nickel.inconel718._sources."thermal.thermal_expansion"]
+citation = "Special Metals Inc. INCONEL alloy 718 Technical Bulletin"
+kind = "vendor"
+ref = "specialmetals.com:inconel-alloy-718"
+license = "proprietary-reference-only"
+note = "Inconel 718 mean linear expansion 70 degF to 200 degF (21-93 degC) from Table 5, SMC-045; 7.31e-6 in/in/degF = 13.16e-6 1/K (TOML rounds to 13.0e-6 1/K, conventional 718 RT alpha); pub. SMC-045 (2007); verified 2026-05-07."
+
+[nickel.inconel718._sources."electrical.resistivity"]
+citation = "Special Metals Inc. INCONEL alloy 718 Technical Bulletin"
+kind = "vendor"
+ref = "specialmetals.com:inconel-alloy-718"
+license = "proprietary-reference-only"
+note = "Inconel 718 annealed 1800F/1hr electrical resistivity at 70 degF (21 degC) from Table 5, SMC-045; 753 ohm-circ-mil/ft = 125 microohm-cm = 1.25e-6 ohm*m; pub. SMC-045 (2007); verified 2026-05-07."
 
 [iron._sources._default]
 citation = "py-mat-curation-3.x"


### PR DESCRIPTION
## Summary

Adds two new aerospace-grade nickel-base superalloy entries to `src/pymat/data/metals.toml` under the existing `[nickel]` family node. Per-property MIL-HDBK-5J citations follow the pattern landed in PR #205 (#166); thermal/electrical properties (which MIL-HDBK-5J only graphs, not tabulates) come from the Special Metals public technical bulletins under `proprietary-reference-only`.

Closes #125, #126.

### Per-material values

| Property | Inconel 625 | Inconel 718 | Source |
|---|---|---|---|
| Condition | AMS 5599 sheet, annealed | AMS 5596 sheet, STA per spec | MIL-HDBK-5J |
| Density (g/cm³) | 8.44 | 8.22 | MIL-HDBK-5J Table 6.3.3.0(b) p.6-35 / 6.3.5.0(b) p.6-52 |
| UTS, Ftu (MPa) | 820 (L, A-basis) | 1241 (LT, A-basis) | MIL-HDBK-5J p.6-35 / p.6-52 |
| Yield, Fty (MPa) | 379 (L, A-basis) | 1014 (LT, A-basis) | MIL-HDBK-5J p.6-35 / p.6-52 |
| E (GPa) | 205 | 203 | MIL-HDBK-5J p.6-35 / p.6-52 |
| Poisson μ | 0.28 | 0.29 | MIL-HDBK-5J p.6-35 / p.6-52 |
| Elongation (%) | 30 (LT, S-basis) | 12 (LT, S-basis) | MIL-HDBK-5J p.6-35 / p.6-52 |
| Melting range (°C) | 1290–1350 (1350 stored) | 1260–1336 (1336 stored) | Special Metals SMC-063 / SMC-045 Table 2 |
| Thermal k (W/m·K) | 9.8 @ 21 °C | 11.1 @ 21 °C | Special Metals SMC-063 Table 3 / SMC-045 Table 5 |
| Specific heat (J/kg·K) | 410 @ 21 °C | 435 @ 21 °C | Special Metals SMC-063 / SMC-045 Table 2 |
| α CTE (1/K, 21–93 °C mean) | 12.8e-6 | 13.0e-6 | Special Metals SMC-063 Table 3 / SMC-045 Table 5 |
| Resistivity (Ω·m) | 1.29e-6 @ 21 °C | 1.25e-6 @ 21 °C | Special Metals SMC-063 / SMC-045 |

All MIL-HDBK-5J citations use `kind = "handbook"`, `license = "PD-USGov"`, `ref = "mil-hdbk-5j:p<page>"`. Vendor bulletin citations use `kind = "vendor"`, `license = "proprietary-reference-only"`, `ref = "specialmetals.com:inconel-alloy-<625|718>"`. Each `note` records spec, condition (annealed vs STA), basis (A/B/S/typical), orientation (L/LT), conversion (ksi→MPa, lb/in³→g/cm³), and verification date.

### MIL-HDBK-5J pages used

- `mil-hdbk-5j:p6-35` — Table 6.3.3.0(b), Inconel 625 sheet/plate (AMS 5599, annealed)
- `mil-hdbk-5j:p6-52` — Table 6.3.5.0(b), Inconel 718 sheet/plate (AMS 5596, STA)

Verified directly from the 67 MB MIL-HDBK-5J PDF on everyspec.com (https://everyspec.com/MIL-HDBK/MIL-HDBK-0001-0099/MIL_HDBK_5J_139/) on 2026-05-07. PDF page→handbook page mapping: PDF +1040 = handbook page (e.g. PDF 1074 → page 6-34).

### Vendor bulletins used

- https://www.specialmetals.com/documents/technical-bulletins/inconel/inconel-alloy-625.pdf (SMC-063, INCONEL alloy 625)
- https://www.specialmetals.com/documents/technical-bulletins/inconel/inconel-alloy-718.pdf (SMC-045, INCONEL alloy 718)

Used per `docs/data-policy.md` "fact extraction (one value, with attribution)" exemption — single-value extraction with full citation, not bulk-table copy.

### Judgment calls

- **Inconel 625 condition: annealed sheet (Table 6.3.3.0(b)), not bar (Table 6.3.3.0(c)).** The sheet table provides A/B-basis allowables (true design allowables); the bar table is S-basis only. Spec hint mentioned 414 MPa annealed yield — that's the bar S-basis value. We chose sheet A-basis (379 MPa) which is the more conservative and statistically rigorous engineering value. A future PR can add `inconel625.bar` or `inconel625.sta` child nodes if needed.
- **Inconel 718 STA over annealed.** Aerospace use of 718 is essentially always in the STA condition; annealed 718 has Fty ~520 MPa vs 1014 MPa STA — the alloy is specified for the STA properties. AMS 5596 is the standard sheet/plate STA spec; chose the 1700–1850 °F anneal + standard age schedule (the values in Table 6.3.5.0(b) reflect this). Note: the spec hint's "1170 MPa STA2" came from the bar table 6.3.5.0(c) (185 ksi UTS, 150 ksi Fty); we used sheet (180 ksi LT) for the primary because it is A-basis allowable.
- **Melting point stored as liquidus (upper bound) for both.** MIL-HDBK-5J does not list melting points; both bulletins give a range. Stored upper bound: 1350 °C for 625, 1336 °C for 718. The lower (solidus) bound is documented in the source `note`.
- **Density 8.44 vs 8.22.** Confirmed independently — MIL-HDBK-5J 625 uses 0.305 lb/in³, 718 uses 0.297 lb/in³. They differ slightly, as expected from composition (718 has more Fe and Nb that lighten the alloy). Both also match Special Metals bulletins.
- **Inconel 718 thermal conductivity 11.1 W/(m·K) at RT** — confirmed low magnitude (matches the spec edge-case warning). Converted from 77 BTU·in/(ft²·h·°F) using factor 0.14423.
- **CTE convention.** Both bulletins give "mean linear expansion from 70 °F to T". The lowest tabulated T for 625 is 200 °F (12.8e-6/K); for 718 it's 200 °F (13.16e-6/K, rounded to 13.0e-6/K — the conventional 718 RT CTE). These represent the 21–93 °C average — the closest published value to RT.
- **Compositions** are nominal mid-spec mass fractions taken from the same Special Metals bulletins (single fact extraction), not MIL-HDBK-5J. Documented as such in the per-property `note`.

## Test plan

- [x] `python -c "import tomllib; tomllib.loads(open('src/pymat/data/metals.toml').read())"` — TOML parses
- [x] `python scripts/check_licenses.py` — license gate passes (7 TOML files)
- [x] `uv run pytest tests/test_toml_integrity.py tests/test_sources.py` — 43 passed
- [x] `uv run pytest` — 714 passed, 18 skipped
- [x] `uv run ruff check . && uv run ruff format --check .` — clean
- [x] `uv run python -c "from pymat import inconel625, inconel718; print(inconel625.density, inconel718.density)"` — 8.44 8.22
- [x] `uv run python -c "from pymat import inconel625; print(inconel625.source_of('mechanical.tensile_strength'))"` — returns Source(citation='MIL-HDBK-5J p.6-35', kind='handbook', ref='mil-hdbk-5j:p6-35', license='PD-USGov', …)