### PR TITLE
test: guard PIL import so a bare py3.13 checkout doesn't break collection

### DIFF
--- a/tests/test_visual_compare.py
+++ b/tests/test_visual_compare.py
@@ -10,9 +10,15 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-from PIL import Image
 
-from tests._visual_compare import (
+# PIL is an optional viz dependency — pulled transitively (build123d on
+# py<=3.12, Playwright in the render jobs), but absent on a bare py3.13
+# core checkout. Skip this whole module rather than erroring collection
+# for the entire suite when it's missing. `tests._visual_compare` also
+# imports PIL at top, so the importorskip must gate its import too.
+Image = pytest.importorskip("PIL.Image")
+
+from tests._visual_compare import (  # noqa: E402 — deferred past importorskip guard
     DEFAULT_RMS_TOLERANCE,
     _rms,
     assert_matches_baseline,


### PR DESCRIPTION
## Problem

On a plain **py3.13** local checkout (core install, no `build123d`/Playwright), `pytest` dies at collection:

```
ERROR tests/test_visual_compare.py — ModuleNotFoundError: No module named 'PIL'
!!!! Interrupted: 1 error during collection !!!!
```

One optional-viz-dep module takes down the **entire 990-test suite** — it reads as "all the tests are broken" when nothing else is. CI stays green only because its env happens to have Pillow (pulled transitively via `build123d` on py≤3.12).

## Fix

Gate the module with `pytest.importorskip("PIL.Image")` — the house pattern (`test_visual_regression.py` already imports the PIL-backed helper lazily inside its Playwright-gated tests). No-op where PIL is present (CI still runs these), clean skip where it isn't.

## Checklist

- [x] Reproduced the collection break on a bare py3.13 env
- [x] Guarded the import with `pytest.importorskip` (house pattern)
- [x] Plain `pytest` now green: **924 passed, 70 skipped, 8 xfailed, 0 errors**
- [x] Confirmed CI cells with PIL present still *run* (not skip) these tests
- [x] Test-only change — no runtime/API surface touched

## Verification

Plain `pytest` on a bare py3.13 env: **1 error / interrupted → 924 passed, 70 skipped, 8 xfailed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)