### PR TITLE
feat(quality): PEP 8 trailing-underscore hook + chainable rename (#130, #218)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,6 +321,13 @@ jobs:
         # audit window.
         run: python scripts/check_licenses.py
 
+      - name: Run check_pep_naming.py
+        # Stdlib-only AST hook. Flags trailing-`_` on names whose
+        # stripped form isn't a Python keyword/built-in — Bernhard's
+        # py-mat #218 readability ask. Ruff's N-rules don't cover
+        # this specific pattern.
+        run: python scripts/check_pep_naming.py
+
   summary:
     name: CI Summary
     runs-on: ubuntu-22.04

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -104,3 +104,13 @@ repos:
         language: python
         files: ^(src/pymat/data/.*\.toml|scripts/check_licenses\.py|\.github/license-ratchet\.txt)$
         pass_filenames: false
+
+      # Custom PEP-8 naming: trailing-`_` reserved for keyword-collision
+      # avoidance only. Catches the gap ruff's N-rules don't cover.
+      # Stdlib-only (ast/keyword/builtins).
+      - id: pep-naming-trailing-underscore
+        name: PEP 8 trailing-underscore (kw-collision only)
+        entry: python scripts/check_pep_naming.py
+        language: python
+        files: ^(src/|tests/|scripts/).*\.py$
+        pass_filenames: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,31 @@ line-length = 100
 target-version = "py311"
 
 [tool.ruff.lint]
-select = ["E", "F", "W", "I"]
+select = ["E", "F", "W", "I", "N"]
+
+[tool.ruff.lint.per-file-ignores]
+# Scientific unit suffixes (K, C, eV, keV, Bq, ...) are intentional in
+# public API field names and method parameters per SI / domain convention.
+# PEP 8's strict-lowercase rule (N803 / N815) reads as a violation but the
+# suffixes carry meaning lowercase would erase. File-level ignore is cleaner
+# than per-field noqa.
+"src/pymat/curves.py" = ["N803", "N815"]
+"src/pymat/properties.py" = ["N803", "N815"]
+
+# Tests use domain-realistic local names (`s316L`, `mp_K`, `bp_K`, ...) and
+# may define test-local helper classes / exception types whose strict
+# adherence to PEP 8 naming would erase the test's documentary value.
+# - N802: test function names with unit suffixes (`test_parse_temperature_C`)
+# - N803 / N806 / N815: unit-suffixed identifiers
+# - N805: methods on stub classes that aren't real `self` (FakeClient, etc.)
+# - N818: test-local exception names that don't ship as public API
+"tests/**.py" = ["N801", "N802", "N803", "N805", "N806", "N815", "N818"]
+
+# Enricher scripts parse external data with unit-suffixed value names
+# (`_parse_temperature_C`, `_parse_density_g_per_cm3`, …); the suffixes
+# match the source-of-truth in the underlying scientific data and erasing
+# them via lowercase-rename would make the parser less self-documenting.
+"scripts/**.py" = ["N802", "N803", "N806", "N815"]
 
 [dependency-groups]
 dev = [

--- a/scripts/check_pep_naming.py
+++ b/scripts/check_pep_naming.py
@@ -1,0 +1,152 @@
+"""Custom PEP-8 naming hook — flags trailing-single-underscore method
+and function names whose stripped form isn't a Python keyword or
+built-in.
+
+PEP 8: "Trailing underscores are used by convention to avoid conflicts
+with Python keyword[s], e.g. `class_`, `type_`, `id_`." Using a
+trailing underscore as a general naming convention (e.g. `grade_`,
+`temper_`) violates this contract and confuses readers. Bernhard's
+py-mat #218 called this out explicitly.
+
+Ruff's `N` rule set covers most PEP-8 naming patterns but not this
+one specifically — `N802` accepts any `[a-z][a-z0-9_]*` form
+including `grade_`. This hook is the gap-filler.
+
+Suppression: add ``# noqa: PYMAT_TRAILING_UNDERSCORE`` (or ``# pymat-quality:
+ignore trailing-underscore``) on the same line as the `def` to
+suppress, e.g. for back-compat deprecation aliases.
+
+Run: ``python scripts/check_pep_naming.py [PATH ...]``
+Exits 0 with no output on clean code, 1 with diagnostics on
+violations.
+"""
+
+from __future__ import annotations
+
+import ast
+import builtins
+import keyword
+import sys
+from collections.abc import Iterable, Iterator
+from pathlib import Path
+
+# Names whose trailing underscore IS legitimate per PEP 8 (kw/builtin
+# disambiguation). Built-ins extend keywords with the standard set
+# users commonly want to shadow without losing the original (`type_`,
+# `id_`, `list_`, `dict_`).
+_LEGITIMATE_STRIPPED_NAMES: frozenset[str] = frozenset(
+    keyword.kwlist
+) | frozenset(dir(builtins))
+
+# Ignore directives recognized on the def line (case-insensitive).
+# Short form `pymat-keep-_` is preferred — keeps the def signature on
+# one line. The longer forms are recognized for back-compat with early
+# call sites and humans who like reading the verb out.
+_IGNORE_TOKENS = (
+    "pymat-keep-_",
+    "noqa: pymat_trailing_underscore",
+    "pymat-quality: ignore trailing-underscore",
+)
+
+
+def _has_ignore_directive(source: str, lineno: int) -> bool:
+    """Return True if line ``lineno`` (1-based) contains an ignore
+    directive in its trailing comment.
+
+    Walks back to the opening ``def`` line in case the signature spans
+    multiple lines and the directive sits on the def line itself.
+    """
+    lines = source.splitlines()
+    if lineno - 1 >= len(lines):
+        return False
+    line = lines[lineno - 1].lower()
+    return any(tok in line for tok in _IGNORE_TOKENS)
+
+
+def _walk_def_nodes(tree: ast.AST) -> Iterator[ast.FunctionDef | ast.AsyncFunctionDef]:
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            yield node
+
+
+def _check_node(
+    node: ast.FunctionDef | ast.AsyncFunctionDef, source: str
+) -> tuple[str, int] | None:
+    """Return (message, line) if the node's name violates the rule;
+    else None."""
+    name = node.name
+    if not name.endswith("_"):
+        return None
+    if name.startswith("__") or name.endswith("__"):
+        # Dunders / sunders use leading-and-trailing underscores; not
+        # the trailing-single-underscore convention this hook targets.
+        return None
+    if name.startswith("_"):
+        # Single-leading-underscore names (private) — skip; the trailing
+        # underscore here is unusual but private API convention is
+        # already a different lint axis (PEP 8 says nothing about it).
+        return None
+
+    stripped = name.rstrip("_")
+    if stripped in _LEGITIMATE_STRIPPED_NAMES:
+        return None  # legitimate kw/builtin disambiguation
+
+    if _has_ignore_directive(source, node.lineno):
+        return None
+
+    msg = (
+        f"PYMAT_TRAILING_UNDERSCORE: function/method `{name}` ends with `_` "
+        f"but `{stripped}` is not a Python keyword or built-in. PEP 8 reserves "
+        "trailing single underscore for keyword-collision avoidance only. "
+        "Rename (e.g. `add_grade` for `grade_`) or add a deprecation alias "
+        "with `# noqa: PYMAT_TRAILING_UNDERSCORE` if intentionally preserving "
+        "back-compat."
+    )
+    return msg, node.lineno
+
+
+def check_path(path: Path) -> list[str]:
+    """Return list of formatted violations for one .py file."""
+    try:
+        source = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        return [f"{path}: read error: {exc}"]
+
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError as exc:
+        return [f"{path}:{exc.lineno}: SyntaxError: {exc.msg}"]
+
+    diagnostics: list[str] = []
+    for node in _walk_def_nodes(tree):
+        result = _check_node(node, source)
+        if result is None:
+            continue
+        msg, line = result
+        diagnostics.append(f"{path}:{line}: {msg}")
+    return diagnostics
+
+
+def _iter_files(paths: Iterable[Path]) -> Iterator[Path]:
+    for p in paths:
+        if p.is_dir():
+            yield from sorted(p.rglob("*.py"))
+        elif p.suffix == ".py":
+            yield p
+
+
+def main(argv: list[str]) -> int:
+    if not argv:
+        # Default: check src/ + tests/ if invoked without arguments.
+        argv = ["src", "tests", "scripts"]
+    paths = [Path(p) for p in argv if Path(p).exists()]
+    diagnostics: list[str] = []
+    for f in _iter_files(paths):
+        diagnostics.extend(check_path(f))
+    for d in diagnostics:
+        print(d)
+    return 1 if diagnostics else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/check_pep_naming.py
+++ b/scripts/check_pep_naming.py
@@ -12,9 +12,10 @@ Ruff's `N` rule set covers most PEP-8 naming patterns but not this
 one specifically — `N802` accepts any `[a-z][a-z0-9_]*` form
 including `grade_`. This hook is the gap-filler.
 
-Suppression: add ``# noqa: PYMAT_TRAILING_UNDERSCORE`` (or ``# pymat-quality:
-ignore trailing-underscore``) on the same line as the `def` to
-suppress, e.g. for back-compat deprecation aliases.
+Suppression: add ``# pymat-keep-_`` on the same line as the `def`
+(short form). Long forms ``# pymat-quality: ignore trailing-underscore``
+and ``# noqa: PYMAT_TRAILING_UNDERSCORE`` are also recognized.
+Use only for back-compat deprecation aliases.
 
 Run: ``python scripts/check_pep_naming.py [PATH ...]``
 Exits 0 with no output on clean code, 1 with diagnostics on
@@ -96,9 +97,8 @@ def _check_node(
         f"PYMAT_TRAILING_UNDERSCORE: function/method `{name}` ends with `_` "
         f"but `{stripped}` is not a Python keyword or built-in. PEP 8 reserves "
         "trailing single underscore for keyword-collision avoidance only. "
-        "Rename (e.g. `add_grade` for `grade_`) or add a deprecation alias "
-        "with `# noqa: PYMAT_TRAILING_UNDERSCORE` if intentionally preserving "
-        "back-compat."
+        "Rename (e.g. `add_grade` for `grade_`) or add `# pymat-keep-_` on "
+        "the def line if this is an intentional back-compat deprecation alias."
     )
     return msg, node.lineno
 

--- a/scripts/check_pep_naming.py
+++ b/scripts/check_pep_naming.py
@@ -34,9 +34,7 @@ from pathlib import Path
 # disambiguation). Built-ins extend keywords with the standard set
 # users commonly want to shadow without losing the original (`type_`,
 # `id_`, `list_`, `dict_`).
-_LEGITIMATE_STRIPPED_NAMES: frozenset[str] = frozenset(
-    keyword.kwlist
-) | frozenset(dir(builtins))
+_LEGITIMATE_STRIPPED_NAMES: frozenset[str] = frozenset(keyword.kwlist) | frozenset(dir(builtins))
 
 # Ignore directives recognized on the def line (case-insensitive).
 # Short form `pymat-keep-_` is preferred — keeps the def signature on

--- a/src/pymat/core.py
+++ b/src/pymat/core.py
@@ -74,12 +74,12 @@ def _make_material(
     # batched through set_identity so construction never exposes a
     # half-assigned (source-but-no-material_id) state.
     if vis:
-        _IDENTITY_KEYS = {"source", "material_id", "tier"}
-        identity_kwargs = {k: vis[k] for k in _IDENTITY_KEYS if k in vis}
+        _identity_keys = {"source", "material_id", "tier"}
+        identity_kwargs = {k: vis[k] for k in _identity_keys if k in vis}
         if identity_kwargs:
             mat.vis.set_identity(**identity_kwargs)
         for key, value in vis.items():
-            if key in _IDENTITY_KEYS:
+            if key in _identity_keys:
                 continue
             setattr(mat.vis, key, value)
 
@@ -328,25 +328,93 @@ class _MaterialInternal:
     # Chainable Methods
     # =========================================================================
 
-    def grade_(self, key: str, **props) -> _MaterialInternal:
+    def add_grade(self, key: str, **props) -> _MaterialInternal:
         """Add a grade variant (e.g., 304, 316L, 6061, a7075)."""
         return self._add_child(key, grade=key, **props)
 
-    def temper_(self, key: str, **props) -> _MaterialInternal:
-        """Add a temper/heat treatment (e.g., T6, O, annealed)."""
+    def add_temper(self, key: str, **props) -> _MaterialInternal:
+        """Add a temper / heat treatment (e.g., T6, O, annealed)."""
         return self._add_child(key, temper=key, **props)
 
-    def treatment_(self, key: str, **props) -> _MaterialInternal:
+    def add_treatment(self, key: str, **props) -> _MaterialInternal:
         """Add a surface treatment (e.g., passivated, anodized, electropolished)."""
         return self._add_child(key, treatment=key, **props)
 
-    def vendor_(self, key: str, **props) -> _MaterialInternal:
+    def add_vendor(self, key: str, **props) -> _MaterialInternal:
         """Add a vendor-specific variant."""
         return self._add_child(key, vendor=key, **props)
 
-    def variant_(self, key: str, **props) -> _MaterialInternal:
+    def add_variant(self, key: str, **props) -> _MaterialInternal:
         """Add a generic variant (dopant, alloy composition, etc.)."""
         return self._add_child(key, **props)
+
+    # ─── Deprecated trailing-underscore aliases ────────────────────────
+    # PEP 8 reserves trailing single underscore for keyword / built-in
+    # collision disambiguation only (`class_`, `type_`, `id_`); using it
+    # as a general method-naming convention reads as a violation to
+    # typed users (Bernhard's py-mat #218). Renamed to verb-form
+    # `add_X`. Aliases below keep 3.x BC and emit DeprecationWarning so
+    # callers migrate. Scheduled for removal in 4.0.
+
+    def grade_(self, key: str, **props) -> _MaterialInternal:  # pymat-keep-_ (deprecated alias)
+        """Deprecated alias for :meth:`add_grade`. Removed in 4.0."""
+        import warnings
+
+        warnings.warn(
+            "Material.grade_() is deprecated; use Material.add_grade() instead. "
+            "Will be removed in 4.0.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.add_grade(key, **props)
+
+    def temper_(self, key: str, **props) -> _MaterialInternal:  # pymat-keep-_
+        """Deprecated alias for :meth:`add_temper`. Removed in 4.0."""
+        import warnings
+
+        warnings.warn(
+            "Material.temper_() is deprecated; use Material.add_temper() instead. "
+            "Will be removed in 4.0.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.add_temper(key, **props)
+
+    def treatment_(self, key: str, **props) -> _MaterialInternal:  # pymat-keep-_
+        """Deprecated alias for :meth:`add_treatment`. Removed in 4.0."""
+        import warnings
+
+        warnings.warn(
+            "Material.treatment_() is deprecated; use Material.add_treatment() instead. "
+            "Will be removed in 4.0.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.add_treatment(key, **props)
+
+    def vendor_(self, key: str, **props) -> _MaterialInternal:  # pymat-keep-_
+        """Deprecated alias for :meth:`add_vendor`. Removed in 4.0."""
+        import warnings
+
+        warnings.warn(
+            "Material.vendor_() is deprecated; use Material.add_vendor() instead. "
+            "Will be removed in 4.0.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.add_vendor(key, **props)
+
+    def variant_(self, key: str, **props) -> _MaterialInternal:  # pymat-keep-_
+        """Deprecated alias for :meth:`add_variant`. Removed in 4.0."""
+        import warnings
+
+        warnings.warn(
+            "Material.variant_() is deprecated; use Material.add_variant() instead. "
+            "Will be removed in 4.0.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.add_variant(key, **props)
 
     # =========================================================================
     # Application to Shapes
@@ -759,11 +827,11 @@ class Material(_MaterialInternal):
         # Identity keys batch through set_identity (single invalidation,
         # no half-assigned intermediate state).
         if vis:
-            _IDENTITY_KEYS = {"source", "material_id", "tier"}
-            identity_kwargs = {k: vis[k] for k in _IDENTITY_KEYS if k in vis}
+            _identity_keys = {"source", "material_id", "tier"}
+            identity_kwargs = {k: vis[k] for k in _identity_keys if k in vis}
             if identity_kwargs:
                 self.vis.set_identity(**identity_kwargs)
             for key, value in vis.items():
-                if key in _IDENTITY_KEYS:
+                if key in _identity_keys:
                     continue
                 setattr(self.vis, key, value)

--- a/src/pymat/loader.py
+++ b/src/pymat/loader.py
@@ -132,18 +132,18 @@ def _build_properties_from_dict(
         consumed_stddev = set()
 
         # Keys that signal a uncertainty/range dict — anything else stays as-is.
-        _UFLOAT_KEYS = {"nominal", "stddev", "min", "max"}
+        _ufloat_keys = {"nominal", "stddev", "min", "max"}
 
         def assign(base_key: str, raw_value):
             """Parse a value (possibly a {nominal, stddev} dict), fold sibling
             stddev if present, and setattr on prop_obj.
 
-            Only dicts whose top-level keys overlap with `_UFLOAT_KEYS` are
+            Only dicts whose top-level keys overlap with `_ufloat_keys` are
             routed through `_parse_value`. Structured-data dicts (e.g.
             `emission_spectrum = {wavelengths_nm, intensities}` from #153)
             are passed through verbatim.
             """
-            if isinstance(raw_value, dict) and (set(raw_value) & _UFLOAT_KEYS):
+            if isinstance(raw_value, dict) and (set(raw_value) & _ufloat_keys):
                 parsed = _parse_value(raw_value)
             else:
                 parsed = raw_value

--- a/tests/test_chainable_rename.py
+++ b/tests/test_chainable_rename.py
@@ -1,0 +1,110 @@
+"""Tests for the trailing-`_` chainable-method rename + deprecation
+aliases (Bernhard's py-mat #218 readability ask).
+
+Each old name (``grade_``, ``temper_``, ``treatment_``, ``vendor_``,
+``variant_``) survives as a deprecation alias that:
+
+1. Emits :class:`DeprecationWarning` with the new name in the message.
+2. Returns the same value the new method would have returned.
+3. Mutates state identically to the new method.
+
+Removed in 4.0.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from pymat.core import Material
+
+
+@pytest.fixture
+def base() -> Material:
+    return Material("steel", density=7.85)
+
+
+class TestAddVerbForms:
+    """The new (PEP-clean) method names must be the canonical surface."""
+
+    def test_add_grade_creates_child(self, base):
+        s316 = base.add_grade("s316L", density=8.0)
+        assert s316.grade == "s316L"
+        assert s316.parent is base
+
+    def test_add_temper_creates_child(self, base):
+        t6 = base.add_temper("T6")
+        assert t6.temper == "T6"
+
+    def test_add_treatment_creates_child(self, base):
+        ep = base.add_treatment("electropolished")
+        assert ep.treatment == "electropolished"
+
+    def test_add_vendor_creates_child(self, base):
+        v = base.add_vendor("saint_gobain")
+        assert v.vendor == "saint_gobain"
+
+    def test_add_variant_creates_child(self, base):
+        v = base.add_variant("ce_doped")
+        assert v.parent is base
+
+
+class TestDeprecatedAliases:
+    """Old trailing-`_` forms still work, but now warn."""
+
+    @pytest.mark.parametrize(
+        ("old_name", "new_name"),
+        [
+            ("grade_", "add_grade"),
+            ("temper_", "add_temper"),
+            ("treatment_", "add_treatment"),
+            ("vendor_", "add_vendor"),
+            ("variant_", "add_variant"),
+        ],
+    )
+    def test_alias_warns_and_points_to_new_name(self, base, old_name, new_name):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            getattr(base, old_name)("x")
+
+        deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        assert deprecations, f"{old_name} did not emit DeprecationWarning"
+        msg = str(deprecations[0].message)
+        assert old_name in msg
+        assert new_name in msg
+        assert "4.0" in msg
+
+    def test_alias_returns_same_shape_as_new(self, base):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            old = base.grade_("s316_old")
+        new = base.add_grade("s316_new")
+        # Both must be Material-shaped children with grade set.
+        assert old.grade == "s316_old"
+        assert new.grade == "s316_new"
+        assert type(old) is type(new)
+
+    def test_alias_state_mutation_matches(self, base):
+        # Calling the alias must register the child in the parent's
+        # _children map identically to the new method.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            base.temper_("T6_old")
+        base.add_temper("T6_new")
+        assert "T6_old" in base._children
+        assert "T6_new" in base._children
+
+
+class TestStacklevel:
+    """``stacklevel=2`` → warning points at the caller, not the alias
+    body. Without this, IDE quick-fixes / pytest output get noisy."""
+
+    def test_warning_filename_is_caller(self, base):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            base.grade_("s")  # this line is the caller
+        deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        assert deprecations
+        # The warning's filename should be this test file, not core.py.
+        assert deprecations[0].filename.endswith("test_chainable_rename.py")

--- a/tests/test_check_pep_naming.py
+++ b/tests/test_check_pep_naming.py
@@ -1,0 +1,186 @@
+"""Tests for ``scripts/check_pep_naming.py`` — the custom PEP-8 hook
+that flags trailing-single-underscore names whose stripped form isn't
+a keyword or built-in.
+
+The hook is a stdlib-only AST walker; tests are also stdlib-only.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parent.parent
+_HOOK_PATH = _REPO / "scripts" / "check_pep_naming.py"
+
+
+def _load_hook():
+    spec = importlib.util.spec_from_file_location("check_pep_naming", _HOOK_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["check_pep_naming"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+hook = _load_hook()
+
+
+def _write(tmp_path: Path, src: str) -> Path:
+    f = tmp_path / "sample.py"
+    f.write_text(src, encoding="utf-8")
+    return f
+
+
+class TestTrailingUnderscoreDetection:
+    def test_flags_non_keyword_trailing_underscore(self, tmp_path):
+        f = _write(tmp_path, "def grade_(self): pass\n")
+        diags = hook.check_path(f)
+        assert len(diags) == 1
+        assert "grade_" in diags[0]
+        assert "PYMAT_TRAILING_UNDERSCORE" in diags[0]
+
+    def test_allows_class_underscore(self, tmp_path):
+        # `class` is a Python keyword — `class_` is the textbook PEP 8 case.
+        f = _write(tmp_path, "def make(class_): pass\n")
+        # Note: this hook only flags function/method *names*, not
+        # parameters. Ruff's N803 covers parameter names. So a `def`
+        # whose parameter is `class_` should not produce diagnostics.
+        diags = hook.check_path(f)
+        assert diags == []
+
+    def test_allows_keyword_function_name(self, tmp_path):
+        # `def class_(...)` would be flagged by ruff (N802) for being
+        # confusing, but our hook is specifically about the
+        # trailing-`_` rule — and `class` is a keyword, so the
+        # trailing underscore IS legitimate per PEP 8. Hook stays out.
+        f = _write(tmp_path, "def class_(): pass\n")
+        diags = hook.check_path(f)
+        assert diags == []
+
+    def test_allows_builtin_function_name(self, tmp_path):
+        # `type`, `id`, `list`, `dict` — common shadow targets.
+        f = _write(tmp_path, "def type_(): pass\ndef id_(): pass\ndef list_(): pass\n")
+        diags = hook.check_path(f)
+        assert diags == []
+
+    def test_skips_dunder(self, tmp_path):
+        f = _write(tmp_path, "def __init_subclass__(cls): pass\n")
+        diags = hook.check_path(f)
+        assert diags == []
+
+    def test_skips_leading_underscore_private(self, tmp_path):
+        # Single-leading-underscore names — private. Trailing here is
+        # weird but it's a different lint axis; PEP 8 doesn't speak
+        # to it. Hook stays out.
+        f = _write(tmp_path, "def _grade_(self): pass\n")
+        diags = hook.check_path(f)
+        assert diags == []
+
+    def test_no_underscore_no_flag(self, tmp_path):
+        f = _write(tmp_path, "def add_grade(self, key): pass\n")
+        diags = hook.check_path(f)
+        assert diags == []
+
+
+class TestSuppression:
+    def test_short_form_keep_directive(self, tmp_path):
+        f = _write(
+            tmp_path,
+            "def grade_(self): pass  # pymat-keep-_\n",
+        )
+        diags = hook.check_path(f)
+        assert diags == []
+
+    def test_long_form_quality_directive(self, tmp_path):
+        f = _write(
+            tmp_path,
+            "def grade_(self): pass  # pymat-quality: ignore trailing-underscore\n",
+        )
+        diags = hook.check_path(f)
+        assert diags == []
+
+    def test_legacy_noqa_form(self, tmp_path):
+        # Back-compat with the early call sites (not used post-rename
+        # in the codebase, but kept recognized so churn is contained).
+        f = _write(
+            tmp_path,
+            "def grade_(self): pass  # noqa: PYMAT_TRAILING_UNDERSCORE\n",
+        )
+        diags = hook.check_path(f)
+        assert diags == []
+
+    def test_unrelated_comment_does_not_suppress(self, tmp_path):
+        f = _write(tmp_path, "def grade_(self): pass  # legacy method\n")
+        diags = hook.check_path(f)
+        assert len(diags) == 1
+
+
+class TestIntegration:
+    def test_main_returns_0_on_clean_file(self, tmp_path):
+        clean = tmp_path / "clean.py"
+        clean.write_text("def add_grade(self, key): pass\n", encoding="utf-8")
+        rc = hook.main([str(clean)])
+        assert rc == 0
+
+    def test_main_returns_1_on_violation(self, tmp_path, capsys):
+        bad = tmp_path / "bad.py"
+        bad.write_text("def grade_(self): pass\n", encoding="utf-8")
+        rc = hook.main([str(bad)])
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "grade_" in out
+
+    def test_walks_directories(self, tmp_path):
+        sub = tmp_path / "nested"
+        sub.mkdir()
+        (sub / "a.py").write_text("def grade_(self): pass\n", encoding="utf-8")
+        (sub / "b.py").write_text("def add_grade(self): pass\n", encoding="utf-8")
+        rc = hook.main([str(tmp_path)])
+        assert rc == 1
+
+    def test_repo_is_clean(self):
+        """The codebase itself must pass. Regression guard against
+        accidentally re-introducing trailing-`_` methods without a
+        deprecation directive."""
+        rc = hook.main(["src", "tests", "scripts"])
+        assert rc == 0
+
+
+class TestSyntaxError:
+    def test_reports_syntax_error_does_not_crash(self, tmp_path):
+        bad = _write(tmp_path, "def broken(\n")
+        diags = hook.check_path(bad)
+        assert any("SyntaxError" in d for d in diags)
+
+
+@pytest.mark.parametrize(
+    ("name", "expected_violation"),
+    [
+        ("grade_", True),
+        ("temper_", True),
+        ("treatment_", True),
+        ("vendor_", True),
+        ("variant_", True),
+        ("class_", False),
+        ("type_", False),
+        ("id_", False),
+        ("dict_", False),
+        ("list_", False),
+        ("set_", False),
+        ("input_", False),
+        ("filter_", False),
+        ("format_", False),
+        ("from_", False),
+        ("add_grade", False),
+        ("__init__", False),
+        ("__call__", False),
+    ],
+)
+def test_known_names(tmp_path, name, expected_violation):
+    f = _write(tmp_path, f"def {name}(self): pass\n")
+    diags = hook.check_path(f)
+    assert bool(diags) == expected_violation, (name, diags)


### PR DESCRIPTION
## Summary
- New stdlib AST hook (`scripts/check_pep_naming.py`) flags trailing-single-underscore names whose stripped form isn't a Python keyword or built-in — the gap ruff's `N` rules don't cover. Suppress on legitimate deprecation aliases with `# pymat-keep-_`.
- Wired ruff's `N` ruleset; per-file-ignores for files where scientific unit suffixes (`mp_K`, `melting_point_C`, `mee_eV`) are intentional API surface (curves/properties), and for tests/scripts where unit-suffixed identifiers carry domain meaning.
- Renamed chainable methods to verb-form: `grade_` → `add_grade`, `temper_` → `add_temper`, `treatment_` → `add_treatment`, `vendor_` → `add_vendor`, `variant_` → `add_variant`. Old names survive as deprecation aliases (`DeprecationWarning`, removed in 4.0).
- Hook wired into pre-commit (`.pre-commit-config.yaml`) and CI lint job (`.github/workflows/ci.yml`).

## Why
Bernhard's py-mat #218 explicitly called out the trailing-underscore convention as a PEP 8 violation. PEP 8 reserves the trailing single underscore for keyword-collision avoidance only (`class_`, `type_`). Using it as a general "verb-ish" suffix confuses readers and tools.

## Test plan
- [x] 34 tests for the hook itself (`tests/test_check_pep_naming.py`) — keyword/builtin allow-list, dunder skip, suppression directives, syntax-error handling, repo-clean regression guard
- [x] 13 tests for the rename + deprecation aliases (`tests/test_chainable_rename.py`) — warning fires, message points at new name, stacklevel=2 attributes the warning to the caller, state mutation parity
- [x] Full pytest suite: 857 passed, 36 skipped, 15 xfailed (visual-regression module skipped — needs PIL)
- [x] `ruff check .` clean
- [x] `python scripts/check_pep_naming.py` clean on src/, tests/, scripts/

## Migration
3.x callers using `mat.grade_(...)` etc. will see a `DeprecationWarning` but continue to work. Update to `add_grade(...)` before 4.0.