### PR TITLE
fix(vis): graceful scalar-only sources (closes #222)

### DIFF
--- a/src/pymat/vis/_model.py
+++ b/src/pymat/vis/_model.py
@@ -225,7 +225,7 @@ class Vis:
     # positional-arg signature (ADR-0002).
     source: str | None = None
     material_id: str | None = None
-    tier: str = "1k"
+    tier: str | None = "1k"
     finishes: dict[str, FinishEntry] = field(default_factory=dict)
 
     # PBR scalars — the canonical home in 3.0+. Loaded from the [vis]
@@ -268,6 +268,59 @@ class Vis:
         """
         super().__setattr__("_textures", {})
         super().__setattr__("_fetched", False)
+        self._auto_resolve_tier_from_manifest()
+
+    def _auto_resolve_tier_from_manifest(self) -> None:
+        """Reconcile ``tier`` against the source's manifest tier list.
+
+        The dataclass default of ``"1k"`` matches the textured-source
+        majority (gpuopen / ambientcg / polyhaven) but is wrong for
+        scalar-only sources like ``physicallybased`` which only ship
+        a ``"scalar"`` tier. Without this resolution, the call
+        ``Vis(source="physicallybased", material_id="Aluminum")`` lands
+        with ``tier="1k"`` and the next ``.textures`` access raises
+        ``MaterialNotStagedError`` deep inside mat-vis-client without
+        the user ever asking for ``"1k"``. Closes #222 / mat-vis #313.
+
+        Resolution policy:
+
+        - If source / material_id aren't both set: skip (incomplete identity).
+        - If the configured ``tier`` IS in the source's manifest tier list:
+          keep it (user's choice respected).
+        - Else if a single canonical fallback exists (currently ``"scalar"``
+          for sources whose tier list contains it): silently swap to it.
+        - Else: leave ``tier`` alone — fetch will raise with the offending
+          input echoed (better than guessing wrong).
+
+        Permissive on errors: if the client / manifest is unreachable
+        (offline, corrupted cache, future-version migration), skip — same
+        policy as ``_validate_tier``. Worse to break offline workflows than
+        to leave a tier mismatch unresolved; the lazy-fetch path will still
+        surface the issue at ``.textures`` access time.
+        """
+        if self.source is None or self.material_id is None:
+            return
+        try:
+            from mat_vis_client import get_client
+
+            manifest = get_client().manifest
+        except Exception:
+            return
+
+        source_entry = (manifest.get("sources") or {}).get(self.source)
+        if not source_entry:
+            return  # Unknown source — let fetch surface the error
+        available_tiers = list((source_entry.get("tiers") or {}).keys())
+        if not available_tiers:
+            return
+        if self.tier in available_tiers:
+            return  # User's tier choice is valid for this source
+        # Tier mismatch — fall back to a canonical option if there's a
+        # clear winner. ``"scalar"`` is the canonical scalar-only tier;
+        # if it's the only one available, use it. Otherwise, leave
+        # alone (better an explicit error at fetch than a silent guess).
+        if "scalar" in available_tiers:
+            super().__setattr__("tier", "scalar")
 
     # ── Cache invalidation on identity mutation ──────────────────
 
@@ -692,12 +745,29 @@ class Vis:
     # ── Internals ────────────────────────────────────────────────
 
     def _fetch(self) -> None:
-        """Fetch textures via the vis client. Called lazily."""
+        """Fetch textures via the vis client. Called lazily.
+
+        Scalar-only sources (currently ``physicallybased``, identified
+        by ``tier == "scalar"``) ship no texture maps — only authored
+        PBR scalars in their catalog entry. The ``fetch_all_textures``
+        path raises ``MaterialNotStagedError`` for them; we short-
+        circuit with an empty texture dict instead. The scalars are
+        already on the ``Vis`` (loaded from TOML or set explicitly);
+        downstream adapters fall back to ``Vis._PBR_DEFAULTS`` for
+        anything still ``None``. Closes #222 / mat-vis #313.
+        """
         if not self.has_mapping:
             return
 
         # Thin delegate — matches the ADR-0002 principle.
         src, mid, tier = self._identity_args()
+        if tier == "scalar":
+            # No texture fetch for scalar-only sources. Mark fetched so
+            # the lazy property doesn't keep re-trying every access.
+            super().__setattr__("_textures", {})
+            super().__setattr__("_fetched", True)
+            return
+
         textures = self.client.fetch_all_textures(src, mid, tier=tier)
         # Write via super() so we don't trip the identity-invalidation
         # guard (`_textures` and `_fetched` aren't identity fields, so

--- a/tests/test_substrate_repros.py
+++ b/tests/test_substrate_repros.py
@@ -157,29 +157,28 @@ class TestMatVis311_MaterialNames:
 
 
 class TestMatVis313_PhysicallybasedAccess:
-    """Constructing a ``Vis`` against the ``physicallybased`` source
-    and calling ``to_threejs()`` raises ``MaterialNotStagedError`` —
-    the source is exposed as a valid choice but materials aren't
-    actually accessible through the same path the textured sources
-    use. physicallybased is scalar-only (no textures), so the path
-    needs to dispatch to a scalar-only fetch when there's no texture
-    tier to pull.
+    """``Vis(source='physicallybased', material_id='Aluminum').to_threejs()``
+    must not raise. mat-vis #313 was the upstream symptom (substrate
+    path treated physicallybased like a textured source); py-mat #222
+    closed the consumer-facing manifestation by auto-resolving
+    ``tier`` to ``"scalar"`` when the source's manifest only ships a
+    scalar tier, then short-circuiting the texture fetch in
+    ``Vis._fetch``.
+
+    The test passes today thanks to the py-mat-side handling. The
+    upstream issue stays open until mat-vis ships a release that
+    unbreaks the substrate path natively — but consumers don't see
+    that bug anymore because we route around it.
     """
 
-    @pytest.mark.xfail(
-        reason=(
-            "mat-vis #313: Vis('physicallybased', 'Aluminum').to_threejs() "
-            "raises MaterialNotStagedError because the substrate path "
-            "treats physicallybased like a textured source. Will flip to "
-            "passing when the scalar-only path is wired through to_threejs."
-        ),
-        strict=True,
-    )
     def test_physicallybased_aluminum_to_threejs(self):
         from pymat.vis import Vis
 
         with _skip_on_upstream_outage():
             v = Vis(source="physicallybased", material_id="Aluminum")
+            # Auto-resolution should land tier on "scalar" without the
+            # caller asking — the whole point of #222's fix.
+            assert v.tier == "scalar", f"tier auto-resolution failed: {v.tier!r}"
             out = v.to_threejs()
 
         # Just assert it doesn't raise + returns a usable dict — the

--- a/tests/test_vis_bernhard_repros.py
+++ b/tests/test_vis_bernhard_repros.py
@@ -190,10 +190,6 @@ def _install_scalar_only_fake_client(monkeypatch):
     return fake, _NotStaged
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="mat#222: Vis defaults tier='1k' even for scalar-only sources",
-)
 class TestIssue222ScalarOnlySources:
     """Bernhard's mat-vis#313 + #311 'Support physicallybased.info'.
 


### PR DESCRIPTION
## Summary

`Vis(source='physicallybased', material_id='Aluminum').to_threejs()` previously raised `MaterialNotStagedError` because the substrate path treated `physicallybased` like a textured source — `tier` defaulted to `"1k"` which doesn't exist in `physicallybased`'s manifest, so `fetch_all_textures` raised before scalars could be read.

Closes the py-mat-side manifestation of [mat-vis #313](https://github.com/MorePET/mat-vis/issues/313). Upstream issue stays open for the substrate-path fix; consumers no longer hit the symptom because we route around it.

## Three pieces

1. **Type widening**: `tier: str = "1k"` → `tier: str | None = "1k"`. Matches the type already used in `set_identity` / `_validate_tier`. Setting `vis.tier = None` is a documented un-mapping operation per `has_mapping` docstring.

2. **`__post_init__` auto-resolution** via new `_auto_resolve_tier_from_manifest()`. When source + material_id are set and the configured tier isn't in the source's manifest tier list, fall back to `"scalar"` if available. Permissive on client / manifest unavailability — mirrors `_validate_tier`'s policy. Default stays `"1k"` (textured-source majority); `physicallybased` silently re-resolves to `"scalar"`.

3. **`_fetch` short-circuit**: when `tier == "scalar"`, skip `client.fetch_all_textures` entirely and mark fetched with empty texture dict. Scalars are already on the Vis (loaded from TOML or set explicitly); downstream adapters fall back to `Vis._PBR_DEFAULTS` for anything still `None`.

## Caller compatibility

| Call | Behavior |
|---|---|
| `Vis(source="ambientcg", material_id="Wood095")` | unchanged — auto-resolution sees `"1k"` is in ambientcg's tier list |
| `Vis(source="physicallybased", material_id="Aluminum")` | now resolves `tier → "scalar"`; `.to_threejs()` returns populated dict; `.textures` returns `{}` |
| Offline / cache-miss caller | auto-resolution silently skips rather than blocking construction |

## Tests

| Test | Was | Now |
|---|---|---|
| `tests/test_vis_bernhard_repros.py::TestIssue222ScalarOnlySources` (PR #224) | strict-xfail (3 tests) | passing — xfail marker dropped |
| `tests/test_substrate_repros.py::TestMatVis313_PhysicallybasedAccess` (PR #219) | strict-xfail (1 test) | passing — xfail marker dropped, assertion tightened to verify `vis.tier == "scalar"` after construction |

Suite: **823 passed, 43 skipped, 15 xfailed** (down from 17 xfailed — the two that flipped were the #222 + #313 markers).

## Test plan

- [x] `pytest tests/test_vis_bernhard_repros.py::TestIssue222ScalarOnlySources -v` — 3 passed
- [x] `pytest tests/test_substrate_repros.py::TestMatVis313_PhysicallybasedAccess -v` — 1 passed
- [x] Full suite — 823 passed, 0 failed
- [x] `ruff check .` — clean
- [x] `ruff format --check .` — clean

Refs #222, #313, #220, #221