### PR TITLE
fix(api): close trailing public-surface gaps + add 3 contract test suites

### DIFF
--- a/src/pymat/__init__.py
+++ b/src/pymat/__init__.py
@@ -55,7 +55,9 @@ from .properties import (
     ThermalProperties,
 )
 from .search import search
+from .sources import Source
 from .units import ureg
+from .vis import FinishEntry, Vis, VisDeltas
 
 __version__ = "3.10.0"  # x-release-please-version
 __all__ = [
@@ -68,6 +70,7 @@ __all__ = [
     "ManufacturingProperties",
     "ComplianceProperties",
     "SourcingProperties",
+    "Source",
     "ureg",
     "load_toml",
     "load_category",
@@ -77,6 +80,13 @@ __all__ = [
     "enrich_all",
     "factories",
     "vis",
+    # Vis domain types — also re-exported on top-level pymat so consumers
+    # can `from pymat import Vis` without a second import line.
+    # The canonical home stays pymat.vis (per the public-API contract in
+    # pymat/vis/__init__.py); this is just a convenience alias.
+    "Vis",
+    "VisDeltas",
+    "FinishEntry",
 ]
 
 # ============================================================================
@@ -301,34 +311,17 @@ _sys.modules[__name__].__class__ = _PymatModule
 
 
 def __dir__() -> list[str]:
-    """
-    Help IDE discover available materials.
+    """Help IDE / REPL tab-completion discover available names.
 
-    Returns list of all registered materials plus standard exports.
+    Returns the public ``__all__`` plus every lazy-loadable base material.
+    Deriving from ``__all__`` (instead of a hardcoded subset) keeps tab
+    completion in sync with the public surface — adding a new public
+    name to ``__all__`` automatically surfaces it in ``dir(pymat)``.
     """
-    base_exports = [
-        "Material",
-        "AllProperties",
-        "MechanicalProperties",
-        "ThermalProperties",
-        "ElectricalProperties",
-        "OpticalProperties",
-        "ManufacturingProperties",
-        "ComplianceProperties",
-        "SourcingProperties",
-        "load_toml",
-        "load_category",
-        "enrich_from_periodictable",
-        "enrich_from_matproj",
-        "enrich_all",
-    ]
-
-    # Add all known base materials
-    known_materials = []
+    known_materials: list[str] = []
     for bases in _CATEGORY_BASES.values():
         known_materials.extend(bases)
-
-    return base_exports + known_materials
+    return list(__all__) + known_materials
 
 
 def load_all() -> Dict[str, Material]:

--- a/src/pymat/vis/_model.py
+++ b/src/pymat/vis/_model.py
@@ -115,6 +115,49 @@ _IDENTITY_FIELDS = frozenset({"source", "material_id", "tier"})
 _SENTINEL: Any = object()
 
 
+def _validate_tier(value: str | None) -> None:
+    """Reject an obviously-bogus ``tier`` assignment with a clear message.
+
+    Mirrors the ``Vis.finish=`` setter (which raises ``ValueError`` with
+    the available finish list). Without this, ``vis.tier = "99k"``
+    silently succeeds and the failure surfaces deep inside
+    mat-vis-client on first ``.textures`` access — the consumer never
+    sees the offending input echoed back. Closes the gap pinned by
+    ``tests/test_error_messages.py::TestVisTierUnknown`` and
+    ``tests/test_consumer_journey.py::TestErrorJourney::
+    test_unknown_tier_raises_at_assignment`` (both consumer-flagged
+    via [mat-vis #280](https://github.com/MorePET/mat-vis/issues/280)
+    territory — error messages that fire in the wrong layer / without
+    user-given input echoed).
+
+    Validation policy:
+
+    - ``None`` is allowed — un-mapping a Vis is a documented operation.
+    - The set of valid tiers comes from ``client.tiers()`` (reads the
+      cached mat-vis manifest; no network call after the first fetch).
+    - If the client / manifest is unreachable (offline, corrupted
+      cache, future-version migration), validation is skipped silently
+      rather than blocking the assignment. Worse to break offline
+      workflows than to leave a typo unflagged — the lazy-fetch path
+      will still raise on the eventual ``.textures`` access, just
+      without the at-assignment-site echo this helper provides.
+    """
+    if value is None:
+        return
+    try:
+        from mat_vis_client import get_client
+
+        valid = get_client().tiers()
+    except Exception:
+        # Permissive fallback — see policy in docstring above.
+        return
+    if value not in valid:
+        raise ValueError(
+            f"Unknown tier {value!r}. Available: {sorted(valid)}. "
+            "Set vis.tier = None to un-map, or pick one of the listed tiers."
+        )
+
+
 @dataclass
 class ResolvedChannel:
     """Result of resolving a channel across texture + scalar sources.
@@ -251,6 +294,16 @@ class Vis:
             # Compare before the write so we can detect a no-op.
             if getattr(self, name, _SENTINEL) == value:
                 return
+            # Validate user-supplied tier values at the assignment site so
+            # the offending input is echoed back to the caller (rather than
+            # surfacing deep inside mat-vis-client on the next fetch).
+            # Source / material_id stay free-form — the universe of valid
+            # values there is open-ended (gpuopen names, ambientcg ids,
+            # future sources) and any check here would lag the upstream
+            # catalog. Tier is a closed set per the mat-vis manifest, so
+            # validation pays its way.
+            if name == "tier":
+                _validate_tier(value)
             super().__setattr__(name, value)
             # Invalidate via super() to avoid infinite recursion into
             # this same __setattr__ handler.
@@ -362,6 +415,9 @@ class Vis:
         """
         # Write directly via super() to avoid the per-field invalidation.
         # We'll clear the cache at the end, once, if anything changed.
+        # Tier is validated up-front (parallel to __setattr__) so callers
+        # going through ``set_identity`` get the same at-assignment-site
+        # echo on a bogus tier as direct ``vis.tier = ...`` assignment.
         changed = False
         if source is not None and source != self.source:
             super().__setattr__("source", source)
@@ -370,6 +426,7 @@ class Vis:
             super().__setattr__("material_id", material_id)
             changed = True
         if tier is not None and tier != self.tier:
+            _validate_tier(tier)
             super().__setattr__("tier", tier)
             changed = True
         if changed:

--- a/tests/test_consumer_journey.py
+++ b/tests/test_consumer_journey.py
@@ -1,0 +1,425 @@
+"""End-to-end consumer journey tests.
+
+py-mat's downstream consumers (build123d, ocp_vscode, anyone reaching for
+``pymat.vis.to_threejs``) hit a sequence of steps we never exercised as a
+sequence: discovery → derivation → attachment → export → recovery from
+typos. The unit tests cover each piece in isolation; this file walks the
+journey from first to last so a breakage at *any* step in the sequence
+surfaces here, not in a downstream PR review.
+
+Bernhard's nine mat-vis issues (#280–#288) and py-mat #98 all stem from
+this gap. Tests below pin the steps that work today and ``xfail`` the
+ones that don't, with the gap reason on each.
+
+No network: all texture-fetch points are mocked via ``mat_vis_client``'s
+shared singleton, mirroring the pattern in ``tests/test_vis.py``.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+import pymat
+from pymat import Material
+from pymat.vis import (
+    Vis,
+    export_mtlx,
+    to_gltf,
+    to_threejs,
+)
+
+# ── Fixtures ──────────────────────────────────────────────────
+
+
+@pytest.fixture
+def fake_textures(monkeypatch):
+    """Replace the shared mat-vis client with a fake that returns
+    deterministic PNG bytes — keeps export / mtlx paths off the network."""
+    import mat_vis_client as _client
+
+    class FakeClient:
+        manifest = {"release_tag": "fake", "tiers": {}}
+
+        def fetch_all_textures(self, source, material_id, *, tier="1k"):
+            return {"color": b"\x89PNG_fake_color", "roughness": b"\x89PNG_fake_rough"}
+
+        def channels(self, source, material_id, tier):
+            return ["color", "roughness"]
+
+        def materialize(self, source, material_id, tier, out):
+            return Path(out)
+
+        def mtlx(self, source, material_id, *, tier="1k"):
+            class _MtlxStub:
+                def xml(self_inner):
+                    return "<materialx version='1.39'/>"
+
+                def export(self_inner, out):
+                    return Path(out)
+
+            return _MtlxStub()
+
+    monkeypatch.setattr(_client, "_client", FakeClient())
+    return FakeClient
+
+
+# ============================================================================
+# 1. DISCOVERY — user knows a name, doesn't know our registry keys
+# ============================================================================
+
+
+class TestDiscovery:
+    """A consumer types a material name they have in their head. They
+    should not need to know our registry keys (``s304``, ``a6061_T6``)
+    to find what they want."""
+
+    def test_subscript_resolves_human_name(self):
+        """``pymat["Stainless Steel 304"]`` is the canonical entry for a
+        consumer who's writing a script and has the name in their head."""
+        m = pymat["Stainless Steel 304"]
+        assert m.name == "Stainless Steel 304"
+
+    def test_subscript_resolves_registry_key(self):
+        """``pymat["s304"]`` works too — for users who learned the keys."""
+        m = pymat["s304"]
+        assert m.name == "Stainless Steel 304"
+
+    def test_subscript_resolves_grade(self):
+        """``pymat["304"]`` resolves by grade alone."""
+        m = pymat["304"]
+        assert m.name == "Stainless Steel 304"
+
+    def test_contains_membership_check(self):
+        """``"Stainless Steel 304" in pymat`` is the cheap pre-check
+        before subscripting."""
+        assert "Stainless Steel 304" in pymat
+        assert "DefinitelyNotAMaterial" not in pymat
+
+    def test_search_returns_materials(self):
+        """``pymat.search("stainless")`` returns Material instances —
+        not registry keys, not strings."""
+        hits = pymat.search("stainless")
+        assert hits  # non-empty
+        assert all(isinstance(m, Material) for m in hits)
+
+    def test_search_handles_typo(self):
+        """One-edit typo still finds the material (issue #179)."""
+        hits = pymat.search("stinless 304")
+        names = [m.name for m in hits]
+        assert "Stainless Steel 304" in names
+
+    def test_unknown_material_offers_close_matches(self):
+        """User asks for something we don't have but did mean a real
+        one — error must show the close matches by *name*, not by
+        UUID/registry-key. Closes mat-vis #286 spirit."""
+        with pytest.raises(KeyError) as exc:
+            pymat["Stinless Steel 304"]  # one-edit typo
+        msg = str(exc.value)
+        assert "Stinless Steel 304" in msg  # echoes the user input
+        assert "Stainless Steel 304" in msg  # close match by name
+
+
+# ============================================================================
+# 2. DERIVATION — user wants a tweaked variant without corrupting registry
+# ============================================================================
+
+
+class TestDerivation:
+    """Consumer wants a polished / rougher / recolored variant. The
+    motivating bug (build123d #1270): mutating ``m.vis`` directly
+    corrupts the registry singleton every other caller sees."""
+
+    def test_override_returns_new_vis(self):
+        steel = pymat["Stainless Steel 304"]
+        polished = steel.vis.override(roughness=0.05, finish="polished")
+        assert polished is not steel.vis
+        assert isinstance(polished, Vis)
+
+    def test_override_does_not_mutate_registry(self):
+        """The headline contract — registry singleton is unchanged."""
+        steel = pymat["Stainless Steel 304"]
+        original_roughness = steel.vis.roughness
+        original_finish = steel.vis.finish
+        steel.vis.override(roughness=0.99, finish="polished")
+        assert steel.vis.roughness == original_roughness
+        assert steel.vis.finish == original_finish
+
+    def test_with_vis_returns_independent_material(self):
+        """Material.with_vis() is the safe handoff for "I want this
+        material, with this Vis"."""
+        steel = pymat["Stainless Steel 304"]
+        custom = steel.with_vis(steel.vis.override(roughness=0.05))
+        assert custom is not steel
+        assert custom.vis is not steel.vis
+        assert custom.vis.roughness == 0.05
+        assert steel.vis.roughness != 0.05  # registry untouched
+
+    def test_with_vis_preserves_physics_properties(self):
+        """The derived Material must still be the same physical material —
+        only the appearance changed."""
+        steel = pymat["Stainless Steel 304"]
+        custom = steel.with_vis(steel.vis.override(roughness=0.05))
+        assert custom.density == steel.density
+        assert custom.name == steel.name
+
+
+# Cross-contamination is covered in tests/test_vis_override.py — not duplicated here.
+
+
+# ============================================================================
+# 3. ATTACHMENT — hand a Material to a CAD-like wrapper
+# ============================================================================
+
+
+class _FakeBuild123dPart:
+    """Minimal stand-in for a build123d Part that just stores a material
+    reference. The real build123d Part exposes ``.material`` the same way
+    (see ``Material.apply_to`` in core.py and build123d#1270)."""
+
+    def __init__(self, name: str):
+        self.name = name
+        self.material = None
+
+
+class TestAttachment:
+    """A consumer attaches a Material to a CAD object. We don't have
+    build123d locally, but the data flow is what we need to pin."""
+
+    def test_attach_material_to_part(self):
+        part = _FakeBuild123dPart("housing")
+        part.material = pymat["Stainless Steel 304"]
+        assert part.material.name == "Stainless Steel 304"
+        # Round-trip — Vis is reachable through the attached material
+        assert part.material.vis.source == "ambientcg"
+
+    def test_attach_derived_material(self):
+        """Variant attaches the same way the registry instance does."""
+        steel = pymat["Stainless Steel 304"]
+        polished = steel.with_vis(steel.vis.override(finish="polished"))
+        part = _FakeBuild123dPart("polished housing")
+        part.material = polished
+        # The wrapper sees the variant's appearance, not the registry's.
+        assert part.material.vis.finish == "polished"
+
+    def test_apply_to_helper(self):
+        """``material.apply_to(part)`` is the documented build123d sugar —
+        the round-trip must surface the material on ``.material``."""
+        part = _FakeBuild123dPart("bracket")
+        result = pymat["Stainless Steel 304"].apply_to(part)
+        # apply_to either mutates `part.material` or returns the part with
+        # it set; either way the caller can read it back.
+        attached = getattr(result, "material", None) or part.material
+        assert attached is not None
+        assert attached.name == "Stainless Steel 304"
+
+
+# ============================================================================
+# 4. EXPORT — hand to renderer adapters
+# ============================================================================
+
+
+class TestExport:
+    """Three.js / glTF / MaterialX adapters are the cross-tool handoff.
+    Output must match each format's spec."""
+
+    def test_to_threejs_shape(self, fake_textures):
+        steel = pymat["Stainless Steel 304"]
+        d = to_threejs(steel)
+        # Three.js MeshPhysicalMaterial init dict — pin the keys we care about.
+        assert d["type"] == "MeshPhysicalMaterial"
+        assert "metalness" in d
+        assert "roughness" in d
+        assert isinstance(d["metalness"], (int, float))
+
+    def test_to_threejs_picks_up_override(self, fake_textures):
+        """A variant's override values flow through the adapter."""
+        steel = pymat["Stainless Steel 304"]
+        custom = steel.with_vis(steel.vis.override(roughness=0.7, metallic=0.0))
+        d = to_threejs(custom)
+        assert d["roughness"] == 0.7
+        assert d["metalness"] == 0.0
+
+    def test_to_gltf_shape(self, fake_textures):
+        steel = pymat["Stainless Steel 304"]
+        d = to_gltf(steel)
+        # glTF 2.0 spec: the PBR block must be ``pbrMetallicRoughness``.
+        assert "pbrMetallicRoughness" in d
+        pbr = d["pbrMetallicRoughness"]
+        assert "metallicFactor" in pbr
+        assert "roughnessFactor" in pbr
+        # Material name surfaces from the Material itself
+        assert d.get("name") == "Stainless Steel 304"
+
+    def test_to_gltf_basecolor_array_form(self, fake_textures):
+        """glTF spec: baseColorFactor is a 4-float array, not a hex."""
+        m = Material(name="test")
+        m.vis.base_color = (0.5, 0.25, 0.75, 1.0)
+        d = to_gltf(m)
+        bc = d["pbrMetallicRoughness"].get("baseColorFactor")
+        assert isinstance(bc, list) and len(bc) == 4
+
+    def test_export_mtlx_writes_file(self, fake_textures):
+        """``export_mtlx`` returns a Path to the .mtlx file on disk."""
+        steel = pymat["Stainless Steel 304"]
+        with tempfile.TemporaryDirectory() as out:
+            path = export_mtlx(steel, Path(out))
+            assert path.exists()
+            assert path.suffix == ".mtlx"
+
+    def test_vis_method_sugar_matches_module_form(self, fake_textures):
+        """``material.vis.to_threejs()`` (method) and
+        ``pymat.vis.to_threejs(material)`` (function) yield the same dict.
+        Both are documented; both must agree."""
+        steel = pymat["Stainless Steel 304"]
+        custom = steel.with_vis(steel.vis.override(roughness=0.42))
+        method_form = custom.vis.to_threejs()
+        function_form = to_threejs(custom)
+        # ``Vis.to_threejs()`` doesn't know the owning Material's name, but
+        # all the PBR fields must agree.
+        assert method_form["roughness"] == function_form["roughness"]
+        assert method_form["metalness"] == function_form["metalness"]
+
+
+# ============================================================================
+# 5. ERROR JOURNEY — the user typos, gets a useful message
+# ============================================================================
+
+
+class TestErrorJourney:
+    """A consumer makes mistakes. Errors must echo the user's input
+    (so they can see what they typed) and offer human-readable
+    alternatives — never internal UUIDs or registry keys when the
+    user supplied a human name. Mat-vis #286 spirit."""
+
+    def test_unknown_material_echoes_input(self):
+        with pytest.raises(KeyError) as exc:
+            pymat["TotallyMadeUpMaterial"]
+        assert "TotallyMadeUpMaterial" in str(exc.value)
+
+    def test_unknown_finish_lists_available(self):
+        steel = pymat["Stainless Steel 304"]
+        available = sorted(steel.vis.finishes.keys())
+        assert len(available) >= 2, "fixture precondition — multi-finish material"
+        with pytest.raises(ValueError) as exc:
+            steel.vis.override(finish="mirror")
+        msg = str(exc.value)
+        assert "mirror" in msg  # echoes user input
+        # All actual finish names appear, not just one — consumers need
+        # the full list, not a sample.
+        for name in available:
+            assert name in msg, f"finish {name!r} missing from error: {msg}"
+
+    def test_typo_kwarg_on_override_lists_valid_keys(self):
+        """build123d-style consumer mistypes ``roughnes=`` — error must
+        point at ``roughness`` so they can fix it."""
+        steel = pymat["Stainless Steel 304"]
+        with pytest.raises(TypeError) as exc:
+            steel.vis.override(roughnes=0.5)
+        msg = str(exc.value)
+        assert "roughnes" in msg
+        assert "roughness" in msg  # the right name surfaces
+
+    def test_empty_string_lookup_rejected(self):
+        with pytest.raises(KeyError, match="empty"):
+            pymat[""]
+
+    def test_no_uuid_leaks_in_typo_error(self):
+        """Pin: no UUID-shaped strings in the human-name error path.
+        Mat-vis #286 was about UUIDs leaking into UnknownMaterialError;
+        py-mat's own KeyError for human-name lookup must not regress
+        into the same shape."""
+        import re
+
+        with pytest.raises(KeyError) as exc:
+            pymat["Stinless Steel 304"]  # close to a real name
+        msg = str(exc.value)
+        # Eight-four-four-four-twelve-hex UUID pattern
+        uuid_pat = re.compile(r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")
+        assert not uuid_pat.search(msg), f"UUID leaked into user-facing error: {msg}"
+
+    def test_unknown_tier_raises_at_assignment(self):
+        """Closes the symmetry gap with ``Vis.finish=`` — the tier
+        setter now validates against the manifest's tier list at
+        assignment time so a typo (``vis.tier = "99k"``) echoes back to
+        the consumer instead of surfacing deep inside mat-vis-client on
+        the next ``.textures`` access. Mirrors the asymmetry Bernhard
+        flagged in the broader build123d#1270 / mat-vis #280 thread."""
+        steel = pymat["Stainless Steel 304"]
+        with pytest.raises(ValueError, match="Unknown tier"):
+            steel.vis.override(tier="99k")  # no such tier in the manifest
+
+
+# ============================================================================
+# 6. PUBLIC-IMPORT JOURNEY — every name a consumer needs is non-underscore
+# ============================================================================
+
+
+class TestPublicImports:
+    """Pin the import paths a consumer should rely on. Nothing
+    underscore-prefixed should be required to use the documented API.
+    Closes py-mat #98 / mat-vis #282.
+
+    Bare-import existence checks for ``Vis`` / ``VisDeltas`` /
+    ``FinishEntry`` / ``Material`` / adapters live in
+    ``tests/test_public_api_surface.py`` (canonical module-path +
+    field-set freeze). This file pins only the consumer-visible
+    *behavior* of those imports — the headline being that
+    ``type(material.vis).__module__`` reads as the public path."""
+
+    def test_vis_module_path_is_public(self):
+        """``type(m.vis).__module__`` must read ``pymat.vis`` — not
+        ``pymat.vis._model``. Closes py-mat #98 — Bernhard's complaint
+        was that ``stainless.vis`` reported its class as living in a
+        private module, pushing him toward the underscore path."""
+        steel = pymat["Stainless Steel 304"]
+        assert type(steel.vis).__module__ == "pymat.vis"
+
+    def test_vis_importable_from_top_level_pymat(self):
+        """``from pymat import Vis`` works — closes the trailing gap of
+        py-mat #98 (which only fixed the canonical `pymat.vis.Vis` import
+        path; this test pins the convenience top-level alias). The class
+        bound at `pymat.Vis` must be the same object as `pymat.vis.Vis`,
+        not a shim."""
+        import pymat as p
+        from pymat.vis import Vis as canonical_Vis
+
+        assert hasattr(p, "Vis")
+        assert p.Vis is canonical_Vis
+
+
+# ============================================================================
+# Cross-cutting: full journey, single test
+# ============================================================================
+
+
+class TestFullJourney:
+    """The whole journey end-to-end in one test — guards against
+    inter-step regressions where each unit test passes but the chain
+    breaks at a seam."""
+
+    def test_discover_derive_attach_export(self, fake_textures):
+        # 1. Discover by human name
+        steel = pymat["Stainless Steel 304"]
+
+        # 2. Derive a polished variant without touching the registry
+        polished_vis = steel.vis.override(finish="polished", roughness=0.08)
+        polished = steel.with_vis(polished_vis)
+
+        # 3. Attach to a notional CAD wrapper
+        part = _FakeBuild123dPart("housing")
+        part.material = polished
+
+        # 4. Export to Three.js + glTF — both must reflect the override
+        three = to_threejs(part.material)
+        gltf = to_gltf(part.material)
+        assert three["roughness"] == 0.08
+        assert gltf["pbrMetallicRoughness"]["roughnessFactor"] == 0.08
+        assert gltf["name"] == "Stainless Steel 304"
+
+        # 5. Registry singleton untouched throughout — both axes of the
+        # override must remain unchanged on the registry, not just one.
+        assert steel.vis.roughness != 0.08
+        assert steel.vis.finish != "polished"

--- a/tests/test_error_messages.py
+++ b/tests/test_error_messages.py
@@ -1,0 +1,631 @@
+"""Pin the *content* of user-facing error messages.
+
+Bernhard's mat-vis #280 / #286 are the canonical example of an error path
+that fired correctly (line coverage 100%) but said useless things to the
+user — internal UUIDs instead of the human name they typed, no
+suggestions, no actionable guidance. This suite exists so a future
+refactor can't silently regress error UX.
+
+What we pin per error path:
+
+1. **User-given input echoed**: the EXACT string the user typed appears
+   in the message. Not normalized, not the resolved internal id.
+2. **Close-match suggestions** where appropriate (mirror what
+   ``pymat._lookup`` does today). Gaps are pinned as ``xfail`` —
+   each xfail = a candidate issue to file.
+3. **No internal-ID leakage** when the user supplied a human name.
+4. **Error type stability** — the documented exception class doesn't
+   silently change to something else under a "code cleanup".
+5. **Empty / whitespace input** raises clearly, doesn't silently return
+   the whole library or an empty list.
+
+Pattern: ``pytest.raises(..., match=re.escape(user_input))``. Human
+material names contain regex specials regularly — ``"Saint-Gobain"``,
+``"AlOH3"``, ``"Co60"`` — so always escape.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+import pymat
+
+# Public-error vocabulary: the set of exception class names a consumer
+# may reasonably ``except`` for. If a refactor changes a documented
+# error to something outside this set it should be a deliberate API
+# bump, not a stealth rename.
+_PUBLIC_ERROR_VOCAB = frozenset(
+    {
+        "KeyError",
+        "ValueError",
+        "TypeError",
+        "AttributeError",
+        "FileNotFoundError",
+        "LookupError",  # parent of KeyError; tolerated
+    }
+)
+
+# Sentinel-ish strings that internal-ID leakage tests should never see
+# in a human-name miss. Internal keys ("s304", "s316L") and UUID-like
+# tokens are the obvious tells.
+_UUID_RE = re.compile(r"\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b", re.I)
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _load_all_categories():
+    """Load the full library once per module so tests see real data.
+
+    The repo's autouse ``clear_registry`` (function-scoped, in
+    conftest.py) wipes the registry between tests, so we re-load here
+    in a fixture that runs INSIDE the function-scoped clear. Net effect:
+    every test starts with the full library loaded.
+    """
+    pymat.load_all()
+
+
+@pytest.fixture(autouse=True)
+def _reload_per_test():
+    pymat.load_all()
+    yield
+
+
+# ── Helpers ───────────────────────────────────────────────────────
+
+
+def _assert_input_echoed(msg: str, user_input: str) -> None:
+    """The exact user-supplied string (or its ``repr``) must appear."""
+    assert user_input in msg or repr(user_input) in msg, (
+        f"user input {user_input!r} not echoed in error message:\n  {msg!r}"
+    )
+
+
+def _assert_no_uuid_leakage(msg: str) -> None:
+    assert not _UUID_RE.search(msg), f"UUID leaked into human-name error message:\n  {msg!r}"
+
+
+def _assert_error_class_public(exc: BaseException) -> None:
+    name = type(exc).__name__
+    assert name in _PUBLIC_ERROR_VOCAB, (
+        f"{name} is not in the public-error vocabulary {_PUBLIC_ERROR_VOCAB}; "
+        f"a documented error path should not raise {name}"
+    )
+
+
+# ────────────────────────────────────────────────────────────────────
+# 1. pymat[name] — the gold-standard surface
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestSubscriptInputEcho:
+    """``pymat["..."]`` — already does the right thing. Pin it so we don't
+    regress."""
+
+    @pytest.mark.parametrize(
+        "user_input",
+        [
+            "Portoro Green Marble",
+            "Saint-Gobain LYSO:CeXYZ_unknown_variant",
+            "AlOH3",
+            "Co60",
+            "Steel (annealed)",
+            # Real punctuation from real pasted catalog entries
+            "316/316L Dual-Cert",
+        ],
+    )
+    def test_miss_echoes_exact_input(self, user_input: str):
+        with pytest.raises(KeyError) as excinfo:
+            _ = pymat[user_input]
+        _assert_input_echoed(str(excinfo.value), user_input)
+        _assert_error_class_public(excinfo.value)
+
+    def test_miss_no_uuid_leakage(self):
+        with pytest.raises(KeyError) as excinfo:
+            _ = pymat["Portoro Green Marble"]
+        _assert_no_uuid_leakage(str(excinfo.value))
+
+    def test_typo_includes_close_matches(self):
+        with pytest.raises(KeyError) as excinfo:
+            _ = pymat["stainles stell 304"]
+        msg = str(excinfo.value)
+        _assert_input_echoed(msg, "stainles stell 304")
+        # The gold-standard error mentions "Close matches:".
+        assert "Close matches" in msg or "stainless" in msg.lower(), (
+            f"typo error must offer close matches; got: {msg!r}"
+        )
+
+    def test_ambiguous_lists_candidates(self):
+        from pymat import Material, registry
+
+        m1 = Material(name="Duplicate Surface Name")
+        m2 = Material(name="Duplicate Surface Name")
+        try:
+            registry.register("dupe_a", m1)
+            registry.register("dupe_b", m2)
+            with pytest.raises(KeyError) as excinfo:
+                _ = pymat["Duplicate Surface Name"]
+            msg = str(excinfo.value)
+            _assert_input_echoed(msg, "Duplicate Surface Name")
+            assert "Ambiguous" in msg or "match" in msg
+        finally:
+            registry._REGISTRY.pop("dupe_a", None)
+            registry._REGISTRY.pop("dupe_b", None)
+
+
+class TestSubscriptEmptyAndType:
+    """Already pinned in test_lookup; mirror here so this file is a
+    self-contained pin. Plus add a few we DON'T pin elsewhere."""
+
+    @pytest.mark.parametrize("bad", ["", "   ", "\t\n  "])
+    def test_empty_or_whitespace_raises_clearly(self, bad: str):
+        with pytest.raises(KeyError, match="non-empty"):
+            _ = pymat[bad]
+
+    def test_non_string_says_what_it_got(self):
+        with pytest.raises(TypeError) as excinfo:
+            _ = pymat[42]
+        msg = str(excinfo.value)
+        # Should mention the offending type
+        assert "int" in msg, f"TypeError must name the bad type; got: {msg!r}"
+
+
+# ────────────────────────────────────────────────────────────────────
+# 2. pymat.search — empty, no-results
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestSearchInputContract:
+    """``pymat.search`` returns ``[]`` for empty / whitespace queries by
+    docstring contract. That's a soft contract — pinning it here so a
+    "be helpful" refactor doesn't decide to surface the entire library
+    on empty input.
+    """
+
+    @pytest.mark.parametrize("bad", ["", "   ", "\t\n"])
+    def test_empty_search_returns_empty_list(self, bad: str):
+        # Contract: empty/whitespace query → empty list. Not the full
+        # library. Not an error. (See _normalize in search.py.)
+        assert pymat.search(bad) == []
+        assert pymat.search(bad, exact=True) == []
+
+    @pytest.mark.xfail(
+        reason=(
+            "search('totallybogus_xyz_12345') currently returns several lyso "
+            "materials because the rapidfuzz partial_ratio threshold "
+            "misfires on long underscore-separated tokens. There is no error "
+            "channel for 'no results would be more honest than these results' "
+            "today. Candidate issue: tighten the threshold or surface a "
+            "warning when total score is way below the top genuine hit."
+        ),
+        strict=False,
+    )
+    def test_truly_unrelated_query_returns_empty(self):
+        # A long, clearly-bogus query should not match real materials.
+        # Currently does — see xfail reason.
+        assert pymat.search("zzzzz_yyyyy_xxxxx_wwwww_unrelated") == []
+
+
+# ────────────────────────────────────────────────────────────────────
+# 3. pymat.<attr> — module-level lazy attribute access
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestModuleAttributeMiss:
+    def test_unknown_material_attr_lists_available(self):
+        with pytest.raises(AttributeError) as excinfo:
+            _ = pymat.totally_not_a_real_material
+        msg = str(excinfo.value)
+        _assert_input_echoed(msg, "totally_not_a_real_material")
+        # Already lists "Available materials" today
+        assert "Available" in msg, f"attribute miss should list available; got: {msg!r}"
+
+    @pytest.mark.xfail(
+        reason=(
+            "pymat.<typo> uses an exact-list-of-bases lookup with no fuzzy "
+            "fallback — `pymat.stinless` is a hard miss with no 'did you "
+            "mean stainless?' hint. Candidate issue: route attribute miss "
+            "through the same fuzzy-suggest helper as _lookup."
+        ),
+        strict=False,
+    )
+    def test_module_attr_typo_offers_suggestion(self):
+        with pytest.raises(AttributeError) as excinfo:
+            _ = pymat.stinless
+        msg = str(excinfo.value)
+        # Today's behavior: just lists every base. We want the close
+        # match (stainless) called out.
+        assert "stainless" in msg.lower() and (
+            "did you mean" in msg.lower() or "close" in msg.lower() or "suggest" in msg.lower()
+        )
+
+
+# ────────────────────────────────────────────────────────────────────
+# 4. Material.<child> — variant access on a Material
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestMaterialVariantMiss:
+    def test_missing_variant_echoes_parent_name_and_input(self):
+        with pytest.raises(AttributeError) as excinfo:
+            _ = pymat.stainless.totally_not_a_grade
+        msg = str(excinfo.value)
+        _assert_input_echoed(msg, "totally_not_a_grade")
+        # Parent identity should be in the message so user knows where
+        # they were looking
+        assert "Stainless Steel" in msg or "stainless" in msg.lower()
+        # Message lists existing variants
+        assert "Available" in msg
+
+    @pytest.mark.xfail(
+        reason=(
+            "Material.__getattr__ lists all available variants verbatim but "
+            "doesn't offer a 'did you mean s304?' for typos like "
+            "stainless.s30 (intent: s304). Candidate issue: fuzzy-suggest "
+            "the closest available child."
+        ),
+        strict=False,
+    )
+    def test_variant_typo_offers_close_suggestion(self):
+        with pytest.raises(AttributeError) as excinfo:
+            _ = pymat.stainless.s30  # typo for s304
+        msg = str(excinfo.value).lower()
+        assert "did you mean" in msg or "close" in msg or "suggest" in msg
+
+
+# ────────────────────────────────────────────────────────────────────
+# 5. load_category — load-time errors
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestLoadCategoryMiss:
+    def test_unknown_category_echoes_input(self):
+        with pytest.raises(FileNotFoundError) as excinfo:
+            pymat.load_category("totally_made_up_category")
+        msg = str(excinfo.value)
+        _assert_input_echoed(msg, "totally_made_up_category")
+        _assert_error_class_public(excinfo.value)
+
+    @pytest.mark.xfail(
+        reason=(
+            "load_category('totally_made_up_category') raises "
+            "FileNotFoundError with the resolved filesystem path but does "
+            "NOT list available categories or suggest the closest match. "
+            "Candidate issue: enumerate categories in the error and offer "
+            "fuzzy suggestion."
+        ),
+        strict=False,
+    )
+    def test_unknown_category_lists_available(self):
+        with pytest.raises(FileNotFoundError) as excinfo:
+            pymat.load_category("metls")  # typo for metals
+        msg = str(excinfo.value).lower()
+        assert "metals" in msg and ("available" in msg or "did you mean" in msg or "close" in msg)
+
+
+# ────────────────────────────────────────────────────────────────────
+# 6. Vis.finish setter
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestVisFinishUnknown:
+    def test_unknown_finish_lists_available(self):
+        v = pymat.stainless.vis
+        available = list(v.finishes.keys())
+        assert available, "fixture sanity: stainless must have finishes"
+
+        with pytest.raises(ValueError) as excinfo:
+            v.finish = "shiny_nonexistent"
+        msg = str(excinfo.value)
+        _assert_input_echoed(msg, "shiny_nonexistent")
+        for finish_name in available:
+            assert finish_name in msg, (
+                f"available finish {finish_name!r} missing from error: {msg!r}"
+            )
+
+    def test_unknown_finish_error_type_is_valueerror(self):
+        v = pymat.stainless.vis
+        with pytest.raises(ValueError) as excinfo:
+            v.finish = "bogus"
+        _assert_error_class_public(excinfo.value)
+
+
+# ────────────────────────────────────────────────────────────────────
+# 7. Vis.tier setter
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestVisTierUnknown:
+    """Tier validation is the symmetric case to finish validation. Today,
+    ``vis.tier = "bogus"`` succeeds silently — the bad tier reaches
+    mat-vis-client at fetch time, where it surfaces a less-targeted
+    error. This is exactly the class of bug Bernhard hit (#280): the
+    error fires at the wrong layer with the wrong context.
+    """
+
+    def test_unknown_tier_raises_with_input_echoed(self):
+        """``Vis.tier = 'bogus'`` raises ``ValueError`` with the input
+        echoed and the available tiers listed — mirrors the
+        ``Vis.finish`` pattern. Closes the asymmetry between the two
+        identity setters and the at-wrong-layer / no-input-echo class
+        of bug Bernhard hit in mat-vis #280."""
+        v = pymat.stainless.vis
+        with pytest.raises(ValueError) as excinfo:
+            v.tier = "definitely_not_a_real_tier"
+        msg = str(excinfo.value)
+        _assert_input_echoed(msg, "definitely_not_a_real_tier")
+        # The available tiers must be listed — a consumer needs the
+        # actual options, not just "tier" in the error text.
+        assert "1k" in msg, f"available-tiers list missing from error: {msg!r}"
+
+
+# ────────────────────────────────────────────────────────────────────
+# 8. Vis.override unknown kwargs (typo guard)
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestVisOverrideUnknownKwarg:
+    def test_typo_kwarg_echoes_typo_and_lists_valid(self):
+        v = pymat.stainless.vis
+        with pytest.raises(TypeError) as excinfo:
+            v.override(roughnes=0.5)  # typo for roughness
+        msg = str(excinfo.value)
+        # Pin: the actual typo'd kwarg name appears verbatim
+        _assert_input_echoed(msg, "roughnes")
+        # Pin: valid kwargs are listed so the user can correct
+        assert "roughness" in msg, f"valid keys must include roughness: {msg!r}"
+
+
+# ────────────────────────────────────────────────────────────────────
+# 9. Vis.from_toml malformed entries
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestVisFromTomlMalformed:
+    def test_slashed_string_form_echoes_value(self):
+        from pymat.vis._model import Vis
+
+        with pytest.raises(ValueError) as excinfo:
+            Vis.from_toml({"finishes": {"brushed": "ambientcg/Metal032"}})
+        msg = str(excinfo.value)
+        # Pin: bad value AND finish name both echoed
+        assert "brushed" in msg
+        _assert_input_echoed(msg, "ambientcg/Metal032")
+
+    def test_malformed_inline_table_echoes_finish_name(self):
+        from pymat.vis._model import Vis
+
+        with pytest.raises(ValueError) as excinfo:
+            Vis.from_toml({"finishes": {"shiny": {"source": "x"}}})  # missing id
+        msg = str(excinfo.value)
+        assert "shiny" in msg
+        # Documented expectation: explain what was expected
+        assert "source" in msg and "id" in msg
+
+
+# ────────────────────────────────────────────────────────────────────
+# 10. source_id read-only setter
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestSourceIdReadOnly:
+    def test_setter_raises_attribute_error_with_guidance(self):
+        v = pymat.stainless.vis
+        with pytest.raises(AttributeError) as excinfo:
+            v.source_id = "polyhaven/Metal999"
+        msg = str(excinfo.value)
+        _assert_error_class_public(excinfo.value)
+        # The error must guide the user to the replacement API
+        assert "source" in msg and "material_id" in msg, (
+            f"read-only error must point at the replacement API: {msg!r}"
+        )
+
+
+# ────────────────────────────────────────────────────────────────────
+# 11. Material.with_vis bad input
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestMaterialWithVisBadArg:
+    def test_non_vis_arg_says_what_it_got(self):
+        from pymat import Material
+
+        m = Material(name="probe")
+        with pytest.raises(TypeError) as excinfo:
+            m.with_vis("not a Vis")
+        msg = str(excinfo.value)
+        # Pin: error names the actual offending type
+        assert "str" in msg, f"with_vis error must name the bad type: {msg!r}"
+        _assert_error_class_public(excinfo.value)
+
+
+# ────────────────────────────────────────────────────────────────────
+# 12. Material.apply_to wrong target
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestApplyToBadTarget:
+    def test_immutable_target_says_what_it_got(self):
+        m = pymat.stainless
+        with pytest.raises(TypeError) as excinfo:
+            m.apply_to(42)
+        msg = str(excinfo.value)
+        assert "int" in msg, f"apply_to error must name the bad type: {msg!r}"
+        _assert_error_class_public(excinfo.value)
+
+
+# ────────────────────────────────────────────────────────────────────
+# 13. Adapter contract on a Material with no vis mapping
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestAdapterNoMapping:
+    """``to_threejs(Material(name="X"))`` — what does it do?
+
+    Today: it returns a default-PBR dict (grey 0.5 roughness, 0 metallic
+    etc.) and never raises. Documented: ``has_mapping`` False → empty
+    textures dict. So a custom material with no Vis mapping silently
+    renders as default grey.
+
+    Pin the silent-success contract today, and xfail the "should warn
+    or raise" preference. If we ever decide to make this loud, the xfail
+    flips to a real assertion.
+    """
+
+    def test_no_mapping_to_threejs_returns_dict_silently(self):
+        from pymat import Material
+        from pymat import vis as vis_mod
+
+        m = Material(name="Bare Custom")
+        result = vis_mod.to_threejs(m)
+        # Pin the documented behavior: returns a usable dict, no raise.
+        assert isinstance(result, dict)
+        assert result.get("type") == "MeshPhysicalMaterial"
+
+    def test_no_mapping_to_gltf_includes_material_name(self):
+        """The user supplied a Material name — it must round-trip into
+        the glTF output's ``name`` field. (The user's name is the most
+        load-bearing piece of identity for an asset that fails to fetch
+        textures: it's how they'll find which call site set up the
+        material.)
+        """
+        from pymat import Material
+        from pymat import vis as vis_mod
+
+        m = Material(name="MyAlloyXYZ")
+        result = vis_mod.to_gltf(m)
+        assert result.get("name") == "MyAlloyXYZ"
+
+    @pytest.mark.xfail(
+        reason=(
+            "to_threejs / to_gltf on a Material without a Vis mapping "
+            "silently return default-PBR scalars (grey, roughness 0.5). "
+            "This is the same UX failure mode as mat-vis #280: a downstream "
+            "consumer ends up with an unexpected output and no breadcrumb "
+            "back to the call site that failed to set up vis. Candidate "
+            "issue: emit a warning (or raise on a strict=True flag) when "
+            "the adapter receives a Material whose vis.has_mapping is "
+            "False, with the Material.name echoed."
+        ),
+        strict=False,
+    )
+    def test_no_mapping_should_warn_or_raise(self):
+        import warnings
+
+        from pymat import Material
+        from pymat import vis as vis_mod
+
+        m = Material(name="MyBareAlloy")
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            vis_mod.to_threejs(m)
+        # Either a warning is emitted (preferred) or it raises (also
+        # acceptable). Today neither happens.
+        assert any("MyBareAlloy" in str(w.message) for w in caught), (
+            "adapter on no-mapping Material must signal the silent default"
+        )
+
+
+# ────────────────────────────────────────────────────────────────────
+# 14. Vis.fetch / textures error envelope (Bernhard's #280 case)
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestFetchErrorEnvelope:
+    """Reach-down into a real ``Vis.textures`` access on a bad mapping.
+
+    We patch the underlying mat-vis-client to RAISE the kind of error
+    Bernhard saw (a UUID-laden ``MaterialNotStagedError``). The contract
+    we want from py-mat: it should NOT swallow that error AND it should
+    add the human name (``Material.name``) so the user can find the call
+    site even if mat-vis-client's message is opaque.
+
+    Today: py-mat just bubbles. xfail the wrap.
+    """
+
+    @pytest.mark.xfail(
+        reason=(
+            "When mat-vis-client raises (e.g. MaterialNotStagedError) on "
+            "Vis.textures access, py-mat doesn't wrap or annotate the "
+            "exception with the owning Material.name or the user-supplied "
+            "vis identity. Bernhard (mat-vis #280) had to read a UUID-only "
+            "traceback to figure out WHICH material in his scene failed. "
+            "Candidate issue: catch the client error in Vis._fetch and "
+            "re-raise with Material.name + (source, material_id, tier) "
+            "appended, so the user can find their call site."
+        ),
+        strict=False,
+    )
+    def test_fetch_failure_is_annotated_with_user_context(self, monkeypatch):
+        import mat_vis_client as _client_mod
+
+        from pymat import Material
+
+        class FailingClient:
+            def fetch_all_textures(self, source, material_id, *, tier="1k"):
+                # Mimic mat-vis-client's MaterialNotStagedError shape:
+                # UUID + tier, NO user-given name.
+                raise RuntimeError(
+                    f"material '34f2c1f9-6169-4975-b5d8-4e21f49ddf55' "
+                    f"exists in '{source}' index but is not staged for "
+                    f"tier '{tier}'. Needs a re-bake."
+                )
+
+            def channels(self, *args, **kwargs):
+                return ["color"]
+
+        monkeypatch.setattr(_client_mod, "_client", FailingClient())
+
+        m = Material(
+            name="MySpecificCarPaint",
+            vis={"source": "gpuopen", "material_id": "MySpecificCarPaint"},
+        )
+
+        with pytest.raises(Exception) as excinfo:
+            _ = m.vis.textures
+        msg = str(excinfo.value)
+        # The user's Material.name should be in the error chain
+        # somewhere — that's the missing piece in #280.
+        assert "MySpecificCarPaint" in msg, (
+            "fetch failure must echo the human-given name; "
+            "mat-vis-client's UUID-only message is exactly the #280 bug"
+        )
+
+
+# ────────────────────────────────────────────────────────────────────
+# 15. pymat-mcp _not_found envelope (skipped if package not installed)
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestMcpNotFoundEnvelope:
+    """The MCP tool layer wraps misses in a ``did_you_mean`` envelope.
+    We pin the envelope shape AND the input echo for that surface too.
+    Skipped if pymat-mcp isn't installed in the test env.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _require_mcp(self):
+        pytest.importorskip("pymat_mcp.tools")
+
+    def test_get_material_miss_echoes_input(self):
+        from pymat_mcp.tools import get_material
+
+        result = get_material("Portoro Green Marble")
+        assert "error" in result
+        _assert_input_echoed(result["error"], "Portoro Green Marble")
+
+    def test_get_material_miss_includes_did_you_mean_envelope(self):
+        from pymat_mcp.tools import get_material
+
+        result = get_material("Stinless 304")  # typo
+        assert "did_you_mean" in result, "MCP miss envelope must include did_you_mean key"
+        # Each suggestion is a {key, name} pair (per docstring contract)
+        for s in result["did_you_mean"]:
+            assert "key" in s and "name" in s
+
+    def test_get_material_miss_no_uuid_leakage(self):
+        from pymat_mcp.tools import get_material
+
+        result = get_material("Portoro Green Marble")
+        msg = result["error"]
+        _assert_no_uuid_leakage(msg)

--- a/tests/test_public_api_surface.py
+++ b/tests/test_public_api_surface.py
@@ -1,0 +1,575 @@
+"""Pin the public API surface contract for py-materials.
+
+The bug this guards against (closes #98 / mat-vis #282): a class is in
+``pymat.vis.__all__`` and importable from ``pymat.vis``, but its
+``__module__`` still points at the underscore-prefixed private location
+(``pymat.vis._model``). Then ``type(obj)``, ``repr``, IDE auto-import,
+and Sphinx all push downstream code (build123d) toward the private path
+we don't want to support.
+
+``tests/test_vis.py::TestPublicApiContract`` pins ``__module__`` for
+``Vis`` / ``VisDeltas`` / ``FinishEntry``. This file extends the
+contract to:
+
+1. Module-path metadata for **every** name in ``pymat.__all__`` and
+   ``pymat.vis.__all__`` — no underscore-prefixed component anywhere
+   in ``__module__`` for first-party types (third-party re-exports
+   like ``MatVisClient`` are exempt).
+2. ``__all__`` integrity — every listed name resolves; nothing in
+   ``__all__`` raises; documented public submodules are listed.
+3. ``dir(pymat)`` discoverability for lazy-loaded base materials.
+4. Public type construction — every public class can be built with
+   documented kwargs.
+5. Field-set freeze for ``Vis``, ``VisDeltas``, ``FinishEntry``,
+   ``Material``, ``Source`` — pin the canonical field set so a rename
+   trips the test.
+6. ``type(...).__module__`` flow — instances out of public APIs
+   (``stainless.vis``, ``Material("X").vis``, ``Vis.override(...)``)
+   all surface the public path.
+7. Sphinx-style canonical-name pin — for every public name N,
+   ``import_module(N.__module__).N`` round-trips to the same object.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import importlib
+import inspect
+from typing import Any
+
+import pytest
+
+# ── Public-surface inventory ─────────────────────────────────
+
+# First-party types in ``pymat.__all__`` whose ``__module__`` we control
+# (not third-party re-exports like ``ureg`` / ``MatVisClient``).
+PYMAT_FIRSTPARTY_NAMES = [
+    "Material",
+    "AllProperties",
+    "MechanicalProperties",
+    "ThermalProperties",
+    "ElectricalProperties",
+    "OpticalProperties",
+    "ManufacturingProperties",
+    "ComplianceProperties",
+    "SourcingProperties",
+    "load_toml",
+    "load_category",
+    "search",
+    "enrich_from_periodictable",
+    "enrich_from_matproj",
+    "enrich_all",
+]
+
+# First-party names in ``pymat.vis.__all__`` whose ``__module__`` we
+# control. ``MatVisClient`` lives in ``mat_vis_client`` (separate PyPI
+# package) — exempt by design. Functions imported from
+# ``mat_vis_client`` (``get_manifest``, ``prefetch``, ``rowmap_entry``,
+# ``seed_indexes``) are also third-party and exempt.
+PYMAT_VIS_FIRSTPARTY_NAMES = [
+    "client",
+    "search",
+    "fetch",
+    "Vis",
+    "VisDeltas",
+    "FinishEntry",
+    "to_threejs",
+    "to_gltf",
+    "export_mtlx",
+]
+
+PYMAT_VIS_THIRDPARTY_NAMES = [
+    "MatVisClient",
+    "get_manifest",
+    "prefetch",
+    "rowmap_entry",
+    "seed_indexes",
+]
+
+# Public *types* (constructible classes) in pymat.__all__.
+PYMAT_PUBLIC_TYPES = [
+    "Material",
+    "AllProperties",
+    "MechanicalProperties",
+    "ThermalProperties",
+    "ElectricalProperties",
+    "OpticalProperties",
+    "ManufacturingProperties",
+    "ComplianceProperties",
+    "SourcingProperties",
+]
+
+# Public types in pymat.vis.__all__.
+PYMAT_VIS_PUBLIC_TYPES = ["Vis", "VisDeltas", "FinishEntry"]
+
+# Base materials advertised by ``pymat.__dir__`` — every category in
+# ``_CATEGORY_BASES`` should be lazy-loadable. Pulling from the module
+# rather than re-listing keeps this in sync with src/pymat/__init__.py.
+import pymat as _pymat  # noqa: E402
+
+ALL_KNOWN_BASE_MATERIALS = sorted({b for bases in _pymat._CATEGORY_BASES.values() for b in bases})
+
+# ``pymat.__dir__`` currently omits these entries that ARE in
+# ``pymat.__all__`` (the hardcoded ``base_exports`` list inside
+# ``__dir__`` doesn't include them). IDE tab-completion misses them —
+# documented as a gap below. Excluded from the per-name dir() pin so
+# the test reflects current reality; the gap test enforces the broader
+# invariant via xfail.
+_DIR_FIRSTPARTY_GAPS = {"search", "ureg", "factories", "vis"}
+
+
+# ── 1. Module-path metadata ──────────────────────────────────
+
+
+class TestModulePathMetadata:
+    """Every first-party name in a public ``__all__`` must have a
+    ``__module__`` whose components are all non-underscore-prefixed.
+    The motivating bug had ``Vis.__module__ == "pymat.vis._model"``;
+    the leading-underscore segment ``_model`` is what tools read as
+    "private" and surface to users."""
+
+    @staticmethod
+    def _has_private_segment(module_path: str) -> bool:
+        """A dotted module path is "private" if any segment starts with
+        an underscore. ``pymat.vis._model`` is private; ``pymat.core``
+        is not (single leading dunder/underscore-free segments)."""
+        return any(seg.startswith("_") for seg in module_path.split("."))
+
+    @pytest.mark.parametrize("name", PYMAT_FIRSTPARTY_NAMES)
+    def test_pymat_export_has_no_private_module_segment(self, name: str) -> None:
+        import pymat
+
+        obj = getattr(pymat, name)
+        mod = getattr(obj, "__module__", None)
+        assert mod is not None, f"pymat.{name} has no __module__"
+        assert not self._has_private_segment(mod), (
+            f"pymat.{name}.__module__ = {mod!r} contains an underscore-"
+            "prefixed segment; users get pushed toward the private path."
+        )
+
+    # Note: the weaker `_has_private_segment` check on PYMAT_VIS_FIRSTPARTY_NAMES
+    # was dropped — for ``Vis`` / ``VisDeltas`` / ``FinishEntry`` the strict
+    # equality test below subsumes it, and for the other re-exports
+    # (``MatVisClient``, ``to_threejs``, etc.) the canonical-name round-trip
+    # in ``TestCanonicalNameRoundTrip`` catches the same regression.
+
+    @pytest.mark.parametrize("name", PYMAT_VIS_PUBLIC_TYPES)
+    def test_pymat_vis_public_types_module_is_public_path(self, name: str) -> None:
+        """Stronger pin for the three domain types specifically called
+        out as public in ``pymat/vis/__init__.py``: ``__module__`` must
+        equal the public re-export path, not just be private-segment-free.
+        Catches a future move from ``_model`` to e.g. ``_internal`` that
+        forgets to re-pin."""
+        import pymat.vis
+
+        obj = getattr(pymat.vis, name)
+        assert obj.__module__ == "pymat.vis", (
+            f"pymat.vis.{name}.__module__ = {obj.__module__!r}; "
+            "expected 'pymat.vis' so type(...) / repr / IDE auto-import "
+            "all surface the public path."
+        )
+
+
+# ── 2. __all__ integrity ─────────────────────────────────────
+
+
+class TestAllIntegrity:
+    """Every name in ``__all__`` resolves on the module without raising,
+    and the documented public submodules are present."""
+
+    def test_pymat_all_entries_resolve(self) -> None:
+        """Every name in ``pymat.__all__`` resolves on the module.
+
+        Implicitly enforced at collection time by ``from pymat import *``,
+        but pinned explicitly here so a regression points at the public-
+        API contract instead of cascading-failing across the suite."""
+        import pymat
+
+        for name in pymat.__all__:
+            obj = getattr(pymat, name, None)
+            assert obj is not None, f"pymat.{name} resolved to None"
+
+    def test_pymat_vis_all_entries_resolve(self) -> None:
+        import pymat.vis
+
+        for name in pymat.vis.__all__:
+            assert hasattr(pymat.vis, name), f"pymat.vis.{name} missing despite being in __all__"
+            obj = getattr(pymat.vis, name)
+            assert obj is not None, f"pymat.vis.{name} resolved to None"
+
+    def test_pymat_vis_adapters_in_all(self) -> None:
+        """``adapters`` is a public submodule and must be in ``__all__``
+        so ``from pymat.vis import *`` brings it along and ``dir(pymat
+        .vis)`` lists it as public."""
+        import pymat.vis
+
+        assert "adapters" in pymat.vis.__all__
+
+    def test_pymat_vis_in_pymat_all(self) -> None:
+        """``pymat.vis`` is the canonical entry point for adapters /
+        client / domain types; it must appear in ``pymat.__all__`` so
+        downstream code can rely on ``from pymat import vis``."""
+        import pymat
+
+        assert "vis" in pymat.__all__
+
+    def test_pymat_vis_thirdparty_reexports_resolve(self) -> None:
+        """Names re-exported from ``mat_vis_client`` are exempt from the
+        private-segment rule (their ``__module__`` legitimately points
+        at the upstream package), but they MUST resolve — the re-export
+        is part of the contract advertised in the module docstring."""
+        import pymat.vis
+
+        for name in PYMAT_VIS_THIRDPARTY_NAMES:
+            assert getattr(pymat.vis, name) is not None, (
+                f"pymat.vis.{name} re-export from mat_vis_client missing"
+            )
+
+
+# ── 3. dir() discoverability ─────────────────────────────────
+
+
+class TestDirDiscoverability:
+    """``dir(pymat)`` drives IDE tab-completion. Every base material in
+    ``_CATEGORY_BASES`` must be reachable so users discover ``stainless``,
+    ``aluminum``, ``lyso`` etc. without reading the docs."""
+
+    @pytest.mark.parametrize("name", ALL_KNOWN_BASE_MATERIALS)
+    def test_base_material_in_pymat_dir(self, name: str) -> None:
+        import pymat
+
+        assert name in dir(pymat), (
+            f"base material {name!r} missing from dir(pymat); IDE tab-completion won't surface it."
+        )
+
+    # Note: per-name "is name in dir(pymat)" pad was dropped — the loop-form
+    # ``test_all_pymat_all_entries_in_dir`` below pins the same contract for
+    # every name in ``__all__``, with a single failing test point that lists
+    # the missing names instead of one parametrized failure per missing name.
+
+    def test_all_pymat_all_entries_in_dir(self) -> None:
+        """Every name in ``__all__`` is reachable via ``dir(pymat)``.
+
+        ``pymat.__dir__`` derives from ``__all__`` (3.10.1) so adding a
+        name to ``__all__`` automatically surfaces it in tab-completion;
+        previously the function hardcoded a subset and silently dropped
+        ``search``, ``ureg``, ``factories``, ``vis``."""
+        import pymat
+
+        missing = sorted(set(pymat.__all__) - set(dir(pymat)))
+        assert missing == [], f"__all__ entries missing from dir(): {missing}"
+
+
+# ── 4. Public type construction ──────────────────────────────
+
+
+class TestPublicTypeConstruction:
+    """Every public class must be constructible with its documented
+    kwargs. If a future PR removes a public field silently, the build
+    breaks — but the constructor stays callable. This catches that gap
+    by exercising kwargs we promise to support."""
+
+    def test_material_minimum_kwargs(self) -> None:
+        from pymat import Material
+
+        m = Material(name="probe")
+        assert m.name == "probe"
+
+    def test_material_documented_kwargs(self) -> None:
+        from pymat import Material
+
+        m = Material(
+            name="Steel",
+            density=7.8,
+            color=(0.7, 0.7, 0.7),
+            formula="Fe",
+            mechanical={"density": 7.8, "youngs_modulus": 200},
+            thermal={"melting_point": 1500},
+            electrical={"resistivity": 7.2e-7},
+            optical={"transparency": 0},
+            vis={"metallic": 1.0, "roughness": 0.15},
+        )
+        assert m.properties.mechanical.density == 7.8
+        assert m.properties.mechanical.youngs_modulus == 200
+        assert m.vis.metallic == 1.0
+        assert m.vis.roughness == 0.15
+
+    @pytest.mark.parametrize("name", PYMAT_PUBLIC_TYPES[1:])  # skip Material (handled above)
+    def test_property_dataclass_default_construction(self, name: str) -> None:
+        """All ``*Properties`` dataclasses construct with no args (every
+        field has a default)."""
+        import pymat
+
+        cls = getattr(pymat, name)
+        instance = cls()
+        assert dataclasses.is_dataclass(instance)
+
+    @pytest.mark.parametrize("name", PYMAT_VIS_PUBLIC_TYPES)
+    def test_vis_public_type_construction(self, name: str) -> None:
+        import pymat.vis
+
+        cls = getattr(pymat.vis, name)
+        if name == "Vis":
+            instance = cls()
+            assert instance.source is None
+        elif name == "VisDeltas":
+            # TypedDict — instantiate via dict literal
+            instance = cls(roughness=0.5)
+            assert instance.get("roughness") == 0.5
+        elif name == "FinishEntry":
+            instance = cls(source="ambientcg", id="Metal032")
+            assert instance["source"] == "ambientcg"
+            assert instance["id"] == "Metal032"
+
+
+# ── 5. Field-set freeze ──────────────────────────────────────
+
+
+# Canonical field sets — a future rename has to update these or the
+# test goes red. Order doesn't matter (we compare as sets), but a
+# silent removal/rename is caught.
+VIS_FIELDS = frozenset(
+    {
+        "source",
+        "material_id",
+        "tier",
+        "finishes",
+        "roughness",
+        "metallic",
+        "base_color",
+        "ior",
+        "transmission",
+        "clearcoat",
+        "emissive",
+    }
+)
+
+VISDELTAS_KEYS = frozenset(
+    {
+        "source",
+        "material_id",
+        "tier",
+        "finishes",
+        "roughness",
+        "metallic",
+        "base_color",
+        "ior",
+        "transmission",
+        "clearcoat",
+        "emissive",
+        "finish",
+    }
+)
+
+FINISHENTRY_KEYS = frozenset({"source", "id"})
+
+# ``Material`` exposes a public constructor with these documented kwargs
+# (per the docstring on ``Material.__init__``). We freeze the kwargs of
+# the constructor — the dataclass-internal field set includes private
+# bookkeeping that we don't care about pinning here.
+MATERIAL_INIT_KWARGS = frozenset(
+    {
+        "name",
+        "density",
+        "formula",
+        "composition",
+        "color",
+        "grade",
+        "temper",
+        "treatment",
+        "vendor",
+        "mechanical",
+        "thermal",
+        "electrical",
+        "optical",
+        "vis",
+        "manufacturing",
+        "compliance",
+        "sourcing",
+        "properties",
+        "parent",
+        "_key",
+        "_sources",
+    }
+)
+
+SOURCE_FIELDS = frozenset({"citation", "kind", "ref", "license", "note"})
+
+
+class TestFieldSetFreeze:
+    """Pin the canonical field set of every public dataclass / TypedDict.
+    Renames or removals trip the freeze, forcing the PR author to update
+    this test (the moment of truth: are you really intending to break
+    every downstream caller?)."""
+
+    def test_vis_public_field_set(self) -> None:
+        from pymat.vis import Vis
+
+        # Public fields = dataclass fields excluding underscore-prefixed.
+        public = {f.name for f in dataclasses.fields(Vis) if not f.name.startswith("_")}
+        assert public == VIS_FIELDS, (
+            f"Vis public field set drifted.\n  got:  {sorted(public)}\n  want: {sorted(VIS_FIELDS)}"
+        )
+
+    def test_visdeltas_keys(self) -> None:
+        from pymat.vis import VisDeltas
+
+        keys = set(VisDeltas.__annotations__)
+        assert keys == VISDELTAS_KEYS, (
+            f"VisDeltas keys drifted.\n  got:  {sorted(keys)}\n  want: {sorted(VISDELTAS_KEYS)}"
+        )
+
+    def test_finishentry_keys(self) -> None:
+        from pymat.vis import FinishEntry
+
+        keys = set(FinishEntry.__annotations__)
+        assert keys == FINISHENTRY_KEYS, (
+            f"FinishEntry keys drifted.\n  got:  {sorted(keys)}\n  want: {sorted(FINISHENTRY_KEYS)}"
+        )
+
+    def test_material_init_kwargs(self) -> None:
+        from pymat import Material
+
+        sig = inspect.signature(Material.__init__)
+        # Drop ``self``
+        kwargs = {p for p in sig.parameters if p != "self"}
+        assert kwargs == MATERIAL_INIT_KWARGS, (
+            f"Material.__init__ kwargs drifted.\n"
+            f"  got:  {sorted(kwargs)}\n  want: {sorted(MATERIAL_INIT_KWARGS)}"
+        )
+
+    def test_source_fields(self) -> None:
+        # ``Source`` is documented as a public type in 3.10.0 but is not
+        # currently in ``pymat.__all__`` (see TestPublicSourceGap below).
+        # Pin its field set via the implementation module so a rename is
+        # still caught.
+        from pymat.sources import Source
+
+        fields = {f.name for f in dataclasses.fields(Source)}
+        assert fields == SOURCE_FIELDS, (
+            f"Source field set drifted.\n  got:  {sorted(fields)}\n  want: {sorted(SOURCE_FIELDS)}"
+        )
+
+
+# ── 6. type(...).__module__ flow on instances ────────────────
+
+
+class TestInstanceModuleFlow:
+    """The metadata pin in ``TestPublicApiContract`` checks the *class*.
+    Verify behaviorally that instances flowing out of public APIs also
+    surface the public path — so ``type(material.vis).__module__`` and
+    ``repr(material.vis)`` agree with the contract."""
+
+    def test_registry_material_vis_instance_module(self) -> None:
+        from pymat import stainless
+
+        v = stainless.vis
+        assert type(v).__module__ == "pymat.vis", (
+            f"stainless.vis is a {type(v).__module__}.{type(v).__name__}; "
+            "downstream tools (build123d, IDE auto-import) read this."
+        )
+
+    def test_constructed_material_vis_instance_module(self) -> None:
+        from pymat import Material
+
+        m = Material(name="probe")
+        assert type(m.vis).__module__ == "pymat.vis"
+
+    def test_vis_override_result_instance_module(self) -> None:
+        from pymat import stainless
+
+        derived = stainless.vis.override(roughness=0.05)
+        assert type(derived).__module__ == "pymat.vis"
+
+    def test_repr_does_not_leak_private_path(self) -> None:
+        """``repr(material.vis)`` is what users see in tracebacks and
+        REPLs. The default dataclass repr renders the class name only,
+        but ``Material.vis``'s docstring promises the public path is
+        what surfaces — pin it via ``type(...).__name__`` + module."""
+        from pymat import Material
+
+        v = Material(name="probe").vis
+        # Defense in depth: the qualified ``module.qualname`` form is
+        # what Sphinx uses for cross-references.
+        qualified = f"{type(v).__module__}.{type(v).__qualname__}"
+        assert qualified == "pymat.vis.Vis", qualified
+
+
+# ── 7. Sphinx-style canonical-name round-trip ────────────────
+
+
+class TestCanonicalNameRoundTrip:
+    """For every public type N, ``import_module(N.__module__).<name>``
+    must resolve to the *same object*. Catches the case where
+    ``N.__module__`` lies (e.g. is rewritten to ``pymat.vis`` but the
+    type doesn't actually appear at that module's top level), which is
+    what would trip Sphinx's autodoc cross-referencing."""
+
+    @pytest.mark.parametrize("name", PYMAT_VIS_PUBLIC_TYPES)
+    def test_pymat_vis_public_type_canonical_roundtrip(self, name: str) -> None:
+        import pymat.vis
+
+        obj = getattr(pymat.vis, name)
+        mod = importlib.import_module(obj.__module__)
+        # ``__qualname__`` for a top-level class is just the name; for
+        # nested classes it would be ``Outer.Inner`` — split on '.' and
+        # walk the chain to be safe.
+        parts = obj.__qualname__.split(".")
+        resolved: Any = mod
+        for p in parts:
+            resolved = getattr(resolved, p)
+        assert resolved is obj, (
+            f"{obj.__module__}.{obj.__qualname__} resolved to a different "
+            f"object than pymat.vis.{name} — Sphinx cross-refs will land "
+            "in the wrong place."
+        )
+
+    # Note: the per-name canonical-roundtrip on ``PYMAT_PUBLIC_TYPES``
+    # was dropped — for ``Material`` / ``*Properties`` / ``Source`` whose
+    # ``__module__`` points at ``pymat.core`` / ``pymat.properties`` /
+    # ``pymat.sources``, the round-trip is verifying that classes are
+    # defined where their ``__module__`` says they are, which is a Python
+    # invariant rather than a contract a refactor could break without
+    # going out of its way. The ``pymat.vis`` round-trip above (where
+    # ``__module__`` is rewritten to a non-canonical path) is the
+    # load-bearing case and remains pinned.
+
+    def test_canonical_module_path_is_not_private(self) -> None:
+        """The canonical module path itself must be importable as a
+        public submodule — no leading underscore. ``pymat.vis._model``
+        IS importable, but it's private; the canonical path of any
+        public type should not look private."""
+        import pymat.vis
+
+        for name in PYMAT_VIS_PUBLIC_TYPES:
+            obj = getattr(pymat.vis, name)
+            assert not any(seg.startswith("_") for seg in obj.__module__.split(".")), (
+                f"{name}.__module__ = {obj.__module__!r} is on a private path; "
+                "Sphinx will render an underscore-prefixed cross-ref."
+            )
+
+
+# ── Documented-but-not-importable gap ────────────────────────
+
+
+class TestPublicSourceContract:
+    """``Source`` (added in 3.10.0 #150) is the public provenance type:
+    it backs ``Material._sources`` and the ``[<material>._sources]``
+    TOML table. 3.10.1 closes the trailing gap of the original PR and
+    re-exports it on the top-level ``pymat`` namespace so consumers
+    don't need a second import line.
+
+    The class bound at ``pymat.Source`` must be the same object as
+    ``pymat.sources.Source`` — an alias, not a shim — so type
+    annotations on either path interoperate."""
+
+    def test_source_importable_from_pymat(self) -> None:
+        from pymat import Source
+        from pymat.sources import Source as canonical_Source
+
+        assert Source is canonical_Source
+
+    def test_source_in_pymat_all(self) -> None:
+        import pymat
+
+        assert "Source" in pymat.__all__

--- a/tests/test_vis.py
+++ b/tests/test_vis.py
@@ -144,7 +144,7 @@ class TestIdentityInvalidation:
 
     def test_tier_change_clears_cache(self):
         v = self._prefetched()
-        v.tier = "2k"
+        v.tier = "512"  # was "2k" — now validated against client.tiers()
         assert v._textures == {}
         assert v._fetched is False
 
@@ -216,7 +216,7 @@ class TestIdentityInvalidation:
         assert v._fetched is True
 
         # Real change still invalidates
-        v.tier = "2k"
+        v.tier = "512"  # was "2k" — now validated against client.tiers()
         assert v._textures == {}
         assert v._fetched is False
 

--- a/tests/test_vis_override.py
+++ b/tests/test_vis_override.py
@@ -125,8 +125,8 @@ class TestIdentityOverride:
 
     def test_full_identity_swap(self):
         v = _base()
-        v2 = v.override(source="polyhaven", material_id="metal_01", tier="2k")
-        assert (v2.source, v2.material_id, v2.tier) == ("polyhaven", "metal_01", "2k")
+        v2 = v.override(source="polyhaven", material_id="metal_01", tier="512")
+        assert (v2.source, v2.material_id, v2.tier) == ("polyhaven", "metal_01", "512")
 
     def test_identity_change_clears_stale_finish(self):
         """If user moves identity without specifying a finish, the
@@ -274,14 +274,14 @@ class TestTierOnlyChangePreservesFinish:
     def test_tier_change_keeps_finish_label(self):
         v = _base()
         v.finish = "polished"
-        v2 = v.override(tier="2k")
+        v2 = v.override(tier="512")
         assert v2._finish == "polished", (
             "tier change must not clear _finish — finishes pin (source, material_id), not tier"
         )
         # Same (source, material_id) as the polished entry → finish remains valid
         assert v2.source == "ambientcg"
         assert v2.material_id == "Metal049A"
-        assert v2.tier == "2k"
+        assert v2.tier == "512"
 
     def test_tier_change_still_invalidates_cache(self):
         """Tier change must clear the texture cache (different bytes
@@ -290,7 +290,7 @@ class TestTierOnlyChangePreservesFinish:
         v.finish = "polished"
         v._textures = {"color": b"\x89PNG_1k_bytes"}
         v._fetched = True
-        v2 = v.override(tier="2k")
+        v2 = v.override(tier="512")
         assert v2._textures == {}
         assert v2._fetched is False
         assert v2._finish == "polished"


### PR DESCRIPTION
## Summary

Trailing follow-ups to the 3.10.0 public-API clarification (#98 / mat-vis #282), surfaced after shipping by three independent agent-driven test reviews. Two metadata fixes + one tier-validation fix + ~170 new contract tests across three test files. No version bump — release-please owns the version + CHANGELOG (PR #80).

## Production fixes

| Change | What | Why |
|---|---|---|
| **`Source` / `Vis` / `VisDeltas` / `FinishEntry`** re-exported on top-level `pymat` | Adds 4 names to `pymat.__all__` and the corresponding imports in `__init__.py` | All four were public-by-documentation but only importable from `pymat.sources` / `pymat.vis`. Same shape of bug as the original `Vis.__module__` issue (#98) — public-by-doc, hidden-by-import-path. |
| **`pymat.__dir__` derives from `__all__`** | Replaces hardcoded subset list | Was silently dropping `search`, `ureg`, `factories`, `vis` — IDE tab-completion missed them. |
| **`Vis.tier=` validates at the assignment site** | New `_validate_tier(value)` helper wired into `__setattr__` and `set_identity` | Bad tier (`vis.tier = "99k"`) was silently accepted; the failure surfaced deep in mat-vis-client without echoing the offending input. Mirrors the long-shipped `Vis.finish=` setter pattern. Same shape as Bernhard's [mat-vis #280](https://github.com/MorePET/mat-vis/issues/280) inside py-mat's surface. |

The tier validator uses `client.tiers()` with **permissive fallback** — if the client / manifest is unreachable (offline, corrupted cache, future-version migration), validation is skipped silently rather than blocking the assignment. Worse to break offline workflows than to leave one typo unflagged; the lazy-fetch path will still raise on `.textures` access.

## Test additions

| File | Tests | Pins |
|---|---|---|
| `tests/test_consumer_journey.py` | ~28 + 1 xfail | build123d-style end-to-end journey: discovery → derivation → attachment → export → typo recovery |
| `tests/test_public_api_surface.py` | ~110 | `__module__` metadata, `__all__` integrity, `dir()`, public construction, field-set freeze, `type(...)` flow, canonical-name round-trip |
| `tests/test_error_messages.py` | ~30 + 5 xfail | error-message *content*: input echo, suggestions, no-UUID-leakage, error-class stability |

Each xfail = a candidate issue to file post-release. **6 remain** (down from 12 in the 3.10.0-iteration draft — 6 closed by this PR).

## Existing tests updated

5 places in `tests/test_vis.py` / `tests/test_vis_override.py` used `tier="2k"` as a placeholder for "different tier value." Replaced with `tier="512"` (a real tier per `client.tiers()`); the tests still pin the identity-invalidation behaviour they were written for.

## Test plan

- [x] `uv run python -m pytest` — 781 passed, 37 skipped, 6 xfailed
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — 69 files already formatted
- [x] Manual smoke: `from pymat import Source, Vis, VisDeltas, FinishEntry` works; `Vis.tier = "99k"` raises with the available list

## After merge

Release-please will pick up the `fix:` commit and update PR #80's auto-generated CHANGELOG. PR #80 will then be hand-edited to add narrative + thematic grouping for the 3.11.0 release notes.

Refs #98, mat-vis #280