### PR TITLE
fix(vis): custom __repr__ overlays lazy state on field section (closes mat#221)

### DIFF
--- a/src/pymat/vis/_model.py
+++ b/src/pymat/vis/_model.py
@@ -373,6 +373,51 @@ class Vis:
             return
         super().__setattr__(name, value)
 
+    # ── Repr (mat#221: surface lazy state without touching field semantics) ─
+
+    def __repr__(self) -> str:
+        """Custom ``__repr__`` overlaying lazy/fetched state on top of
+        the dataclass field summary.
+
+        The dataclass-generated repr correctly shows caller-supplied
+        fields (identity + override channels: ``roughness``,
+        ``metallic``, ``base_color``, ...). What it can't show is
+        whether a fetch has happened or what the catalog returned —
+        Bernhard's mat#221 surprise that "all fields are None even
+        though ``to_threejs()`` succeeded."
+
+        This repr keeps the field section verbatim (so explicit
+        overrides stay observable as ``metallic=0.7``) and appends:
+
+        - ``fetched=True/False`` — texture fetch state
+        - ``scalars=`` — sparse catalog + override view (only when
+          fetched, to avoid index IO during repr)
+        - ``available_textures=`` — channel keys actually staged
+
+        Field semantics are unchanged: dataclass slots remain the
+        override channel; resolved values surface via :attr:`scalars`.
+        Two namespaces, two purposes — the repr just makes both
+        legible at a glance.
+        """
+        from dataclasses import fields as _fields
+
+        # Field section — same as the auto-repr would produce, honoring
+        # ``field(repr=False)`` on private cache slots.
+        field_parts = [f"{f.name}={getattr(self, f.name)!r}" for f in _fields(self) if f.repr]
+
+        # Lazy-state suffix — cheap when unfetched (just the flag);
+        # touches ``self.scalars`` (catalog dict lookup, no HTTP) only
+        # post-fetch when the index is already hot.
+        suffix = [f"fetched={self._fetched}"]
+        if self._fetched:
+            scalars = self.scalars
+            if scalars:
+                suffix.append(f"scalars={scalars!r}")
+            if self._textures:
+                suffix.append(f"available_textures={sorted(self._textures)!r}")
+
+        return f"{type(self).__name__}({', '.join(field_parts + suffix)})"
+
     # ── Identity helpers ─────────────────────────────────────────
 
     @property

--- a/tests/test_vis_bernhard_repros.py
+++ b/tests/test_vis_bernhard_repros.py
@@ -17,8 +17,6 @@ mat-vis#287/#288 lesson.
 
 from __future__ import annotations
 
-import pytest
-
 from pymat.vis._model import Vis
 
 # ── #220: Vis.scalars accessor ────────────────────────────────

--- a/tests/test_vis_bernhard_repros.py
+++ b/tests/test_vis_bernhard_repros.py
@@ -107,17 +107,14 @@ class TestIssue220ScalarsAccessor:
 # ── #221: repr observability ──────────────────────────────────
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="mat#221: repr stays all-None after fetch — no fetched flag",
-)
 class TestIssue221ReprObservability:
     """Bernhard's mat-vis#311 'Inconsistent outputs' sub-bullet.
 
-    Acceptance from mat#221:
-    - Pre-fetch repr shows fetched=False
-    - Post-fetch repr shows fetched=True plus scalars=/available_textures=
-    - Override semantics unchanged
+    Closed by the custom ``Vis.__repr__`` that overlays lazy state
+    (``fetched=`` flag, ``scalars=`` summary, ``available_textures=``)
+    on top of the dataclass field section. Field semantics unchanged:
+    override channels remain the dataclass slots; resolved values
+    surface via the new repr suffix and via ``Vis.scalars``.
     """
 
     def test_pre_fetch_repr_shows_fetched_false(self):


### PR DESCRIPTION
## Summary

Closes mat#221 — Bernhard's mat-vis#311 'Inconsistent outputs' sub-bullet. After ``v.textures`` triggers a fetch, ``repr(v)`` still showed every PBR field as ``None`` — no signal anything happened, even though the catalog data was loaded.

## Pythonic decision: two namespaces, two purposes

The dataclass auto-repr was *technically* truthful (those fields are the override channel — user hadn't set them) but visually misleading. Two ways to fix:

| Approach | Trade-off |
|---|---|
| Populate dataclass fields after fetch | Forces a magic distinction between "user-set" and "catalog-set" — needs an ``_overridden: set[str]`` to disambiguate, breaks ``replace`` / equality / pickle semantics, conflates inputs with outputs |
| **Custom ``__repr__`` overlaying lazy state** | Field semantics unchanged; ``scalars=`` and ``available_textures=`` surface the resolved/cached view. Two clearly separate sections, no provenance ambiguity |

We took the second. Same separation already pioneered by ``Vis.scalars`` (the public sparse view from the dispatch refactor): dataclass fields = caller overrides; property accessors = computed/resolved.

## Output shape

Pre-fetch:
```
Vis(source='gpuopen', material_id='Aluminum Brushed', tier='1k',
    finishes={}, roughness=None, metallic=None, ..., fetched=False)
```

Post-fetch (catalog-backed):
```
Vis(source='gpuopen', material_id='Aluminum Brushed', tier='1k',
    finishes={}, roughness=None, metallic=None, ..., fetched=True,
    scalars={'metalness': 1.0, 'roughness': 0.4, 'color_hex': '#cccccc', 'ior': 1.5},
    available_textures=['color', 'normal', 'roughness'])
```

Post-fetch with caller override (``v.metallic = 0.7``):
```
Vis(source='gpuopen', material_id='Aluminum Brushed', tier='1k',
    finishes={}, roughness=None, metallic=0.7, ..., fetched=True,
    scalars={'metalness': 0.7, ...},   ← override won; visible in BOTH places
    available_textures=['color', 'normal', 'roughness'])
```

## Implementation notes

- Touches ``self.scalars`` (catalog dict lookup) only when ``_fetched=True`` — unfetched repr stays cheap, no index IO triggered by ``print(v)`` or debugger inspection.
- Honors ``field(repr=False)`` on private cache slots (``_textures``, ``_fetched``, ``_finish``) — same fields excluded as the auto-repr.
- ~50 LOC total: 1 method on ``Vis``, drops xfail decorator on 3 tests.

## Test plan

- [x] All 3 ``TestIssue221ReprObservability`` xfails flip to passing
- [x] ``test_repr_does_not_leak_private_path`` (the existing repr contract test) still passes — class name + module unchanged
- [x] No regression in 968-test full suite (vs 968 on main pre-fix; xfail count drops 11 → 8)
- [x] Manual visual check across 4 cases (empty / overrides-only / pre-fetch / post-fetch with overrides) — all read clearly

## Out of scope

Bernhard's remaining mat-vis#280-rooted error annotation gaps in ``test_error_messages.py`` (5 xfails) — separate concern, separate PR.

Refs mat#221, Bernhard's mat-vis#311