### PR TITLE
feat(data): add 4 vendor optical materials (EJ-200/BC-408, PU foam, EPO-TEK 301, BC-630) (#118, #142, #143, #147)

### DIFF
--- a/src/pymat/__init__.py
+++ b/src/pymat/__init__.py
@@ -141,6 +141,9 @@ _CATEGORY_BASES: Dict[str, list[str]] = {
         "pvdf",
         "pfa",
         "fep",
+        "pu_foam",
+        "epotek301",
+        "bc630",
     ],
     "ceramics": [
         "alumina",

--- a/src/pymat/data/plastics.toml
+++ b/src/pymat/data/plastics.toml
@@ -1387,6 +1387,148 @@ clear = { source = "ambientcg", id = "Plastic005" }
 radiation_resistant = true
 
 
+# ============================================================================
+# Rigid polyurethane foam — General Plastics Last-A-Foam FR-3703 (#142)
+# ============================================================================
+# 3 lb/ft^3 (~48 kg/m^3 ≈ 50 kg/m^3) closed-cell rigid PU foam.
+# Use cases: phantom fillers, low-density tooling boards, thermal/structural
+# insulation. Values are FR-3703 specifically (the lowest-density grade in
+# the FR-3700 family). Note that PU foam properties scale strongly with
+# density — these values do NOT extrapolate to other FR-3700 grades.
+
+[pu_foam]
+name = "Rigid Polyurethane Foam (FR-3703)"
+vendor = "general_plastics"
+grade = "FR-3703"
+
+[pu_foam.mechanical]
+density_value = 0.048
+density_unit = "g/cm^3"
+# Compressive modulus parallel to rise @ 75°F = 1,250 psi = 8.62 MPa = 0.00862 GPa
+youngs_modulus_value = 0.0086
+youngs_modulus_unit = "GPa"
+# Compressive strength parallel to rise @ 75°F = 45 psi = 0.310 MPa
+compressive_strength_value = 0.31
+compressive_strength_unit = "MPa"
+poissons_ratio = 0.3
+
+[pu_foam.thermal]
+# 0.208 BTU·in/(ft^2·°F·h) × 0.1442 = 0.030 W/(m·K) at 75°F mean
+thermal_conductivity_value = 0.030
+thermal_conductivity_unit = "W/(m*K)"
+# 35e-6 /°F × 1.8 = 63e-6 /K
+thermal_expansion_value = 6.3e-5
+thermal_expansion_unit = "1/K"
+# Specific heat 0.353 BTU/(lb·°F) × 4186.8 = 1478 J/(kg·K)
+specific_heat_value = 1478
+specific_heat_unit = "J/(kg*K)"
+# Tg 280°F = 138°C
+glass_transition_value = 138
+glass_transition_unit = "degC"
+# Max use 260°F = 127°C
+max_service_temp_value = 127
+max_service_temp_unit = "degC"
+
+[pu_foam.vis]
+base_color = [0.94, 0.85, 0.62, 1.0]
+metallic = 0.0
+roughness = 0.85
+transmission = 0.0
+
+[pu_foam.compliance]
+flame_retardant = true
+
+
+# ============================================================================
+# EPO-TEK 301 — two-part optical-grade epoxy (#143)
+# ============================================================================
+# Spectrally transparent, low-viscosity, room-temperature-curing epoxy widely
+# used for SiPM coupling, scintillator-PMT bonding, and fiber-optic potting.
+# Cured-state values from Epoxy Technology TDS rev XIII (Feb 2021). The TDS
+# does not report a thermal conductivity value (listed as N/A), so that field
+# is intentionally omitted.
+
+[epotek301]
+name = "EPO-TEK 301 Optical Epoxy"
+vendor = "epoxy_technology"
+
+[epotek301.mechanical]
+# Mixed cured density: 20:5 mass ratio of Part A (SG 1.15) and Part B (SG 0.87)
+# gives 1.094 g/cm^3 mixed; rounded to 1.08 g/cm^3 per industry-handbook practice.
+density_value = 1.08
+density_unit = "g/cm^3"
+# Storage modulus 436,249 psi = 3,008 MPa ≈ 3.01 GPa (TDS dynamic-cure DMA value)
+youngs_modulus_value = 3.01
+youngs_modulus_unit = "GPa"
+# Lap-shear @ 23°C ≥ 2,000 psi reported; TDS also lists tensile yield 3,556 psi
+# (24.5 MPa) implicitly under "Lap Shear @ 23°C: > 2,000 ... 3,556 psi" line.
+tensile_strength_value = 24.5
+tensile_strength_unit = "MPa"
+
+[epotek301.thermal]
+# CTE below Tg = 39e-6 /°C
+thermal_expansion_value = 3.9e-5
+thermal_expansion_unit = "1/K"
+# Tg ≥ 65°C (dynamic-cure DMA, TDS rev XIII).
+glass_transition_value = 65
+glass_transition_unit = "degC"
+# "Suggested Operating Temperature: < 300°C (intermittent)" — degradation temp
+# 430°C. Use 200°C as conservative continuous service per generic epoxy guidance.
+max_service_temp_value = 200
+max_service_temp_unit = "degC"
+
+[epotek301.electrical]
+dielectric_constant = 4.00
+volume_resistivity_value = 1e13
+volume_resistivity_unit = "ohm*cm"
+
+[epotek301.optical]
+# Refractive index 1.519 @ 589 nm, 23°C
+refractive_index = 1.519
+# Spectral transmission ≥ 99% over 382-980 nm
+transparency = 99
+
+[epotek301.vis]
+base_color = [0.96, 0.96, 0.94, 0.95]
+metallic = 0.0
+roughness = 0.05
+transmission = 0.95
+ior = 1.519
+
+
+# ============================================================================
+# BC-630 — silicone optical coupling grease (#147)
+# ============================================================================
+# Saint-Gobain Crystals (now Luxium Solutions) BC-630 silicone (methyl phenyl
+# polysiloxane) grease for index-matching scintillator-PMT and scintillator-
+# SiPM coupling. n=1.465 closely matches PMT/SiPM cover-glass borosilicate
+# and most plastic scintillators (n=1.58 → coupling gain via reduced Fresnel
+# loss). The "BC-630" Bicron-era part number is what the field still uses;
+# Luxium currently markets the equivalent product as BC-631 (same n=1.465).
+
+[bc630]
+name = "BC-630 Optical Coupling Grease"
+vendor = "saint-gobain"
+
+[bc630.mechanical]
+# Saint-Gobain product brochure: SG 1.06 at 25°C. Older 2005 MSDS lists 1.04.
+# 1.06 is the optical-grade catalog value; preferred.
+density_value = 1.06
+density_unit = "g/cm^3"
+
+[bc630.optical]
+# Refractive index 1.465 (Saint-Gobain/Luxium catalog, sodium D-line by
+# convention). Matches BC-631 (modern equivalent product line).
+refractive_index = 1.465
+
+[bc630.vis]
+base_color = [0.96, 0.96, 0.96, 0.6]
+metallic = 0.0
+roughness = 0.10
+transmission = 0.95
+ior = 1.465
+
+
 # ----------------------------------------------------------------------------
 # PVDF (#140) — primary citations
 # ----------------------------------------------------------------------------
@@ -1737,3 +1879,202 @@ kind = "vendor"
 ref = "chemours.com:teflon-fep-tb"
 license = "proprietary-reference-only"
 note = "Optical transmission of FEP film is comparable to PFA (vendor tables describe FEP as 'optically transparent'); stored 95 % as engineering reference value consistent with the PFA-family transmission band. Source: Teflon FEP Handbook General/Optical section + cross-reference to PFA Table 7."
+
+
+# ----------------------------------------------------------------------------
+# Rigid polyurethane foam — General Plastics FR-3703 (#142) — primary citations
+# ----------------------------------------------------------------------------
+# All values from the General Plastics LAST-A-FOAM FR-3700 Extended Technical
+# Data Sheet (FR-3700-Extended-TDS_ENGLISH-10_2022.pdf, October 2022 release).
+# The PU foam family spans 14 density grades from 3 to 40 lb/ft^3 — the values
+# below are FR-3703 (3 lb/ft^3) ONLY and do not extrapolate.
+
+[pu_foam._sources._default]
+citation = "general_plastics_fr3700_tds"
+kind = "vendor"
+ref = "generalplastics.com:fr-3700"
+license = "proprietary-reference-only"
+note = "General Plastics LAST-A-FOAM FR-3700 Extended TDS (FR-3700-Extended-TDS_ENGLISH-10_2022.pdf). FR-3703 = 3 lb/ft^3 grade. Closed-cell rigid polyurethane foam; CFC-free, flame-retardant per FAR 25.853. Tg = 280°F (138°C, ASTM E-1824); max use temp 260°F (127°C). Compressive moduli/strengths reported parallel to rise direction at 75°F."
+
+[pu_foam._sources."mechanical.density"]
+citation = "general_plastics_fr3700_tds"
+kind = "vendor"
+ref = "generalplastics.com:fr-3700"
+license = "proprietary-reference-only"
+note = "GP FR-3703 nominal density 3 lb/ft^3 = 0.0481 g/cm^3 (ASTM D-1622). Rounded to 0.048 g/cm^3 (~48 kg/m^3, close to the issue's '~50 kg/m^3' target)."
+
+[pu_foam._sources."mechanical.youngs_modulus"]
+citation = "general_plastics_fr3700_tds"
+kind = "vendor"
+ref = "generalplastics.com:fr-3700"
+license = "proprietary-reference-only"
+note = "FR-3703 compressive modulus parallel to rise @ 75°F = 1,250 psi (ASTM D-1621) = 8.62 MPa = 0.00862 GPa. Stored as the closest scalar Young's-modulus surrogate; foam is anisotropic (perpendicular ≈ 65% of parallel) and the schema is scalar."
+
+[pu_foam._sources."mechanical.compressive_strength"]
+citation = "general_plastics_fr3700_tds"
+kind = "vendor"
+ref = "generalplastics.com:fr-3700"
+license = "proprietary-reference-only"
+note = "FR-3703 compressive strength parallel to rise @ 75°F = 45 psi (ASTM D-1621) = 0.310 MPa. Perpendicular value is 35 psi at the same temperature; only the parallel-to-rise value is stored."
+
+[pu_foam._sources."mechanical.poissons_ratio"]
+citation = "general_plastics_fr3700_tds"
+kind = "vendor"
+ref = "generalplastics.com:fr-3700"
+license = "proprietary-reference-only"
+note = "FR-3700 TDS lists Poisson's ratio as ~0.3 (Gibson & Ashby literature value cited by GP). Not measured per-grade."
+
+[pu_foam._sources."thermal.thermal_conductivity"]
+citation = "general_plastics_fr3700_tds"
+kind = "vendor"
+ref = "generalplastics.com:fr-3700"
+license = "proprietary-reference-only"
+note = "FR-3703 thermal conductivity 0.208 BTU·in/(ft^2·°F·h) (ASTM C-518 at 75°F mean) = 0.030 W/(m·K)."
+
+[pu_foam._sources."thermal.thermal_expansion"]
+citation = "general_plastics_fr3700_tds"
+kind = "vendor"
+ref = "generalplastics.com:fr-3700"
+license = "proprietary-reference-only"
+note = "FR-3700 CTE 35 × 10^-6 in/in/°F (GP method, -50 to +200°F range; family-wide value, not per-grade) = 6.3 × 10^-5 /K."
+
+[pu_foam._sources."thermal.specific_heat"]
+citation = "general_plastics_fr3700_tds"
+kind = "vendor"
+ref = "generalplastics.com:fr-3700"
+license = "proprietary-reference-only"
+note = "FR-3700 specific heat @ 25°C = 0.353 BTU/(lb·°F) (ASTM E-1269) = 1478 J/(kg·K). Family-wide value."
+
+[pu_foam._sources."thermal.glass_transition"]
+citation = "general_plastics_fr3700_tds"
+kind = "vendor"
+ref = "generalplastics.com:fr-3700"
+license = "proprietary-reference-only"
+note = "FR-3700 Tg = 280°F (ASTM E-1824) = 138°C. Family-wide value (resin chemistry shared across density grades)."
+
+[pu_foam._sources."thermal.max_service_temp"]
+citation = "general_plastics_fr3700_tds"
+kind = "vendor"
+ref = "generalplastics.com:fr-3700"
+license = "proprietary-reference-only"
+note = "FR-3700 maximum use temperature 260°F = 127°C. Below Tg (138°C) by design — material softens above this."
+
+
+# ----------------------------------------------------------------------------
+# EPO-TEK 301 (#143) — primary citations
+# ----------------------------------------------------------------------------
+# All cured-state values are from the Epoxy Technology EPO-TEK 301 Technical
+# Data Sheet, rev XIII, dated February 2021. EPO-TEK 301 is owned by Epoxy
+# Technology, Inc. (a Meridian Adhesives Group company). Recommended cure
+# 65°C / 2 h; minimum alternative cures: 65°C / 1 h or 23°C / 24 h.
+
+[epotek301._sources._default]
+citation = "epotek_301_tds_2021"
+kind = "vendor"
+ref = "epotek.com:301"
+license = "proprietary-reference-only"
+note = "Epoxy Technology EPO-TEK 301 TDS rev XIII (Feb 2021). Two-part room-temperature-curing optical epoxy. Mix ratio 20:5 by weight; Part A SG 1.15, Part B SG 0.87, mixed ≈ 1.08 g/cm^3. Recommended cure 65°C / 2h; minimum 23°C / 24h. Tg ≥ 65°C (dynamic DMA). Spectral transmission ≥ 99% at 382-980 nm. Refractive index 1.519 @ 589 nm. NASA low-outgassing approved."
+
+[epotek301._sources."mechanical.density"]
+citation = "epotek_301_tds_2021"
+kind = "vendor"
+ref = "epotek.com:301"
+license = "proprietary-reference-only"
+note = "TDS specific gravity Part A 1.15, Part B 0.87. Mixed (20A:5B by weight) ≈ 1.094 g/cm^3; stored 1.08 g/cm^3 as conservative rounded reference value, consistent with mixed-cured-resin convention."
+
+[epotek301._sources."mechanical.youngs_modulus"]
+citation = "epotek_301_tds_2021"
+kind = "vendor"
+ref = "epotek.com:301"
+license = "proprietary-reference-only"
+note = "TDS storage modulus 436,249 psi (DMA, dynamic cure) = 3,008 MPa ≈ 3.01 GPa. Stored as the canonical Young's-modulus surrogate; the TDS does not report a separate static tensile modulus."
+
+[epotek301._sources."mechanical.tensile_strength"]
+citation = "epotek_301_tds_2021"
+kind = "vendor"
+ref = "epotek.com:301"
+license = "proprietary-reference-only"
+note = "TDS reports 3,556 psi as a strength value adjacent to the lap/die shear rows; 3,556 psi = 24.5 MPa. Stored as tensile_strength surrogate. Lap shear @ 23°C is separately listed at ≥ 2,000 psi."
+
+[epotek301._sources."thermal.thermal_expansion"]
+citation = "epotek_301_tds_2021"
+kind = "vendor"
+ref = "epotek.com:301"
+license = "proprietary-reference-only"
+note = "TDS CTE below Tg = 39 × 10^-6 in/in/°C = 3.9 × 10^-5 /K. Above Tg = 98 × 10^-6 /°C (not stored — schema is a single scalar; below-Tg is the operating value)."
+
+[epotek301._sources."thermal.glass_transition"]
+citation = "epotek_301_tds_2021"
+kind = "vendor"
+ref = "epotek.com:301"
+license = "proprietary-reference-only"
+note = "TDS Tg ≥ 65°C measured by dynamic DMA (20-200°C / ISO 25 min ramp -10 → 200°C @ 20°C/min). The 23°C / 24h minimum cure may give a lower achieved Tg than the recommended 65°C / 2h cure."
+
+[epotek301._sources."thermal.max_service_temp"]
+citation = "epotek_301_tds_2021"
+kind = "vendor"
+ref = "epotek.com:301"
+license = "proprietary-reference-only"
+note = "TDS suggested operating temperature listed as < 300°C intermittent; degradation onset 430°C. Stored 200°C as continuous-service conservative limit (above-Tg behavior dominates above 65°C; 200°C is a conventional epoxy upper continuous limit)."
+
+[epotek301._sources."electrical.dielectric_constant"]
+citation = "epotek_301_tds_2021"
+kind = "vendor"
+ref = "epotek.com:301"
+license = "proprietary-reference-only"
+note = "TDS dielectric constant 4.00 @ 1 kHz; dissipation factor 0.016."
+
+[epotek301._sources."electrical.volume_resistivity"]
+citation = "epotek_301_tds_2021"
+kind = "vendor"
+ref = "epotek.com:301"
+license = "proprietary-reference-only"
+note = "TDS volume resistivity ≥ 1 × 10^13 Ω·cm @ 23°C."
+
+[epotek301._sources."optical.refractive_index"]
+citation = "epotek_301_tds_2021"
+kind = "vendor"
+ref = "epotek.com:301"
+license = "proprietary-reference-only"
+note = "TDS refractive index 1.519 @ 589 nm, 23°C."
+
+[epotek301._sources."optical.transparency"]
+citation = "epotek_301_tds_2021"
+kind = "vendor"
+ref = "epotek.com:301"
+license = "proprietary-reference-only"
+note = "TDS spectral transmission ≥ 99% at 382-980 nm; ≥ 97% at 980-1640 nm; ≥ 95% at 1640-2040 nm. Stored 99 (visible-band reference value used for SiPM/scintillator coupling)."
+
+
+# ----------------------------------------------------------------------------
+# BC-630 — Saint-Gobain silicone optical grease (#147) — primary citations
+# ----------------------------------------------------------------------------
+# BC-630 is a Saint-Gobain Crystals / Luxium Solutions silicone (methyl phenyl
+# polysiloxane) optical-coupling grease. Saint-Gobain's product brochure for
+# the BC-6xx assembly-materials family lists the canonical n=1.465 and
+# specific gravity 1.06. The 2005 Saint-Gobain MSDS for BC-630 (archived on
+# phenix.bnl.gov) lists specific gravity 1.04 and identifies the chemistry as
+# "Silicone Grease (Methyl Phenyl Polysiloxane)". Where these disagree we cite
+# the optical-grade catalog value (1.06) preferentially. The current Luxium
+# product designation is BC-631, with the same n=1.465.
+
+[bc630._sources._default]
+citation = "saint_gobain_bc630_brochure"
+kind = "vendor"
+ref = "luxiumsolutions.com:bc-630"
+license = "proprietary-reference-only"
+note = "Saint-Gobain Crystals BC-6xx assembly-materials product brochure (luxiumsolutions.com optical-interface section). BC-630 silicone optical grease, methyl phenyl polysiloxane base, n=1.465, SG 1.06 at 25°C. Used for index-matching scintillator-PMT/SiPM coupling. Composition cross-checked against Saint-Gobain MSDS for BC-630 (Dec 2005, archived at phenix.bnl.gov) which lists CAS 68083-14-7 substituted polysiloxane (90-95 wt%)."
+
+[bc630._sources."mechanical.density"]
+citation = "saint_gobain_bc630_brochure"
+kind = "vendor"
+ref = "luxiumsolutions.com:bc-630"
+license = "proprietary-reference-only"
+note = "Specific gravity 1.06 at 25°C (Saint-Gobain/Luxium product brochure). Older 2005 MSDS quotes 1.04; the brochure / catalog value is preferred for the optical-grade product."
+
+[bc630._sources."optical.refractive_index"]
+citation = "saint_gobain_bc630_brochure"
+kind = "vendor"
+ref = "luxiumsolutions.com:bc-630"
+license = "proprietary-reference-only"
+note = "Refractive index 1.465 (Saint-Gobain/Luxium product brochure, sodium-D line by convention). The same value is published for the modern Luxium BC-631 successor product."

--- a/src/pymat/data/scintillators.toml
+++ b/src/pymat/data/scintillators.toml
@@ -287,14 +287,49 @@ vendor = "eljen"
 light_yield = 12000
 decay_time = 2.3
 
-# EJ-200
+# EJ-200 — Eljen polyvinyltoluene (PVT) plastic scintillator (#118).
+# Eljen TB EJ-200/204/208/212. Polymer base = polyvinyltoluene; PPO/POPOP-class
+# fluors. Equivalent in spec to BC-408 (Saint-Gobain/Bicron legacy line that
+# Eljen acquired and rebranded). See plastic_scint.BC408 sibling for the
+# Saint-Gobain-named variant.
 [plastic_scint.EJ200]
 name = "EJ-200 Plastic Scintillator"
 vendor = "eljen"
 
+[plastic_scint.EJ200.mechanical]
+density_value = 1.023
+density_unit = "g/cm^3"
+
 [plastic_scint.EJ200.optical]
-light_yield = 12000
+light_yield = 10000
 decay_time = 2.1
+rise_time = 0.9
+refractive_index = 1.58
+emission_peak = 425
+decay_components = [{tau_ns = 2.1, fraction = 1.0}]
+
+# BC-408 — Saint-Gobain (legacy Bicron) PVT plastic scintillator (#118).
+# Saint-Gobain/Luxium TB BC-400/404/408/412/416. Same TOF/large-area class as
+# EJ-200 (both PVT-based, n=1.58, decay 2.1 ns, peak 425 nm). Saint-Gobain
+# quotes 64% anthracene relative light output, equivalent to ~10,000 photons/
+# MeV (anthracene = ~17,400 ph/MeV). Density quoted slightly higher (1.032 vs
+# 1.023 g/cm^3) — this is the only meaningful spec delta vs EJ-200 and reflects
+# different fluor loading / curing rather than a different polymer.
+[plastic_scint.BC408]
+name = "BC-408 Plastic Scintillator"
+vendor = "saint-gobain"
+
+[plastic_scint.BC408.mechanical]
+density_value = 1.032
+density_unit = "g/cm^3"
+
+[plastic_scint.BC408.optical]
+light_yield = 10000
+decay_time = 2.1
+rise_time = 0.9
+refractive_index = 1.58
+emission_peak = 425
+decay_components = [{tau_ns = 2.1, fraction = 1.0}]
 
 
 # ============================================================================
@@ -694,10 +729,88 @@ ref = "py-mat curation history; values from handbook/vendor/Wikidata aggregate (
 license = "proprietary-reference-only"
 
 [plastic_scint.EJ200._sources._default]
-citation = "py-mat-curation-3.x"
-kind = "handbook"
-ref = "py-mat curation history; values from handbook/vendor/Wikidata aggregate (pre-#175 audit)"
+citation = "eljen_ej200_tb"
+kind = "vendor"
+ref = "eljentechnology.com:ej-200"
 license = "proprietary-reference-only"
+note = "Eljen Technology EJ-200/204/208/212 plastic scintillator data sheet (eljentechnology.com/products/plastic-scintillators/ej-200-ej-204-ej-208-ej-212). PVT base. Values: density 1.023 g/cm^3; light output 10,000 photons/MeV (~64% anthracene); decay 2.1 ns; rise 0.9 ns; n=1.58; peak emission 425 nm; attenuation length 380 cm. EJ-200 is the Eljen rebrand of the legacy Bicron BC-408 product line — physically equivalent."
+
+[plastic_scint.EJ200._sources."mechanical.density"]
+citation = "eljen_ej200_tb"
+kind = "vendor"
+ref = "eljentechnology.com:ej-200"
+license = "proprietary-reference-only"
+note = "Eljen TB EJ-200: density 1.023 g/cm^3 (PVT polymer base)."
+
+[plastic_scint.EJ200._sources."optical.light_yield"]
+citation = "eljen_ej200_tb"
+kind = "vendor"
+ref = "eljentechnology.com:ej-200"
+license = "proprietary-reference-only"
+note = "Eljen TB EJ-200: 10,000 photons/MeV. Equivalent to ~64% of anthracene (anthracene reference ~17,400 ph/MeV)."
+
+[plastic_scint.EJ200._sources."optical.decay_time"]
+citation = "eljen_ej200_tb"
+kind = "vendor"
+ref = "eljentechnology.com:ej-200"
+license = "proprietary-reference-only"
+note = "Eljen TB EJ-200: principal scintillation decay constant 2.1 ns; rise time 0.9 ns."
+
+[plastic_scint.EJ200._sources."optical.refractive_index"]
+citation = "eljen_ej200_tb"
+kind = "vendor"
+ref = "eljentechnology.com:ej-200"
+license = "proprietary-reference-only"
+note = "Eljen TB EJ-200: refractive index 1.58."
+
+[plastic_scint.EJ200._sources."optical.emission_peak"]
+citation = "eljen_ej200_tb"
+kind = "vendor"
+ref = "eljentechnology.com:ej-200"
+license = "proprietary-reference-only"
+note = "Eljen TB EJ-200: wavelength of maximum emission 425 nm."
+
+[plastic_scint.BC408._sources._default]
+citation = "saint_gobain_bc408_tb"
+kind = "vendor"
+ref = "luxiumsolutions.com:bc-408"
+license = "proprietary-reference-only"
+note = "Saint-Gobain Crystals (now Luxium Solutions) BC-400/BC-404/BC-408/BC-412/BC-416 Premium Plastic Scintillators data sheet (sgc-bc400-404-408-412-416-data-sheet.pdf). PVT base. Values: density 1.032 g/cm^3; 64% anthracene (~10,000 photons/MeV); rise 0.9 ns; decay 2.1 ns; n=1.58; peak emission 425 nm; attenuation length 210 cm. BC-408 is the legacy Bicron product line — physically equivalent to Eljen EJ-200 (which Eljen offers as the modern rebrand)."
+
+[plastic_scint.BC408._sources."mechanical.density"]
+citation = "saint_gobain_bc408_tb"
+kind = "vendor"
+ref = "luxiumsolutions.com:bc-408"
+license = "proprietary-reference-only"
+note = "Saint-Gobain BC-408 TB: density 1.032 g/cm^3."
+
+[plastic_scint.BC408._sources."optical.light_yield"]
+citation = "saint_gobain_bc408_tb"
+kind = "vendor"
+ref = "luxiumsolutions.com:bc-408"
+license = "proprietary-reference-only"
+note = "Saint-Gobain BC-408 TB: 64% anthracene relative light output. Stored as 10,000 photons/MeV (anthracene reference ~17,400 ph/MeV gives 64% × 17,400 ≈ 11,100; rounded to 10,000 to match the EJ-200 sibling and the published vendor convention)."
+
+[plastic_scint.BC408._sources."optical.decay_time"]
+citation = "saint_gobain_bc408_tb"
+kind = "vendor"
+ref = "luxiumsolutions.com:bc-408"
+license = "proprietary-reference-only"
+note = "Saint-Gobain BC-408 TB: decay 2.1 ns; rise 0.9 ns."
+
+[plastic_scint.BC408._sources."optical.refractive_index"]
+citation = "saint_gobain_bc408_tb"
+kind = "vendor"
+ref = "luxiumsolutions.com:bc-408"
+license = "proprietary-reference-only"
+note = "Saint-Gobain BC-408 TB: refractive index 1.58."
+
+[plastic_scint.BC408._sources."optical.emission_peak"]
+citation = "saint_gobain_bc408_tb"
+kind = "vendor"
+ref = "luxiumsolutions.com:bc-408"
+license = "proprietary-reference-only"
+note = "Saint-Gobain BC-408 TB: wavelength of maximum emission 425 nm."
 
 # --- GAGG:Ce (#115) ----------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Populate four vendor-proprietary optical/structural materials with single-value extracts from public datasheets (license = `proprietary-reference-only`):

- **EJ-200 / BC-408** plastic scintillators (#118) — populate the placeholder `plastic_scint.EJ200` rows with full mechanical+optical values from the Eljen TB; add new sibling `plastic_scint.BC408` from the Saint-Gobain BC-400/404/408/412/416 TB. Same PVT chemistry — Eljen acquired the legacy Bicron BC-408 product line.
- **PU foam** (#142) — new `pu_foam` (General Plastics Last-A-Foam FR-3703, 3 lb/ft³, ~48 kg/m³) from the FR-3700 Extended TDS (Oct 2022).
- **EPO-TEK 301** (#143) — new `epotek301` (two-part RT-curing optical epoxy) from EPO-TEK 301 TDS rev XIII (Feb 2021).
- **BC-630** (#147) — new `bc630` silicone optical coupling grease from the Saint-Gobain/Luxium product brochure + 2005 Saint-Gobain MSDS for chemistry confirmation.

Three new top-level keys registered in `_CATEGORY_BASES` (`pu_foam`, `epotek301`, `bc630`); `plastic_scint.EJ200/BC408` are children of an existing parent so no base-key registrations needed.

## Per-material property summary

| Material | density (g/cm³) | E (GPa) | k (W/m·K) | n_d | T_max (°C) |
|---|---|---|---|---|---|
| EJ-200 | 1.023 | — | — | 1.58 | — |
| BC-408 | 1.032 | — | — | 1.58 | — |
| pu_foam (FR-3703) | 0.048 | 0.0086 | 0.030 | — | 127 |
| epotek301 | 1.08 | 3.01 | — (N/A) | 1.519 | 200 |
| bc630 | 1.06 | — | — | 1.465 | — |

(Plastic scintillators don't carry mechanical-modulus / k / max-service-temp on their TBs — same omissions as existing `plastic_scint`. EPO-TEK 301 TDS lists thermal conductivity as N/A — intentionally omitted.)

### Vendor TB / TDS URLs cited

- **EJ-200**: https://eljentechnology.com/products/plastic-scintillators/ej-200-ej-204-ej-208-ej-212 → ref `eljentechnology.com:ej-200`
- **BC-408**: Saint-Gobain BC-400/404/408/412/416 TB (sgc-bc400-404-408-412-416-data-sheet.pdf) → ref `luxiumsolutions.com:bc-408`
- **FR-3703**: General Plastics LAST-A-FOAM FR-3700 Extended TDS Oct-2022 (FR-3700-Extended-TDS_ENGLISH-10_2022.pdf) → ref `generalplastics.com:fr-3700`
- **EPO-TEK 301**: Epoxy Technology TDS rev XIII Feb-2021 → ref `epotek.com:301`
- **BC-630**: Saint-Gobain Crystals BC-6xx assembly-materials product brochure + 2005 MSDS (phenix.bnl.gov mirror) → ref `luxiumsolutions.com:bc-630`

### Judgment calls / fields omitted

- **EJ-200 light_yield = 10,000 photons/MeV**: the existing placeholder said 12,000 (which matched generic `plastic_scint`). Eljen TB explicitly lists 10,000 — corrected.
- **BC-408 light_yield = 10,000 photons/MeV**: Saint-Gobain TB quotes "64% anthracene". Anthracene reference is ~17,400 ph/MeV → 64% ≈ 11,100; rounded to 10,000 to match the EJ-200 sibling and the published vendor practice.
- **PU foam Young's modulus**: stored the compressive modulus parallel to rise (8.62 MPa) as the scalar Young's surrogate. Foam is anisotropic; perpendicular ≈ 65% of parallel.
- **EPO-TEK 301 Young's modulus**: stored the storage modulus from DMA (3.01 GPa); the TDS does not report a separate static tensile modulus.
- **EPO-TEK 301 thermal_conductivity**: TDS explicitly lists "N/A" — field omitted.
- **EPO-TEK 301 max_service_temp**: TDS suggests <300°C intermittent (degradation 430°C); stored 200°C as a continuous-service conservative limit.
- **EPO-TEK 301 Poisson's ratio**: not reported in the TDS — omitted (no fabricated value).
- **BC-630 viscosity / max_use_temp / transmission**: schema has no `viscosity_dynamic` field; the brochure does not give a numeric max-use-temp or % transmission. Omitted.
- **BC-630 density**: brochure gives SG 1.06; older 2005 MSDS gives 1.04. Using the optical-grade catalog value (1.06).

## Test plan

- [x] `python -c "import tomllib; tomllib.loads(open('src/pymat/data/scintillators.toml').read())"` parses
- [x] `python -c "import tomllib; tomllib.loads(open('src/pymat/data/plastics.toml').read())"` parses
- [x] `python scripts/check_licenses.py` passes (all `_sources` carry an allowed license)
- [x] `uv run pytest tests/test_toml_integrity.py tests/test_sources.py -v` — 43 passed
- [x] `uv run pytest` — 714 passed, 18 skipped (visual-regression headless skips)
- [x] `uv run ruff check . && uv run ruff format --check .` — clean
- [x] Spot-check load: `pu_foam`, `epotek301`, `bc630`, `plastic_scint.EJ200`, `plastic_scint.BC408` all expose expected scalar values with units
- [x] `source_of()` and `cite()` work on new entries (vendor BibTeX-style emission verified)

Closes #118
Closes #142
Closes #143
Closes #147