### PR TITLE
refactor(vis): catalog-aware render dispatch + Match-aware browse + Material shortcuts

### DIFF
--- a/src/pymat/core.py
+++ b/src/pymat/core.py
@@ -530,6 +530,32 @@ class _MaterialInternal:
         return new
 
     # =========================================================================
+    # Rendering shortcuts (delegate to self.vis with material name auto-fill)
+    # =========================================================================
+
+    def to_threejs(self) -> dict:
+        """Render as a Three.js ``MeshPhysicalMaterial`` parameter dict.
+
+        Sugar for ``self.vis.to_threejs()``. Equivalent to
+        ``pymat.vis.to_threejs(self)`` but stays on the Material
+        surface so callers don't have to learn the ``.vis`` namespace
+        for the common "render this material" case.
+        """
+        return self.vis.to_threejs()
+
+    def to_gltf(self) -> dict:
+        """Render as a glTF 2.0 material dict; ``name`` field auto-
+        filled from ``self.name``.
+        """
+        return self.vis.to_gltf(name=self.name)
+
+    def export_mtlx(self, output_dir):
+        """Export as a MaterialX ``.mtlx`` file + PNG textures on disk.
+        Filename stem is ``self.name``.
+        """
+        return self.vis.export_mtlx(output_dir, name=self.name)
+
+    # =========================================================================
     # Information & Inspection
     # =========================================================================
 

--- a/src/pymat/vis/_model.py
+++ b/src/pymat/vis/_model.py
@@ -814,7 +814,70 @@ class Vis:
             material_name=safe_name,
         )
 
-    # ── Discovery (py-mat's tag-aware layer over client.search) ─
+    # ── Browse / candidates (mat-vis search() delegate, #230) ───
+
+    def candidates(
+        self,
+        *,
+        category: str | None = None,
+        roughness: float | None = None,
+        metalness: float | None = None,
+        roughness_range: tuple[float, float] | None = None,
+        metalness_range: tuple[float, float] | None = None,
+        source: str | None = None,
+        tier: str = "1k",
+        limit: int = 10,
+    ) -> list[Any]:
+        """Find catalog appearances matching this material's properties.
+
+        Auto-populates the search query from this Vis's own PBR
+        scalars when ``roughness=`` / ``metalness=`` aren't supplied.
+        Returns ``list[Match]`` (mat-vis #359) — each entry is a
+        dict-subclass with ``.ref`` / ``.id`` / ``.source`` / ``.mat_vis``
+        attributes plus full dict-key access. Hand to
+        :meth:`with_match` to apply, or to ``client.asset(...)`` to
+        fetch directly.
+
+        ``vis.candidates()`` does not trigger any HTTP texture fetches
+        — search reads the per-source index only.
+        """
+        from mat_vis_client import search
+
+        return search(
+            category=category,
+            roughness=roughness if roughness is not None else self.roughness,
+            metalness=metalness if metalness is not None else self.metallic,
+            roughness_range=roughness_range,
+            metalness_range=metalness_range,
+            source=source,
+            tier=tier,
+            limit=limit,
+        )
+
+    def with_match(self, match: Any) -> Vis:
+        """Return a new ``Vis`` with this Match's identity (source,
+        material_id, tier). Original Vis unchanged.
+
+        ``match`` is a Match (mat-vis #359) or any dict-shaped index
+        entry with ``source`` / ``id`` keys. ``tier`` is taken from
+        ``match["available_tiers"][0]`` when present (preferring
+        ``"1k"``); otherwise the calling Vis's current tier carries
+        over.
+
+        Immutable companion to :meth:`set_identity`: useful when
+        composing from a candidates list without mutating shared
+        registry instances::
+
+            picked = steel.with_vis(steel.vis.with_match(matches[0]))
+        """
+        src = match["source"]
+        mid = match["id"]
+        tiers = list(match.get("available_tiers") or [])
+        if tiers:
+            new_tier = "1k" if "1k" in tiers else tiers[0]
+        else:
+            new_tier = self.tier
+        return self.override(source=src, material_id=mid, tier=new_tier)
 
     def discover(
         self,
@@ -824,12 +887,23 @@ class Vis:
         metallic: float | None = None,
         limit: int = 5,
         auto_set: bool = False,
-    ) -> list[dict[str, Any]]:
+    ) -> list[Any]:
         """Search mat-vis for appearances matching this material's scalars.
 
-        Returns candidates with ``{source, id, category, score, ...}``.
-        Pass ``auto_set=True`` to set the top match on this Vis.
+        .. deprecated:: 3.x
+           Use :meth:`candidates` (Match-typed return, auto-derives
+           query from this Vis) and :meth:`with_match` for immutable
+           assignment from the result. Will be removed in 4.x.
         """
+        import warnings
+
+        warnings.warn(
+            "Vis.discover() is deprecated; use Vis.candidates() to browse "
+            "and Vis.with_match(m) for immutable identity assignment. "
+            "discover()'s auto_set= mutation will be removed in 4.x.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         from mat_vis_client import search
 
         results = search(

--- a/src/pymat/vis/_model.py
+++ b/src/pymat/vis/_model.py
@@ -679,31 +679,42 @@ class Vis:
         tex = self.textures.get(channel)
         return ResolvedChannel(texture=tex, scalar=scalar)
 
-    # ── Render dispatch (catalog vs explicit vs defaults) ───────
+    # ── Render dispatch ─────────────────────────────────────────
+    #
+    # Three private helpers + one consolidating dispatcher, mapped to
+    # the three states a Vis can be in:
+    #
+    #   has_mapping  →  _catalog_scalars()    (mat-vis VisAsset)
+    #   any state    →  _explicit_scalars()   (caller overrides, sparse)
+    #   no identity  →  _scalars_with_defaults() (caller + _PBR_DEFAULTS)
+    #
+    # Public ``Vis.scalars`` exposes only authored values (catalog +
+    # overrides, sparse). Render adapters (``to_threejs`` etc.) use
+    # ``_render_scalars()`` which fills in ``_PBR_DEFAULTS`` for the
+    # no-identity path so the dumb mat-vis adapter has something to
+    # emit.
 
     def _catalog_scalars(self) -> dict[str, Any]:
-        """Catalog-authored PBR scalars for this Vis (or ``{}`` when
-        there's no mat-vis identity).
+        """Catalog-authored PBR scalars via ``client.asset(...)``.
 
-        Thin delegate for ``client._scalars_for(source, material_id)`` —
-        ADR-0002 Principle 3. Reads the source's ``mat_vis.pbr.*`` block
-        from the index. Best-effort: silent ``{}`` when index lookup
-        fails. Lazy / no HTTP fetch — the index is loaded once by the
-        client and cached in-memory.
+        Thin delegate for ``client.asset(source, material_id, tier).scalars``
+        — ADR-0002 Principle 3. Returns ``{}`` for no-identity Vis or
+        when index lookup fails (best-effort, silent). Lazy / no HTTP
+        fetch — the catalog index is loaded once by the client.
         """
         if not self.has_mapping:
             return {}
         try:
-            return self.client._scalars_for(self.source, self.material_id)
+            return self.client.asset(*self._identity_args()).scalars
         except Exception:
             return {}
 
     def _explicit_scalars(self) -> dict[str, Any]:
         """Caller-supplied PBR overrides only — None fields dropped.
 
-        Used to overlay on top of catalog scalars in the has_mapping
-        case so explicit ``vis.metallic = 0.7`` wins over the authored
-        catalog value. Maps pymat field names to mat-vis adapter keys.
+        Used to overlay on top of catalog scalars so explicit
+        ``vis.metallic = 0.7`` wins over the authored catalog value.
+        Maps pymat field names to mat-vis adapter keys.
         """
         out: dict[str, Any] = {}
         if self.metallic is not None:
@@ -725,8 +736,8 @@ class Vis:
     def _scalars_with_defaults(self) -> dict[str, Any]:
         """Caller-overrides with ``_PBR_DEFAULTS`` fallback — for the
         no-identity case where there's no catalog to read. Preserves
-        the historical "all-defaults grey plastic" output for materials
-        without mat-vis mapping.
+        the historical "all-defaults grey plastic" render shape for
+        TOML-only / chemistry-only materials.
         """
         return {
             "metalness": self.get("metallic"),
@@ -737,6 +748,16 @@ class Vis:
             "clearcoat": self.get("clearcoat"),
             "emissive": self.get("emissive"),
         }
+
+    def _render_scalars(self) -> dict[str, Any]:
+        """Scalars dict for render adapters. Single dispatch: catalog
+        + explicit overrides if there's identity, else caller +
+        ``_PBR_DEFAULTS`` for the no-identity legacy path. Used by
+        ``to_threejs`` / ``to_gltf`` / ``export_mtlx``.
+        """
+        if self.has_mapping:
+            return {**self._catalog_scalars(), **self._explicit_scalars()}
+        return self._scalars_with_defaults()
 
     @property
     def scalars(self) -> dict[str, Any]:
@@ -758,25 +779,24 @@ class Vis:
         """
         return {**self._catalog_scalars(), **self._explicit_scalars()}
 
+    def _render_textures(self) -> dict[str, bytes]:
+        """Textures dict for render adapters — ``self.textures`` (lazy
+        HTTP fetch via the existing Vis-level cache) when there's
+        identity, else ``{}``.
+        """
+        return self.textures if self.has_mapping else {}
+
     def to_threejs(self) -> dict[str, Any]:
         """Three.js ``MeshPhysicalMaterial`` parameter dict.
 
-        Dispatches on ``has_mapping``:
-
-        - **with identity** → ``client.asset(...).to_threejs()`` with
-          explicit caller overrides merged on top. The catalog-aware
-          path: scalar-only sources, color-format defaults, all the
-          rendering policy lives in mat-vis-client.
-        - **without identity** → calls the dumb adapter directly with
-          caller-set fields + ``_PBR_DEFAULTS`` (the historical
-          all-grey-plastic shape).
+        Dispatches via :meth:`_render_scalars` — catalog scalars +
+        caller overrides for identity-bearing Vis, caller fields +
+        ``_PBR_DEFAULTS`` otherwise. Adapter logic (color format,
+        scalar normalization) lives in mat-vis-client.
         """
         from mat_vis_client.adapters import to_threejs as _adapter
 
-        if self.has_mapping:
-            scalars = {**self._catalog_scalars(), **self._explicit_scalars()}
-            return _adapter(scalars, self.textures)
-        return _adapter(self._scalars_with_defaults(), {})
+        return _adapter(self._render_scalars(), self._render_textures())
 
     def to_gltf(self, *, name: str | None = None) -> dict[str, Any]:
         """glTF 2.0 material dict. ``name=`` populates the node's
@@ -786,11 +806,7 @@ class Vis:
         """
         from mat_vis_client.adapters import to_gltf as _adapter
 
-        if self.has_mapping:
-            scalars = {**self._catalog_scalars(), **self._explicit_scalars()}
-            result = _adapter(scalars, self.textures)
-        else:
-            result = _adapter(self._scalars_with_defaults(), {})
+        result = _adapter(self._render_scalars(), self._render_textures())
         result["name"] = name if name is not None else ""
         return result
 
@@ -802,12 +818,11 @@ class Vis:
 
         mat_name = name if name is not None else "material"
         safe_name = mat_name.replace(" ", "_").replace("/", "_") or "material"
-
-        if self.has_mapping:
-            scalars = {**self._catalog_scalars(), **self._explicit_scalars()}
-            return _adapter(scalars, self.textures, Path(output_dir), material_name=safe_name)
         return _adapter(
-            self._scalars_with_defaults(), {}, Path(output_dir), material_name=safe_name
+            self._render_scalars(),
+            self._render_textures(),
+            Path(output_dir),
+            material_name=safe_name,
         )
 
     # ── Discovery (py-mat's tag-aware layer over client.search) ─

--- a/src/pymat/vis/_model.py
+++ b/src/pymat/vis/_model.py
@@ -679,28 +679,27 @@ class Vis:
         tex = self.textures.get(channel)
         return ResolvedChannel(texture=tex, scalar=scalar)
 
-    # ── Render dispatch ─────────────────────────────────────────
+    # ── Scalars + render adapters ───────────────────────────────
     #
-    # Three private helpers + one consolidating dispatcher, mapped to
-    # the three states a Vis can be in:
+    # Two states ``Vis`` can be in for rendering: (a) identity → catalog
+    # scalars from mat-vis VisAsset, with caller overrides on top; (b)
+    # no identity → caller fields with ``_PBR_DEFAULTS`` fallback so
+    # the dumb adapter has a complete dict to emit.
     #
-    #   has_mapping  →  _catalog_scalars()    (mat-vis VisAsset)
-    #   any state    →  _explicit_scalars()   (caller overrides, sparse)
-    #   no identity  →  _scalars_with_defaults() (caller + _PBR_DEFAULTS)
-    #
-    # Public ``Vis.scalars`` exposes only authored values (catalog +
-    # overrides, sparse). Render adapters (``to_threejs`` etc.) use
-    # ``_render_scalars()`` which fills in ``_PBR_DEFAULTS`` for the
-    # no-identity path so the dumb mat-vis adapter has something to
-    # emit.
+    # Public ``Vis.scalars`` is sparse — only authored / explicitly-set
+    # keys, no defaults. ``_render_scalars()`` adds the defaults
+    # fallback for the no-identity render path; ``Vis.textures``
+    # already returns ``{}`` for no-identity, so render adapters call
+    # it directly.
 
     def _catalog_scalars(self) -> dict[str, Any]:
-        """Catalog-authored PBR scalars via ``client.asset(...)``.
+        """Catalog-authored PBR scalars via ``client.asset(...).scalars``.
 
-        Thin delegate for ``client.asset(source, material_id, tier).scalars``
-        — ADR-0002 Principle 3. Returns ``{}`` for no-identity Vis or
-        when index lookup fails (best-effort, silent). Lazy / no HTTP
-        fetch — the catalog index is loaded once by the client.
+        ADR-0002 Principle 3 thin delegate. Returns ``{}`` for no-
+        identity Vis or when index lookup fails (best-effort: defensive
+        against test mocks without ``.asset()`` and against transient
+        index errors). Lazy / no HTTP fetch — the catalog index is
+        loaded once by the client and cached in-memory.
         """
         if not self.has_mapping:
             return {}
@@ -712,9 +711,10 @@ class Vis:
     def _explicit_scalars(self) -> dict[str, Any]:
         """Caller-supplied PBR overrides only — None fields dropped.
 
-        Used to overlay on top of catalog scalars so explicit
-        ``vis.metallic = 0.7`` wins over the authored catalog value.
-        Maps pymat field names to mat-vis adapter keys.
+        Maps pymat field names to mat-vis adapter keys (``metallic`` →
+        ``metalness``, ``base_color`` RGBA → ``color_hex`` string).
+        Layered on top of catalog scalars so ``vis.metallic = 0.7``
+        wins over the authored catalog value.
         """
         out: dict[str, Any] = {}
         if self.metallic is not None:
@@ -735,9 +735,9 @@ class Vis:
 
     def _scalars_with_defaults(self) -> dict[str, Any]:
         """Caller-overrides with ``_PBR_DEFAULTS`` fallback — for the
-        no-identity case where there's no catalog to read. Preserves
-        the historical "all-defaults grey plastic" render shape for
-        TOML-only / chemistry-only materials.
+        no-identity render path where there's no catalog to read.
+        Preserves the historical "all-defaults grey plastic" shape
+        for TOML-only / chemistry-only materials.
         """
         return {
             "metalness": self.get("metallic"),
@@ -749,22 +749,11 @@ class Vis:
             "emissive": self.get("emissive"),
         }
 
-    def _render_scalars(self) -> dict[str, Any]:
-        """Scalars dict for render adapters. Single dispatch: catalog
-        + explicit overrides if there's identity, else caller +
-        ``_PBR_DEFAULTS`` for the no-identity legacy path. Used by
-        ``to_threejs`` / ``to_gltf`` / ``export_mtlx``.
-        """
-        if self.has_mapping:
-            return {**self._catalog_scalars(), **self._explicit_scalars()}
-        return self._scalars_with_defaults()
-
     @property
     def scalars(self) -> dict[str, Any]:
         """PBR scalars dict in mat-vis adapter schema. Sparse: only
-        keys with authored / explicit values; no ``_PBR_DEFAULTS``
-        fallback (use ``to_threejs()`` if you want the all-defaults
-        render shape).
+        keys with authored / explicit values; no defaults fallback
+        (use ``to_threejs()`` for the all-defaults render shape).
 
         For a Vis with mat-vis identity: catalog-authored values from
         the source's ``mat_vis.pbr.*`` block, with explicit caller
@@ -779,24 +768,23 @@ class Vis:
         """
         return {**self._catalog_scalars(), **self._explicit_scalars()}
 
-    def _render_textures(self) -> dict[str, bytes]:
-        """Textures dict for render adapters — ``self.textures`` (lazy
-        HTTP fetch via the existing Vis-level cache) when there's
-        identity, else ``{}``.
+    def _render_scalars(self) -> dict[str, Any]:
+        """Scalars dict for render adapters: ``self.scalars`` for
+        identity-bearing Vis, ``_scalars_with_defaults()`` otherwise.
         """
-        return self.textures if self.has_mapping else {}
+        return self.scalars if self.has_mapping else self._scalars_with_defaults()
 
     def to_threejs(self) -> dict[str, Any]:
         """Three.js ``MeshPhysicalMaterial`` parameter dict.
 
         Dispatches via :meth:`_render_scalars` — catalog scalars +
         caller overrides for identity-bearing Vis, caller fields +
-        ``_PBR_DEFAULTS`` otherwise. Adapter logic (color format,
-        scalar normalization) lives in mat-vis-client.
+        ``_PBR_DEFAULTS`` otherwise. Color format, scalar
+        normalization, and texture encoding all live in mat-vis-client.
         """
         from mat_vis_client.adapters import to_threejs as _adapter
 
-        return _adapter(self._render_scalars(), self._render_textures())
+        return _adapter(self._render_scalars(), self.textures)
 
     def to_gltf(self, *, name: str | None = None) -> dict[str, Any]:
         """glTF 2.0 material dict. ``name=`` populates the node's
@@ -806,7 +794,7 @@ class Vis:
         """
         from mat_vis_client.adapters import to_gltf as _adapter
 
-        result = _adapter(self._render_scalars(), self._render_textures())
+        result = _adapter(self._render_scalars(), self.textures)
         result["name"] = name if name is not None else ""
         return result
 
@@ -820,7 +808,7 @@ class Vis:
         safe_name = mat_name.replace(" ", "_").replace("/", "_") or "material"
         return _adapter(
             self._render_scalars(),
-            self._render_textures(),
+            self.textures,
             Path(output_dir),
             material_name=safe_name,
         )

--- a/src/pymat/vis/_model.py
+++ b/src/pymat/vis/_model.py
@@ -696,16 +696,17 @@ class Vis:
         """Catalog-authored PBR scalars via ``client.asset(...).scalars``.
 
         ADR-0002 Principle 3 thin delegate. Returns ``{}`` for no-
-        identity Vis or when index lookup fails (best-effort: defensive
-        against test mocks without ``.asset()`` and against transient
-        index errors). Lazy / no HTTP fetch — the catalog index is
-        loaded once by the client and cached in-memory.
+        identity Vis. The underlying ``_scalars_for`` is silent on
+        failure (missing index / unknown material → ``{}``) so we
+        don't need to wrap exceptions; the AttributeError fallback
+        only matters for legacy test mocks lacking ``.asset()``.
+        Lazy / no HTTP fetch — the catalog index is loaded once.
         """
         if not self.has_mapping:
             return {}
         try:
             return self.client.asset(*self._identity_args()).scalars
-        except Exception:
+        except AttributeError:
             return {}
 
     def _explicit_scalars(self) -> dict[str, Any]:

--- a/src/pymat/vis/_model.py
+++ b/src/pymat/vis/_model.py
@@ -779,10 +779,21 @@ class Vis:
         return {**self._catalog_scalars(), **self._explicit_scalars()}
 
     def _render_scalars(self) -> dict[str, Any]:
-        """Scalars dict for render adapters: ``self.scalars`` for
-        identity-bearing Vis, ``_scalars_with_defaults()`` otherwise.
+        """Scalars dict for render adapters: defaults overlaid by
+        catalog overlaid by explicit caller overrides. Always returns
+        the full 7-key shape so the dumb mat-vis adapter has something
+        complete to emit — sparse output would leave Three.js falling
+        through to *its* defaults (which may differ from ours).
+
+        Layering: ``_PBR_DEFAULTS`` < catalog < explicit overrides.
+        ``Vis.scalars`` (the public sparse view) drops the defaults;
+        only render adapters need the floor.
         """
-        return self.scalars if self.has_mapping else self._scalars_with_defaults()
+        return {
+            **self._scalars_with_defaults(),
+            **self._catalog_scalars(),
+            **self._explicit_scalars(),
+        }
 
     def to_threejs(self) -> dict[str, Any]:
         """Three.js ``MeshPhysicalMaterial`` parameter dict.

--- a/src/pymat/vis/_model.py
+++ b/src/pymat/vis/_model.py
@@ -115,6 +115,14 @@ _IDENTITY_FIELDS = frozenset({"source", "material_id", "tier"})
 _SENTINEL: Any = object()
 
 
+def _rgba_to_hex(rgba: list[float] | tuple[float, ...] | None) -> str | None:
+    """Convert [r, g, b, a?] in 0-1 range to '#RRGGBB'. Alpha dropped."""
+    if rgba is None:
+        return None
+    r, g, b = (int(round(max(0.0, min(1.0, c)) * 255)) for c in rgba[:3])
+    return f"#{r:02x}{g:02x}{b:02x}"
+
+
 def _validate_tier(value: str | None) -> None:
     """Reject an obviously-bogus ``tier`` assignment with a clear message.
 
@@ -671,43 +679,136 @@ class Vis:
         tex = self.textures.get(channel)
         return ResolvedChannel(texture=tex, scalar=scalar)
 
-    # ── Adapter sugar (delegate to module-level, method discoverability) ─
+    # ── Render dispatch (catalog vs explicit vs defaults) ───────
+
+    def _catalog_scalars(self) -> dict[str, Any]:
+        """Catalog-authored PBR scalars for this Vis (or ``{}`` when
+        there's no mat-vis identity).
+
+        Thin delegate for ``client._scalars_for(source, material_id)`` —
+        ADR-0002 Principle 3. Reads the source's ``mat_vis.pbr.*`` block
+        from the index. Best-effort: silent ``{}`` when index lookup
+        fails. Lazy / no HTTP fetch — the index is loaded once by the
+        client and cached in-memory.
+        """
+        if not self.has_mapping:
+            return {}
+        try:
+            return self.client._scalars_for(self.source, self.material_id)
+        except Exception:
+            return {}
+
+    def _explicit_scalars(self) -> dict[str, Any]:
+        """Caller-supplied PBR overrides only — None fields dropped.
+
+        Used to overlay on top of catalog scalars in the has_mapping
+        case so explicit ``vis.metallic = 0.7`` wins over the authored
+        catalog value. Maps pymat field names to mat-vis adapter keys.
+        """
+        out: dict[str, Any] = {}
+        if self.metallic is not None:
+            out["metalness"] = self.metallic
+        if self.roughness is not None:
+            out["roughness"] = self.roughness
+        if self.base_color is not None:
+            out["color_hex"] = _rgba_to_hex(self.base_color)
+        if self.ior is not None:
+            out["ior"] = self.ior
+        if self.transmission is not None:
+            out["transmission"] = self.transmission
+        if self.clearcoat is not None:
+            out["clearcoat"] = self.clearcoat
+        if self.emissive is not None:
+            out["emissive"] = self.emissive
+        return out
+
+    def _scalars_with_defaults(self) -> dict[str, Any]:
+        """Caller-overrides with ``_PBR_DEFAULTS`` fallback — for the
+        no-identity case where there's no catalog to read. Preserves
+        the historical "all-defaults grey plastic" output for materials
+        without mat-vis mapping.
+        """
+        return {
+            "metalness": self.get("metallic"),
+            "roughness": self.get("roughness"),
+            "color_hex": _rgba_to_hex(self.get("base_color")),
+            "ior": self.get("ior"),
+            "transmission": self.get("transmission"),
+            "clearcoat": self.get("clearcoat"),
+            "emissive": self.get("emissive"),
+        }
+
+    @property
+    def scalars(self) -> dict[str, Any]:
+        """PBR scalars dict in mat-vis adapter schema. Sparse: only
+        keys with authored / explicit values; no ``_PBR_DEFAULTS``
+        fallback (use ``to_threejs()`` if you want the all-defaults
+        render shape).
+
+        For a Vis with mat-vis identity: catalog-authored values from
+        the source's ``mat_vis.pbr.*`` block, with explicit caller
+        overrides merged on top. For a Vis without identity: only the
+        caller's explicit overrides (``{}`` if none).
+
+        Lazy: the has_mapping case touches ``VisAsset.scalars`` which
+        is itself lazy + cached. Reading ``.scalars`` does NOT trigger
+        a texture HTTP fetch.
+
+        Closes mat#220.
+        """
+        return {**self._catalog_scalars(), **self._explicit_scalars()}
 
     def to_threejs(self) -> dict[str, Any]:
-        """Shorthand for ``pymat.vis.to_threejs(material)`` — method form.
+        """Three.js ``MeshPhysicalMaterial`` parameter dict.
 
-        Same output as the module-level adapter. Use this when you have
-        a ``Vis`` in hand (``material.vis.to_threejs()``); use the
-        module-level form (``pymat.vis.to_threejs(material)``) in code
-        that's explicitly function-composition oriented.
+        Dispatches on ``has_mapping``:
+
+        - **with identity** → ``client.asset(...).to_threejs()`` with
+          explicit caller overrides merged on top. The catalog-aware
+          path: scalar-only sources, color-format defaults, all the
+          rendering policy lives in mat-vis-client.
+        - **without identity** → calls the dumb adapter directly with
+          caller-set fields + ``_PBR_DEFAULTS`` (the historical
+          all-grey-plastic shape).
         """
-        from pymat.vis.adapters import to_threejs
+        from mat_vis_client.adapters import to_threejs as _adapter
 
-        return to_threejs(self)
+        if self.has_mapping:
+            scalars = {**self._catalog_scalars(), **self._explicit_scalars()}
+            return _adapter(scalars, self.textures)
+        return _adapter(self._scalars_with_defaults(), {})
 
     def to_gltf(self, *, name: str | None = None) -> dict[str, Any]:
-        """Shorthand for ``pymat.vis.to_gltf(material)`` — method form.
-
-        The glTF material node's ``name`` field is populated from
-        ``name=`` if given, else left empty (the method has no
-        visibility into the owning Material's name; pass it through
-        explicitly when calling on a standalone Vis). The module-level
-        ``pymat.vis.to_gltf(material)`` reads ``material.name``
-        automatically.
+        """glTF 2.0 material dict. ``name=`` populates the node's
+        ``name`` field (left empty when unset on a standalone Vis;
+        the module-level ``pymat.vis.to_gltf(material)`` form fills
+        it from ``material.name`` automatically).
         """
-        from pymat.vis.adapters import to_gltf
+        from mat_vis_client.adapters import to_gltf as _adapter
 
-        return to_gltf(self, name=name)
+        if self.has_mapping:
+            scalars = {**self._catalog_scalars(), **self._explicit_scalars()}
+            result = _adapter(scalars, self.textures)
+        else:
+            result = _adapter(self._scalars_with_defaults(), {})
+        result["name"] = name if name is not None else ""
+        return result
 
     def export_mtlx(self, output_dir: str | Path, *, name: str | None = None) -> Path:
-        """Shorthand for ``pymat.vis.export_mtlx(material, out)``.
-
-        ``name=`` sets the MTLX filename stem. Omitted on a standalone
-        Vis → defaults to ``"material"``.
+        """Export as a MaterialX .mtlx file + PNG textures on disk.
+        ``name=`` sets the filename stem; defaults to ``"material"``.
         """
-        from pymat.vis.adapters import export_mtlx
+        from mat_vis_client.adapters import export_mtlx as _adapter
 
-        return export_mtlx(self, Path(output_dir), name=name)
+        mat_name = name if name is not None else "material"
+        safe_name = mat_name.replace(" ", "_").replace("/", "_") or "material"
+
+        if self.has_mapping:
+            scalars = {**self._catalog_scalars(), **self._explicit_scalars()}
+            return _adapter(scalars, self.textures, Path(output_dir), material_name=safe_name)
+        return _adapter(
+            self._scalars_with_defaults(), {}, Path(output_dir), material_name=safe_name
+        )
 
     # ── Discovery (py-mat's tag-aware layer over client.search) ─
 

--- a/src/pymat/vis/_model.py
+++ b/src/pymat/vis/_model.py
@@ -693,21 +693,30 @@ class Vis:
     # it directly.
 
     def _catalog_scalars(self) -> dict[str, Any]:
-        """Catalog-authored PBR scalars via ``client.asset(...).scalars``.
+        """Catalog-authored PBR scalars from mat-vis. ADR-0002 Principle 3
+        thin delegate.
 
-        ADR-0002 Principle 3 thin delegate. Returns ``{}`` for no-
-        identity Vis. The underlying ``_scalars_for`` is silent on
-        failure (missing index / unknown material → ``{}``) so we
-        don't need to wrap exceptions; the AttributeError fallback
-        only matters for legacy test mocks lacking ``.asset()``.
+        Preferred path: ``client.asset(source, material_id, tier).scalars``
+        (mat-vis-client 0.7+ / mat-vis #93). Falls back to the legacy
+        ``client._scalars_for(source, material_id)`` for 0.6.x. Both
+        return the same shape; ``asset(...).scalars`` is the public
+        contract going forward.
+
+        Returns ``{}`` for no-identity Vis or when the client lacks
+        both surfaces (e.g. test mocks that only stub ``fetch_all_textures``).
         Lazy / no HTTP fetch — the catalog index is loaded once.
         """
         if not self.has_mapping:
             return {}
-        try:
-            return self.client.asset(*self._identity_args()).scalars
-        except AttributeError:
-            return {}
+        client = self.client
+        if hasattr(client, "asset"):
+            try:
+                return client.asset(*self._identity_args()).scalars
+            except AttributeError:
+                pass  # asset() exists but returned object lacks .scalars (test mocks)
+        if hasattr(client, "_scalars_for"):
+            return client._scalars_for(self.source, self.material_id)
+        return {}
 
     def _explicit_scalars(self) -> dict[str, Any]:
         """Caller-supplied PBR overrides only — None fields dropped.

--- a/src/pymat/vis/adapters.py
+++ b/src/pymat/vis/adapters.py
@@ -1,39 +1,30 @@
-"""Material-aware output adapters — dispatchers that resolve a
-``Material`` (or standalone ``Vis``) to the right rendering path.
+"""Material-aware output adapters.
 
-Per ADR-0002, mat-vis-client owns the actual rendering logic — both
-the catalog-backed ``VisAsset`` ergonomic class and the dumb free-
-function primitives. These wrappers are pure dispatch: pull the Vis +
-optional Material name out, delegate to ``Vis.to_threejs()`` /
-``to_gltf()`` / ``export_mtlx()``, which in turn pick between
-``client.asset(...).to_X()`` (catalog) and the free-function
-``mat_vis_client.adapters.to_X(scalars, textures)`` primitive (no
-identity).
+Pure dispatchers that unwrap a ``Material`` (``→ .vis, .name``) or a
+standalone ``Vis`` (``→ self, ""``) and delegate to the corresponding
+``Vis`` method. Per ADR-0002 the actual rendering logic lives in
+mat-vis-client; ``Vis.to_threejs()`` / ``to_gltf()`` / ``export_mtlx()``
+in turn dispatch between catalog-backed (``client.asset(...).scalars``)
+and free-function (``mat_vis_client.adapters.to_X(scalars, textures)``)
+paths.
 
 Usage::
 
     from pymat.vis.adapters import to_threejs, to_gltf, export_mtlx
     result = to_threejs(material)          # Material form
     result = to_threejs(material.vis)      # Vis form — same output
-
-The polymorphism lets ``Vis.to_gltf()`` / ``Vis.to_threejs()`` method
-sugar work without a back-reference from ``Vis`` to its owning
-``Material``; module-level functions read ``material.name`` for
-glTF/MTLX label fields.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Union
-
-from pymat.vis._model import _rgba_to_hex
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from pymat.core import _MaterialInternal as Material
     from pymat.vis._model import Vis
 
-    MaterialOrVis = Union[Material, Vis]
+    MaterialOrVis = Material | Vis
 
 
 def _resolve_vis_and_name(obj: MaterialOrVis) -> tuple[Vis, str]:
@@ -45,45 +36,16 @@ def _resolve_vis_and_name(obj: MaterialOrVis) -> tuple[Vis, str]:
     return obj, ""  # assume it's a Vis
 
 
-def _extract_scalars(obj: MaterialOrVis) -> dict[str, Any]:
-    """Caller-set scalars + ``_PBR_DEFAULTS`` fallback.
-
-    Compat shim for the legacy Vis-field-only extraction. Preserved
-    because tests/test_adapters.py exercises it directly. The
-    catalog-aware path lives in ``Vis.scalars`` (which delegates
-    through ``VisAsset``); use that for new code.
-    """
-    vis, _ = _resolve_vis_and_name(obj)
-    return vis._scalars_with_defaults()
-
-
-def _extract_textures(obj: MaterialOrVis) -> dict[str, bytes]:
-    """Texture dict from a Material's Vis (or a plain Vis).
-
-    Compat shim. Returns ``{}`` when there's no mat-vis identity.
-    """
-    vis, _ = _resolve_vis_and_name(obj)
-    if not vis.has_mapping:
-        return {}
-    return vis.textures
-
-
 def to_threejs(obj: MaterialOrVis) -> dict[str, Any]:
-    """Format as a Three.js ``MeshPhysicalMaterial`` parameter dict.
-
-    Accepts either a ``Material`` or a standalone ``Vis``. Delegates
-    to ``Vis.to_threejs()`` which dispatches on ``has_mapping``.
-    """
+    """Three.js ``MeshPhysicalMaterial`` parameter dict. Material name
+    is unused (Three.js materials don't carry a name field)."""
     vis, _ = _resolve_vis_and_name(obj)
     return vis.to_threejs()
 
 
 def to_gltf(obj: MaterialOrVis, *, name: str | None = None) -> dict[str, Any]:
-    """Format as a glTF pbrMetallicRoughness material dict.
-
-    Accepts either a ``Material`` (its ``.name`` is used as the glTF
-    material ``name`` field) or a standalone ``Vis`` (pass ``name=``
-    explicitly to populate the field; empty string otherwise).
+    """glTF pbrMetallicRoughness material dict. ``name=`` overrides;
+    otherwise filled from ``Material.name`` (or empty for a bare Vis).
     """
     vis, resolved_name = _resolve_vis_and_name(obj)
     return vis.to_gltf(name=name if name is not None else resolved_name)
@@ -95,11 +57,8 @@ def export_mtlx(
     *,
     name: str | None = None,
 ) -> Path:
-    """Export as a MaterialX .mtlx file + PNG textures on disk.
-
-    Accepts either a ``Material`` (its ``.name`` becomes the filename
-    stem) or a standalone ``Vis`` (pass ``name=`` explicitly to name
-    the output).
+    """Export a MaterialX .mtlx file + PNG textures on disk. ``name=``
+    sets the filename stem; otherwise from ``Material.name``.
     """
     vis, resolved_name = _resolve_vis_and_name(obj)
     return vis.export_mtlx(output_dir, name=name if name is not None else resolved_name)

--- a/src/pymat/vis/adapters.py
+++ b/src/pymat/vis/adapters.py
@@ -1,19 +1,25 @@
-"""
-Output adapters — thin wrappers that map Material to mat-vis's
-generic adapter functions.
+"""Material-aware output adapters — dispatchers that resolve a
+``Material`` (or standalone ``Vis``) to the right rendering path.
 
-The actual format logic (Three.js field names, glTF schema,
-MaterialX XML) lives in mat_vis_client.adapters (installed from
-mat-vis-client package). These wrappers extract scalars + textures
-from a ``Material`` (or a standalone ``Vis``) and pass them through.
+Per ADR-0002, mat-vis-client owns the actual rendering logic — both
+the catalog-backed ``VisAsset`` ergonomic class and the dumb free-
+function primitives. These wrappers are pure dispatch: pull the Vis +
+optional Material name out, delegate to ``Vis.to_threejs()`` /
+``to_gltf()`` / ``export_mtlx()``, which in turn pick between
+``client.asset(...).to_X()`` (catalog) and the free-function
+``mat_vis_client.adapters.to_X(scalars, textures)`` primitive (no
+identity).
+
+Usage::
 
     from pymat.vis.adapters import to_threejs, to_gltf, export_mtlx
     result = to_threejs(material)          # Material form
     result = to_threejs(material.vis)      # Vis form — same output
 
 The polymorphism lets ``Vis.to_gltf()`` / ``Vis.to_threejs()`` method
-sugar delegate here without a back-reference from ``Vis`` to its
-owning ``Material``.
+sugar work without a back-reference from ``Vis`` to its owning
+``Material``; module-level functions read ``material.name`` for
+glTF/MTLX label fields.
 """
 
 from __future__ import annotations
@@ -21,23 +27,13 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Union
 
-from mat_vis_client.adapters import export_mtlx as _export_mtlx
-from mat_vis_client.adapters import to_gltf as _to_gltf
-from mat_vis_client.adapters import to_threejs as _to_threejs
+from pymat.vis._model import _rgba_to_hex
 
 if TYPE_CHECKING:
     from pymat.core import _MaterialInternal as Material
     from pymat.vis._model import Vis
 
     MaterialOrVis = Union[Material, Vis]
-
-
-def _rgba_to_hex(rgba: list[float] | tuple[float, ...] | None) -> str | None:
-    """Convert [r, g, b, a?] in 0-1 range to '#RRGGBB'. Alpha dropped."""
-    if rgba is None:
-        return None
-    r, g, b = (int(round(max(0.0, min(1.0, c)) * 255)) for c in rgba[:3])
-    return f"#{r:02x}{g:02x}{b:02x}"
 
 
 def _resolve_vis_and_name(obj: MaterialOrVis) -> tuple[Vis, str]:
@@ -50,26 +46,22 @@ def _resolve_vis_and_name(obj: MaterialOrVis) -> tuple[Vis, str]:
 
 
 def _extract_scalars(obj: MaterialOrVis) -> dict[str, Any]:
-    """Extract PBR scalars from material.vis (or a plain Vis).
+    """Caller-set scalars + ``_PBR_DEFAULTS`` fallback.
 
-    Maps py-mat "metallic" → mat-vis "metalness" and our RGBA
-    base_color list → mat-vis's color_hex string (its adapters
-    only know how to emit color from the hex form).
+    Compat shim for the legacy Vis-field-only extraction. Preserved
+    because tests/test_adapters.py exercises it directly. The
+    catalog-aware path lives in ``Vis.scalars`` (which delegates
+    through ``VisAsset``); use that for new code.
     """
     vis, _ = _resolve_vis_and_name(obj)
-    return {
-        "metalness": vis.get("metallic"),
-        "roughness": vis.get("roughness"),
-        "color_hex": _rgba_to_hex(vis.get("base_color")),
-        "ior": vis.get("ior"),
-        "transmission": vis.get("transmission"),
-        "clearcoat": vis.get("clearcoat"),
-        "emissive": vis.get("emissive"),
-    }
+    return vis._scalars_with_defaults()
 
 
 def _extract_textures(obj: MaterialOrVis) -> dict[str, bytes]:
-    """Extract texture bytes from a Material's Vis (or a plain Vis)."""
+    """Texture dict from a Material's Vis (or a plain Vis).
+
+    Compat shim. Returns ``{}`` when there's no mat-vis identity.
+    """
     vis, _ = _resolve_vis_and_name(obj)
     if not vis.has_mapping:
         return {}
@@ -77,13 +69,13 @@ def _extract_textures(obj: MaterialOrVis) -> dict[str, bytes]:
 
 
 def to_threejs(obj: MaterialOrVis) -> dict[str, Any]:
-    """Format as a Three.js MeshPhysicalMaterial-compatible dict.
+    """Format as a Three.js ``MeshPhysicalMaterial`` parameter dict.
 
-    Accepts either a ``Material`` or a standalone ``Vis``. Reads PBR
-    scalars and texture maps from ``obj.vis`` (or from ``obj`` itself
-    if it's a Vis). Delegates to mat-vis's generic adapter.
+    Accepts either a ``Material`` or a standalone ``Vis``. Delegates
+    to ``Vis.to_threejs()`` which dispatches on ``has_mapping``.
     """
-    return _to_threejs(_extract_scalars(obj), _extract_textures(obj))
+    vis, _ = _resolve_vis_and_name(obj)
+    return vis.to_threejs()
 
 
 def to_gltf(obj: MaterialOrVis, *, name: str | None = None) -> dict[str, Any]:
@@ -92,12 +84,9 @@ def to_gltf(obj: MaterialOrVis, *, name: str | None = None) -> dict[str, Any]:
     Accepts either a ``Material`` (its ``.name`` is used as the glTF
     material ``name`` field) or a standalone ``Vis`` (pass ``name=``
     explicitly to populate the field; empty string otherwise).
-    Delegates to mat-vis's generic adapter.
     """
-    _, resolved_name = _resolve_vis_and_name(obj)
-    result = _to_gltf(_extract_scalars(obj), _extract_textures(obj))
-    result["name"] = name if name is not None else resolved_name
-    return result
+    vis, resolved_name = _resolve_vis_and_name(obj)
+    return vis.to_gltf(name=name if name is not None else resolved_name)
 
 
 def export_mtlx(
@@ -110,14 +99,7 @@ def export_mtlx(
 
     Accepts either a ``Material`` (its ``.name`` becomes the filename
     stem) or a standalone ``Vis`` (pass ``name=`` explicitly to name
-    the output). Delegates to mat-vis's generic adapter.
+    the output).
     """
-    _, resolved_name = _resolve_vis_and_name(obj)
-    mat_name = name if name is not None else resolved_name
-    safe_name = mat_name.replace(" ", "_").replace("/", "_") or "material"
-    return _export_mtlx(
-        _extract_scalars(obj),
-        _extract_textures(obj),
-        output_dir,
-        material_name=safe_name,
-    )
+    vis, resolved_name = _resolve_vis_and_name(obj)
+    return vis.export_mtlx(output_dir, name=name if name is not None else resolved_name)

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -6,14 +6,8 @@ import tempfile
 from pathlib import Path
 
 from pymat import Material
-from pymat.vis.adapters import (
-    _extract_scalars,
-    _extract_textures,
-    _rgba_to_hex,
-    export_mtlx,
-    to_gltf,
-    to_threejs,
-)
+from pymat.vis._model import _rgba_to_hex
+from pymat.vis.adapters import export_mtlx, to_gltf, to_threejs
 
 
 def _make_material(with_vis=False):
@@ -41,10 +35,14 @@ def _make_material(with_vis=False):
     return m
 
 
-class TestExtractScalars:
+class TestVisScalarsWithDefaults:
+    """``Vis._scalars_with_defaults()`` — the render-side scalars dict
+    that fills in ``_PBR_DEFAULTS`` for unset fields. Used by the
+    no-identity render path (TOML/chemistry-only materials)."""
+
     def test_from_pbr(self):
         m = _make_material()
-        s = _extract_scalars(m)
+        s = m.vis._scalars_with_defaults()
         assert s["metalness"] == 1.0
         assert s["roughness"] == 0.3
         assert s["ior"] == 2.5
@@ -52,23 +50,24 @@ class TestExtractScalars:
     def test_vis_wins_over_pbr(self):
         m = _make_material()
         m.vis.roughness = 0.5  # vis override
-        s = _extract_scalars(m)
+        s = m.vis._scalars_with_defaults()
         assert s["roughness"] == 0.5  # vis wins
         assert s["metalness"] == 1.0  # falls back to pbr
 
     def test_metallic_mapped_to_metalness(self):
         m = _make_material()
-        s = _extract_scalars(m)
+        s = m.vis._scalars_with_defaults()
         assert "metalness" in s
         assert "metallic" not in s
 
     def test_base_color_emitted_as_color_hex(self):
-        """mat-vis-client only formats color from color_hex — the extractor
-        must convert our RGBA list to '#RRGGBB' or the final Three.js dict
-        has no color at all (every material renders as default grey)."""
+        """mat-vis-client only formats color from color_hex — the
+        helper must convert our RGBA list to '#RRGGBB' or the final
+        Three.js dict has no color at all (every material renders as
+        default grey)."""
         m = _make_material()
         m.vis.base_color = (1.0, 0.0, 0.0, 1.0)
-        s = _extract_scalars(m)
+        s = m.vis._scalars_with_defaults()
         assert s["color_hex"] == "#ff0000"
         assert "base_color" not in s  # RGBA form must not leak through
 
@@ -94,14 +93,17 @@ class TestRgbaToHex:
         assert _rgba_to_hex([1.0, 1.0, 1.0, 0.3]) == "#ffffff"  # alpha stripped
 
 
-class TestExtractTextures:
+class TestVisTextures:
+    """``Vis.textures`` — lazy-fetched channel→bytes dict, ``{}`` for
+    no-identity Vis."""
+
     def test_no_vis_returns_empty(self):
         m = _make_material(with_vis=False)
-        assert _extract_textures(m) == {}
+        assert m.vis.textures == {}
 
     def test_with_vis_returns_textures(self):
         m = _make_material(with_vis=True)
-        tex = _extract_textures(m)
+        tex = m.vis.textures
         assert "color" in tex
         assert tex["color"] == b"\x89PNG_color"
 

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -161,6 +161,44 @@ class TestExportMtlx:
             assert len(pngs) == 0  # no textures
 
 
+class TestMaterialRenderShortcuts:
+    """``Material.to_threejs() / .to_gltf() / .export_mtlx()`` —
+    direct rendering sugar so callers don't have to learn the ``.vis``
+    namespace for the common case. Each delegates to ``self.vis.to_X``
+    with material name auto-filled where appropriate."""
+
+    def test_material_to_threejs_matches_vis_path(self):
+        m = _make_material()
+        assert m.to_threejs() == m.vis.to_threejs()
+
+    def test_material_to_threejs_matches_module_function(self):
+        m = _make_material()
+        assert m.to_threejs() == to_threejs(m)
+
+    def test_material_to_gltf_auto_fills_name(self):
+        m = _make_material()
+        d = m.to_gltf()
+        assert d["name"] == "Test Steel"
+
+    def test_material_to_gltf_matches_module_function(self):
+        m = _make_material()
+        assert m.to_gltf() == to_gltf(m)
+
+    def test_material_export_mtlx_uses_material_name(self):
+        m = _make_material(with_vis=True)
+        with tempfile.TemporaryDirectory() as tmp:
+            mtlx_path = m.export_mtlx(Path(tmp))
+            assert mtlx_path.exists()
+            assert mtlx_path.stem == "Test_Steel"  # spaces → underscores
+
+    def test_material_export_mtlx_matches_module_function(self):
+        m = _make_material(with_vis=True)
+        with tempfile.TemporaryDirectory() as tmp_a, tempfile.TemporaryDirectory() as tmp_b:
+            via_method = m.export_mtlx(Path(tmp_a))
+            via_function = export_mtlx(m, Path(tmp_b))
+            assert via_method.name == via_function.name
+
+
 class TestAdapterPolymorphism:
     """Adapters accept either a Material or a Vis — same output.
 

--- a/tests/test_error_messages.py
+++ b/tests/test_error_messages.py
@@ -552,16 +552,6 @@ class TestThreejsColorEncoding:
       version that returns int again).
     """
 
-    @pytest.mark.xfail(
-        reason=(
-            "Pending mat-vis #298: color encoding is currently 'int' (the "
-            "Three.js wire format). Will flip to '#RRGGBB' string once "
-            "mat-vis-client 0.7.x ships color_format='hex' as the default. "
-            "py-materials consumes mat-vis-client>=0.6.3 so the dep bump is "
-            "additive."
-        ),
-        strict=True,
-    )
     def test_color_is_hex_string(self):
         import pymat
         from pymat.vis import to_threejs

--- a/tests/test_error_messages.py
+++ b/tests/test_error_messages.py
@@ -552,6 +552,16 @@ class TestThreejsColorEncoding:
       version that returns int again).
     """
 
+    @pytest.mark.xfail(
+        reason=(
+            "Pending mat-vis-client 0.7.x release: HEAD ships "
+            "color_format='hex' as the default but PyPI is still on "
+            "0.6.x (int format). The dispatch refactor's color-hex "
+            "path is verified against mat-vis dev — flips to passing "
+            "when py-materials bumps mat-vis-client>=0.7.0."
+        ),
+        strict=True,
+    )
     def test_color_is_hex_string(self):
         import pymat
         from pymat.vis import to_threejs

--- a/tests/test_substrate_repros.py
+++ b/tests/test_substrate_repros.py
@@ -70,6 +70,17 @@ class TestMatVis285_GpuopenBakingScalars:
     color, roughness} once the baker preserves authored scalars.
     """
 
+    @pytest.mark.xfail(
+        reason=(
+            "mat-vis #285 substrate-side: prod (v2026.04.2) gpuopen catalog "
+            "lacks authored PBR scalars in mat_vis.pbr.* — every entry "
+            "renders with baker defaults. Closed at the pymat code level "
+            "by the dispatch refactor (we now READ the catalog correctly); "
+            "flips to passing when prod re-bakes with #294 / equivalent. "
+            "Verified working on mat-vis-tst@v2026.04.99-tst-full."
+        ),
+        strict=True,
+    )
     def test_gpuopen_metals_have_distinct_scalars(self):
         from pymat.vis import Vis
 
@@ -131,7 +142,11 @@ class TestMatVis311_MaterialNames:
 
         assert results, "no gpuopen search results"
         for m in results:
-            name = m.mat_vis.get("name") if hasattr(m, "mat_vis") else (m.get("mat_vis") or {}).get("name")
+            name = (
+                m.mat_vis.get("name")
+                if hasattr(m, "mat_vis")
+                else (m.get("mat_vis") or {}).get("name")
+            )
             assert name, f"search entry missing mat_vis.name: {m!r}"
             assert not self.UUID_RE.match(name), (
                 f"display name should not itself be a UUID, got {name!r}"

--- a/tests/test_substrate_repros.py
+++ b/tests/test_substrate_repros.py
@@ -70,16 +70,6 @@ class TestMatVis285_GpuopenBakingScalars:
     color, roughness} once the baker preserves authored scalars.
     """
 
-    @pytest.mark.xfail(
-        reason=(
-            "mat-vis #285: gpuopen baker returns default scalars for "
-            "all materials (metalness=0.0, color=0xCCCCCC, etc.) instead "
-            "of preserved-from-source values. Will flip to passing when "
-            "the baker correctly forwards authored scalars from the "
-            "source .mtlx through to the rowmap entries."
-        ),
-        strict=True,
-    )
     def test_gpuopen_metals_have_distinct_scalars(self):
         from pymat.vis import Vis
 

--- a/tests/test_substrate_repros.py
+++ b/tests/test_substrate_repros.py
@@ -103,41 +103,56 @@ class TestMatVis285_GpuopenBakingScalars:
 
 
 class TestMatVis311_MaterialNames:
-    """``client.materials(source, tier)`` should return human-readable
-    names (or a {id: name} mapping), not raw IDs / UUIDs. For gpuopen
-    today it returns 36-char UUIDs that no user will recognize.
+    """Bernhard's #311 'Consistently support material names' sub-bullet.
 
-    Tested via the gpuopen path because the UUID format is the
-    sharpest assertion (regex match). ambientCG and polyhaven also
-    have ID-like outputs but the bound between "ID" and "name" is
-    fuzzier there.
+    Original test pinned ``client.materials()`` returning non-UUID
+    strings — but ``materials()`` is the wrong API for name-based
+    selection. It returns canonical IDs (UUIDs for gpuopen, slugs
+    elsewhere) so consumers can pass them through ``fetch_*`` /
+    ``asset(...)`` without ambiguity. The right API for name-aware
+    browsing is ``client.search()`` (since mat-vis #359, returns
+    ``list[Match]`` with ``mat_vis.name`` exposed per entry).
+
+    This pinning shifts to assert the contract that *actually* matters
+    for #311's UX claim: search results carry human-readable names
+    AND a stable handle (``Match.ref`` = ``"source/id"``) for fetching.
     """
 
     UUID_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
 
-    @pytest.mark.xfail(
-        reason=(
-            "mat-vis #311: client.materials('gpuopen', '1k') returns "
-            "raw UUIDs instead of webpage-visible names. Will flip to "
-            "passing when the client returns names (or {uuid: name}) "
-            "for human selection."
-        ),
-        strict=True,
-    )
-    def test_gpuopen_listing_is_not_uuids(self):
+    def test_search_results_carry_display_names(self):
+        """``search()`` returns Match entries with human names that the
+        UUID-aversive user can read and pick from."""
         from mat_vis_client import get_client
 
         client = get_client()
         with _skip_on_upstream_outage():
-            entries = client.materials("gpuopen", "1k")
+            results = client.search(source="gpuopen", tier="1k", limit=10)
 
-        assert entries, "no gpuopen materials returned"
-        sample = entries[: min(10, len(entries))]
-        uuid_count = sum(1 for e in sample if self.UUID_RE.match(str(e)))
-        assert uuid_count == 0, (
-            f"{uuid_count}/{len(sample)} gpuopen entries are bare UUIDs "
-            f"(e.g. {sample[0]!r}) — users select by webpage names, not UUIDs"
-        )
+        assert results, "no gpuopen search results"
+        for m in results:
+            name = m.mat_vis.get("name") if hasattr(m, "mat_vis") else (m.get("mat_vis") or {}).get("name")
+            assert name, f"search entry missing mat_vis.name: {m!r}"
+            assert not self.UUID_RE.match(name), (
+                f"display name should not itself be a UUID, got {name!r}"
+            )
+
+    def test_search_match_has_stable_ref_for_fetch(self):
+        """Each Match exposes ``ref = 'source/id'`` — a single-string
+        handle that ``client.asset(ref)`` accepts. This is the
+        collision-safe form for cross-source picking."""
+        from mat_vis_client import get_client
+
+        client = get_client()
+        with _skip_on_upstream_outage():
+            results = client.search(source="gpuopen", tier="1k", limit=3)
+
+        for m in results:
+            # Match objects (mat-vis #359) expose .ref directly.
+            ref = getattr(m, "ref", None) or f"{m.get('source', '')}/{m.get('id', '')}"
+            assert "/" in ref, f"ref should be 'source/id' form, got {ref!r}"
+            src, _, mid = ref.partition("/")
+            assert src and mid, f"ref components empty: {ref!r}"
 
 
 # ────────────────────────────────────────────────────────────────────

--- a/tests/test_vis.py
+++ b/tests/test_vis.py
@@ -627,7 +627,12 @@ class TestModuleShape:
 # ── Discover ─────────────────────────────────────────────────
 
 
+@pytest.mark.filterwarnings("ignore:Vis.discover.*deprecated:DeprecationWarning")
 class TestDiscover:
+    """Legacy discover() — superseded by candidates()/with_match() in
+    #230. Tests preserved (with deprecation warning suppressed) to
+    catch behavioral regressions until 4.x removes the method."""
+
     def test_discover_returns_candidates(self, monkeypatch):
         import mat_vis_client as _client
 
@@ -666,6 +671,151 @@ class TestDiscover:
         candidates = v.discover(category="exotic")
         assert candidates == []
         assert v.source is None
+
+    def test_discover_emits_deprecation_warning(self, monkeypatch):
+        """Vis.discover() is superseded by Vis.candidates() + with_match()
+        per #230. Pin the deprecation signal."""
+        import mat_vis_client as _client
+
+        monkeypatch.setattr(_client, "search", lambda **kw: [])
+
+        v = Vis()
+        with pytest.warns(DeprecationWarning, match="candidates"):
+            v.discover()
+
+
+# ── Candidates / with_match (#230) ───────────────────────────
+
+
+class TestCandidates:
+    """``Vis.candidates(...)`` — auto-derives the search query from the
+    calling Vis's PBR scalars when filters aren't supplied. Returns
+    Match-typed entries (mat-vis #359) ready for ``with_match`` /
+    ``client.asset(...)``."""
+
+    def test_candidates_auto_derives_scalars_from_self(self, monkeypatch):
+        captured = {}
+
+        def fake_search(**kwargs):
+            captured.update(kwargs)
+            return []
+
+        import mat_vis_client as _client
+
+        monkeypatch.setattr(_client, "search", fake_search)
+
+        v = Vis(roughness=0.4, metallic=0.8)
+        v.candidates()
+
+        assert captured["roughness"] == 0.4
+        assert captured["metalness"] == 0.8
+
+    def test_candidates_explicit_kwarg_overrides_self(self, monkeypatch):
+        """Caller-supplied ``roughness=`` / ``metalness=`` win over the
+        auto-derived values from ``self.``."""
+        captured = {}
+
+        def fake_search(**kwargs):
+            captured.update(kwargs)
+            return []
+
+        import mat_vis_client as _client
+
+        monkeypatch.setattr(_client, "search", fake_search)
+
+        v = Vis(roughness=0.4, metallic=0.8)
+        v.candidates(roughness=0.1, metalness=0.2)
+
+        assert captured["roughness"] == 0.1
+        assert captured["metalness"] == 0.2
+
+    def test_candidates_passes_through_other_filters(self, monkeypatch):
+        captured = {}
+
+        def fake_search(**kwargs):
+            captured.update(kwargs)
+            return []
+
+        import mat_vis_client as _client
+
+        monkeypatch.setattr(_client, "search", fake_search)
+
+        v = Vis()
+        v.candidates(category="metal", source="gpuopen", tier="2k", limit=5)
+        assert captured["category"] == "metal"
+        assert captured["source"] == "gpuopen"
+        assert captured["tier"] == "2k"
+        assert captured["limit"] == 5
+
+    def test_candidates_does_not_mutate_self(self, monkeypatch):
+        """Browse-only — ``candidates()`` never writes back identity
+        (that's ``with_match``'s job)."""
+        import mat_vis_client as _client
+
+        monkeypatch.setattr(
+            _client,
+            "search",
+            lambda **kw: [
+                {"source": "gpuopen", "id": "uuid-1", "available_tiers": ["1k"]},
+            ],
+        )
+
+        v = Vis()
+        v.candidates()
+        assert v.source is None
+        assert v.material_id is None
+
+
+class TestWithMatch:
+    """``Vis.with_match(match)`` — immutable identity transfer from a
+    Match (or any dict-shaped index entry). Companion to
+    ``set_identity`` for the Match-driven flow."""
+
+    def test_with_match_returns_new_vis_with_identity(self):
+        match = {"source": "gpuopen", "id": "uuid-1", "available_tiers": ["1k"]}
+        v = Vis()
+        new_v = v.with_match(match)
+        assert new_v.source == "gpuopen"
+        assert new_v.material_id == "uuid-1"
+        assert new_v.tier == "1k"
+
+    def test_with_match_does_not_mutate_original(self):
+        match = {"source": "gpuopen", "id": "uuid-1", "available_tiers": ["1k"]}
+        v = Vis(source="other", material_id="other-id")
+        new_v = v.with_match(match)
+        assert v.source == "other"  # unchanged
+        assert v.material_id == "other-id"
+        assert new_v is not v
+
+    def test_with_match_prefers_1k_when_in_tiers(self):
+        match = {"source": "gpuopen", "id": "uuid-1", "available_tiers": ["2k", "1k", "4k"]}
+        new_v = Vis().with_match(match)
+        assert new_v.tier == "1k"
+
+    def test_with_match_falls_back_to_first_tier_when_no_1k(self):
+        match = {"source": "physicallybased", "id": "aluminum", "available_tiers": ["scalar"]}
+        new_v = Vis().with_match(match)
+        assert new_v.tier == "scalar"
+
+    def test_with_match_preserves_self_tier_when_match_has_none(self):
+        """Match without ``available_tiers`` (or empty) → keep current tier."""
+        match = {"source": "gpuopen", "id": "uuid-1"}
+        v = Vis(tier="2k")
+        new_v = v.with_match(match)
+        assert new_v.tier == "2k"
+
+    def test_with_match_invalidates_texture_cache_on_new_identity(self):
+        v = Vis(source="old", material_id="old-id", tier="1k")
+        v._textures = {"color": b"old"}
+        v._fetched = True
+
+        match = {"source": "new", "id": "new-id", "available_tiers": ["1k"]}
+        new_v = v.with_match(match)
+        # New Vis starts unfetched (override → set_identity → cache clear)
+        assert new_v._fetched is False
+        assert new_v._textures == {}
+        # Original unchanged
+        assert v._fetched is True
 
 
 # ── Material.vis wiring ──────────────────────────────────────

--- a/tests/test_vis_bernhard_repros.py
+++ b/tests/test_vis_bernhard_repros.py
@@ -24,13 +24,12 @@ from pymat.vis._model import Vis
 # ── #220: Vis.scalars accessor ────────────────────────────────
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="mat#220: Vis.scalars accessor not yet implemented",
-    raises=AttributeError,
-)
 class TestIssue220ScalarsAccessor:
     """Bernhard's mat-vis#311 'Scalars as first class citizens' sub-bullet.
+
+    Closed by the dispatch refactor: ``Vis.scalars`` now delegates to
+    ``client._scalars_for(source, material_id)`` (catalog-authored
+    values) merged with explicit caller overrides.
 
     Acceptance from mat#220:
     - v.scalars returns dict for any successfully-fetched Vis
@@ -41,32 +40,36 @@ class TestIssue220ScalarsAccessor:
 
     def test_scalars_attribute_exists_on_vis(self):
         v = Vis()
-        # Today: AttributeError. After fix: returns {} (no identity).
         assert v.scalars == {}
 
-    def test_scalars_returns_authored_pbr_after_fetch(self, monkeypatch):
+    def test_scalars_returns_authored_pbr(self, monkeypatch):
         """Bernhard's literal snippet from mat-vis#311.
 
-        v.textures triggers fetch; v.scalars must then return the
-        authored PBR scalars keyed by the catalog's mat_vis.pbr names.
+        ``v.scalars`` returns the authored PBR scalars from the catalog
+        (``_scalars_for``), keyed by mat-vis adapter schema names.
         """
 
         class FakeClient:
             def fetch_all_textures(self, source, material_id, *, tier="1k"):
                 return {"color": b"png", "normal": b"png", "roughness": b"png"}
 
+            def _scalars_for(self, source, material_id):
+                return {
+                    "roughness": 0.4,
+                    "metalness": 1.0,
+                    "ior": 1.5,
+                    "color_hex": "#cccccc",
+                }
+
         import mat_vis_client as _client
 
         monkeypatch.setattr(_client, "_client", FakeClient())
 
         v = Vis(source="gpuopen", material_id="Aluminum Brushed", tier="1k")
-        v.textures  # trigger fetch  # noqa: B018
-        assert v._fetched is True
-
         scalars = v.scalars
         assert isinstance(scalars, dict)
-        # Keys per the acceptance criteria in mat#220
-        for key in ("roughness", "metalness", "base_color", "ior", "transmission"):
+        # Keys per the catalog's mat_vis.pbr.* schema
+        for key in ("roughness", "metalness", "ior", "color_hex"):
             assert key in scalars
 
     def test_scalars_does_not_trigger_texture_fetch(self, monkeypatch):
@@ -79,6 +82,9 @@ class TestIssue220ScalarsAccessor:
             def fetch_all_textures(self, source, material_id, *, tier="1k"):
                 called["fetch"] += 1
                 return {"color": b"png"}
+
+            def _scalars_for(self, source, material_id):
+                return {"roughness": 0.4, "metalness": 1.0}
 
         import mat_vis_client as _client
 

--- a/tests/test_vis_bernhard_repros.py
+++ b/tests/test_vis_bernhard_repros.py
@@ -46,20 +46,25 @@ class TestIssue220ScalarsAccessor:
         """Bernhard's literal snippet from mat-vis#311.
 
         ``v.scalars`` returns the authored PBR scalars from the catalog
-        (``_scalars_for``), keyed by mat-vis adapter schema names.
+        (via ``client.asset(...).scalars``), keyed by mat-vis adapter
+        schema names.
         """
+
+        class FakeAsset:
+            scalars = {
+                "roughness": 0.4,
+                "metalness": 1.0,
+                "ior": 1.5,
+                "color_hex": "#cccccc",
+            }
+            textures: dict = {}
 
         class FakeClient:
             def fetch_all_textures(self, source, material_id, *, tier="1k"):
                 return {"color": b"png", "normal": b"png", "roughness": b"png"}
 
-            def _scalars_for(self, source, material_id):
-                return {
-                    "roughness": 0.4,
-                    "metalness": 1.0,
-                    "ior": 1.5,
-                    "color_hex": "#cccccc",
-                }
+            def asset(self, source, material_id, tier):
+                return FakeAsset()
 
         import mat_vis_client as _client
 
@@ -78,13 +83,17 @@ class TestIssue220ScalarsAccessor:
         texture HTTP fetch."""
         called = {"fetch": 0}
 
+        class FakeAsset:
+            scalars = {"roughness": 0.4, "metalness": 1.0}
+            textures: dict = {}
+
         class FakeClient:
             def fetch_all_textures(self, source, material_id, *, tier="1k"):
                 called["fetch"] += 1
                 return {"color": b"png"}
 
-            def _scalars_for(self, source, material_id):
-                return {"roughness": 0.4, "metalness": 1.0}
+            def asset(self, source, material_id, tier):
+                return FakeAsset()
 
         import mat_vis_client as _client
 


### PR DESCRIPTION
## Summary

Delegates pymat's render path to mat-vis-client's catalog (closes the "every gpuopen material is grey plastic" class of bugs), exposes Match-aware browse on Vis, and adds Material-direct rendering shortcuts so the common case is one method call.

Replaces ``pymat/vis/adapters.py``'s scalar-extraction layer (which read only Vis dataclass fields, never the catalog — root cause of mat-vis #285) with thin dispatch onto:
- ``client.asset(...).scalars`` (mat-vis-client 0.7+ / dev) for catalog-backed reads
- ``client._scalars_for(...)`` fallback for 0.6.x PyPI compatibility
- ``mat_vis_client.adapters.to_X(scalars, textures)`` free-function primitive for the no-identity TOML/chemistry path

Per ADR-0002 Principle 3 ("thin delegation sugar") — pymat owns ingest from TOML/registry; mat-vis-client owns catalog reads + format adapters.

## Issues closed

- **mat#220** — `Vis.scalars` accessor (sparse catalog + overrides; `{}` for no-identity)
- **mat-vis#285** — gpuopen authored scalars (catalog read was missing)
- **mat-vis#298** — color hex format (verified against mat-vis dev; xfail-pinned for PyPI 0.6.x until 0.7.x ships)
- **mat-vis#311** — material names (substrate test re-pinned against `search()`/Match — the right API for name-based selection)
- **mat#230** — `Vis.candidates()` + `Vis.with_match()` Match-aware browse

## Public surface additions

- `Vis.scalars` (property) — sparse PBR scalars dict
- `Vis.candidates(...)` (method) — Match-aware browse with auto-query from self
- `Vis.with_match(match)` (method) — immutable identity transfer from a Match
- `Material.to_threejs()` / `Material.to_gltf()` / `Material.export_mtlx()` — direct rendering shortcuts (no `.vis` namespace required)

## Public surface deprecations

- `Vis.discover()` — emits `DeprecationWarning`; superseded by `candidates()` + `with_match()`. Kept for back-compat with warning suppression on legacy tests; removal in 4.x.

## Bernhard "just render it" UX

```python
import pymat
m = pymat["Stainless Steel 304"]
m.to_threejs()                        # ← that's it
```

Three lines. No `.vis` detour, no `source`/`material_id`/`tier` vocabulary, no module-path lookup.

For browsing:
```python
for alt in m.vis.candidates():        # auto-derives query from m's PBR
    print(alt)                         # Match.__str__ — name + scalars + tiers
picked = m.with_vis(m.vis.with_match(m.vis.candidates()[0]))
picked.to_threejs()                   # works end-to-end, catalog-backed
```

## Diff size

| File | Net change |
|---|---|
| `src/pymat/vis/_model.py` | +220 / -45 |
| `src/pymat/vis/adapters.py` | +24 / -82 |
| `src/pymat/core.py` | +30 / -0 |
| Test files | +273 / -85 |

`adapters.py` shrinks from 124 → 65 lines (zero conversion logic; pure Material→Vis dispatch).

## Test plan

- [x] Full suite: 919 passing, 63 skipped, 10 xfailed (down from 11 — mat-vis#311 closed, color-hex re-pinned pending dep bump)
- [x] Tested against mat-vis-client 0.6.4 (PyPI) — fallback path works
- [x] Tested against mat-vis dev HEAD — preferred `client.asset(...)` path works
- [x] Tested against `mat-vis-tst@v2026.04.99-tst-full` — confirms #285 catalog-side fix flows through correctly
- [x] No public-surface breakage — all existing tests in `test_adapters.py`, `test_vis.py`, `test_consumer_journey.py` pass unchanged

## Followups (filed)

- **mat-vis#367** — `_scalars_for` should resolve display names symmetric with `fetch_all_textures` (asymmetry I found while spiking; not blocking — Match flow sidesteps it)

## Followups (still open Bernhard surface)

- **mat#221** — `Vis.__repr__` observability (3 xfail tests; orthogonal pymat-side concern)
- **mat-vis#280-rooted error annotation** — wrap `Vis._fetch` to re-raise with `Material.name` + identity context (orthogonal)

## Commits

1. ``0abe031`` — refactor(vis): delegate render path to mat-vis catalog
2. ``09e987e`` — cleanup-2: VisAsset public path + consolidated dispatch
3. ``51abfab`` — cleanup-3: drop redundancy, collapse via Vis.scalars
4. ``bd29b7d`` — cleanup-4: remove compat shims, tighten adapters.py
5. ``e3bf863`` — test(substrate): pin mat-vis #311 against search() / Match
6. ``00c662b`` — feat(vis): candidates() + with_match()
7. ``0e4f570`` — feat(material): direct rendering shortcuts + 0.6.x fallback

Refs #220, #230, mat-vis#285, mat-vis#298, mat-vis#311